### PR TITLE
Convert rotate helper to jQuery plugin

### DIFF
--- a/app/assets/javascripts/jquery.rotatehelper.js
+++ b/app/assets/javascripts/jquery.rotatehelper.js
@@ -1,0 +1,64 @@
+(function($) {
+  /*
+    jQuery plugin to rotate an icon inside a Bootstrap dropdown
+
+      Usage: $(selector).rotateHelper(option);
+
+    Available option values = '90cw' [default]
+
+    This plugin :
+      - listens for '[show|hide].bs[collapse|dropdown]' event on callee's
+        parent or element specified in 'data-target' attribute
+      - rotates callee or child element with class 'icon-to-rotate' using
+        specified option
+  */
+
+  $.fn.rotateHelper = function(rotate) {
+    return this.each(function() {
+      var $elButton = $(this),
+          $elToRotate,
+          $parent,
+          cssRotate90cw = 'search-navbar-dropdown-btn-rotate-90',
+          cssRotate;
+
+      cssRotate   = getRotateCssClass();
+      $parent     = getParent();
+      $elToRotate = getRotatableElement();
+
+      $parent.on('show.bs.collapse', function() { $elToRotate.addClass(cssRotate); });
+      $parent.on('show.bs.dropdown', function() { $elToRotate.addClass(cssRotate); });
+      $parent.on('hide.bs.collapse', function() { $elToRotate.removeClass(cssRotate); });
+      $parent.on('hide.bs.dropdown', function() { $elToRotate.removeClass(cssRotate); });
+
+      function getParent() {
+        var $parent = $elButton.parent(),
+            $target = $($elButton.data('target'));
+
+        if ($target.length !== 0) $parent = $target;
+
+        return $parent;
+      }
+
+      function getRotatableElement() {
+        var $elToRotate = $elButton,
+            $elIcon = $elButton.find('.icon-to-rotate');
+
+        if ($elIcon.length !== 0) $elToRotate = $elIcon;
+
+        return $elToRotate;
+      }
+
+      function getRotateCssClass() {
+        cssRotate = cssRotate90cw; // default
+
+        if (typeof rotate !== 'undefined') {
+          if (rotate === '90cw') cssRotate = cssRotate90cw;
+        }
+
+        return cssRotate;
+      }
+
+    });
+  }
+
+})(jQuery);

--- a/app/assets/javascripts/search_navbar_top_menu.js
+++ b/app/assets/javascripts/search_navbar_top_menu.js
@@ -1,16 +1,7 @@
 Blacklight.onLoad(function() {
 
-  // Rotate search navbar menu icon by 90 deg on click
-  var $searchNavBar = $('#search-navbar .navbar-header'),
-      $iconDropdown = $searchNavBar.find('.dropdown-toggle .icon-menu'),
-      cssRotate = 'search-navbar-dropdown-btn-rotate-90';
-
-  $searchNavBar.on('show.bs.dropdown', function() {
-    $iconDropdown.addClass(cssRotate)
-  });
-
-  $searchNavBar.on('hide.bs.dropdown', function() {
-    $iconDropdown.removeClass(cssRotate)
-  });
+  $('#search-navbar .navbar-header .dropdown-toggle').rotateHelper();
+  $('.navbar-toggle').rotateHelper();
 
 });
+

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -7,9 +7,9 @@
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </button>
-    <div>
-      <button class="btn btn-default dropdown-toggle searchbar-topnav" type="button" data-toggle="dropdown">
-        <span class="glyphicon glyphicon-align-justify icon-menu"></span>
+    <div id="searchbar-topnav-menu">
+      <button class="btn btn-default dropdown-toggle searchbar-topnav" type="button" data-toggle="dropdown" data-target="#searchbar-topnav-menu">
+        <span class="glyphicon glyphicon-align-justify icon-to-rotate"></span>
       </button>
       <%= render :partial => 'shared/search_navbar_top_menu' %>
       <%= link_to application_name, root_path, class: "navbar-brand" %>


### PR DESCRIPTION
Closes #87, relates to #23 

Converted icon rotation to a jQuery plugin

Usage: `$(selector).rotateHelper(option);`
## 

![searchworks-issue87-2](https://cloud.githubusercontent.com/assets/302258/3001350/ce692d40-dd2e-11e3-852c-4eb867c357b6.png)
