### PR TITLE
Add icons to record toolbar back button

### DIFF
--- a/app/views/catalog/record/_record_toolbar.html.erb
+++ b/app/views/catalog/record/_record_toolbar.html.erb
@@ -1,6 +1,6 @@
 <div class="record-toolbar container-fluid hidden-xs" role="navigation">
   <div class="col-md-7 col-sm-7">
-    <%= link_back_to_catalog :class => 'btn btn-default' %>
+    <%= link_back_to_catalog :class => 'btn btn-default', :label => t('blacklight.back_to_search').html_safe %>
     <span class="pull-right">
       <%= link_to_previous_document @previous_document %>
       <%= item_page_entry_info %>
@@ -32,7 +32,7 @@
 
 <div class="record-toolbar container-fluid hidden-sm hidden-md hidden-lg" role="navigation">
   <div class="col-xs-8">
-    <%= link_back_to_catalog :class => 'btn btn-default', :label => t('blacklight.back_to_search_xs') %>
+    <%= link_back_to_catalog :class => 'btn btn-default', :label => t('blacklight.back_to_search_xs').html_safe %>
     <span class="pull-right">
       <%= link_to_previous_document @previous_document %>
       <%= item_page_entry_info %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -18,5 +18,5 @@ en:
       sms: 'text'
       printer: 'printer'
 
-    back_to_search: 'Back to results'
-    back_to_search_xs: 'Back'
+    back_to_search: '<span class="glyphicon glyphicon-backward"></span>&nbsp; Back to results'
+    back_to_search_xs: '<span class="glyphicon glyphicon-backward"></span>'


### PR DESCRIPTION
Minor update : Added icons to record toolbar back button to reflect the wireframe spec. 
## 

![searchworks-issue10-3](https://cloud.githubusercontent.com/assets/302258/2951741/fc199658-da2c-11e3-85d6-aa03fb9b80d0.png)
