### PR TITLE
Customize search results metadata display

### DIFF
--- a/app/assets/stylesheets/modules/results-documents.css.scss
+++ b/app/assets/stylesheets/modules/results-documents.css.scss
@@ -1,0 +1,20 @@
+#documents {
+
+  .document {
+
+    h5.index_title {
+      font-size: 1.2em;
+    }
+
+    .document-metadata {
+      list-style-type: none;
+      padding-left: 0;
+    }
+
+    .main-title-date {
+      color: #999;
+    }
+  }
+
+
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -7,5 +7,6 @@
 @import 'modules/breadcrumb';
 @import 'modules/record-metadata-section';
 @import 'modules/record-toolbar';
+@import 'modules/results-documents';
 @import 'modules/search-bar';
 @import 'modules/selected-databases';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -114,6 +114,7 @@ class CatalogController < ApplicationController
     config.add_index_field "author_meeting_display", :label => "Meeting"
     config.add_index_field "vern_author_meeting_display", :label => "Meeting"
     config.add_index_field "pub_date", :label => "Date"
+    config.add_index_field "imprint_display", :label => "Imprint"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/helpers/searchworks/index_view_document_helper.rb
+++ b/app/helpers/searchworks/index_view_document_helper.rb
@@ -1,0 +1,51 @@
+module Searchworks::IndexViewDocumentHelper
+
+  def get_main_title(document)
+    title = h(document[document_show_link_field.to_s])
+
+    if document['vern_' + document_show_link_field.to_s]
+      title = h(document[document_show_link_field]) + " " + h(document['vern_' + document_show_link_field.to_s])
+    end
+  end
+
+  def get_main_title_date(document)
+    publication_year    = document["publication_year_isi"].to_s
+    beginning_year      = document["beginning_year_isi"].to_s
+    earliest_year       = document["earliest_year_isi"].to_s
+    earliest_poss_year  = document["earliest_poss_year_isi"].to_s
+    ending_year         = document["ending_year_isi"].to_s
+    latest_year         = document["latest_year_isi"].to_s
+    latest_poss_year    = document["latest_poss_year_isi"].to_s
+    production_year     = document["production_year_isi"].to_s
+    original_year       = document["original_year_isi"].to_s
+    copyright_year      = document["copyright_year_isi"].to_s
+
+    # single date
+    date = publication_year
+
+    [production_year, original_year, copyright_year].each do |value|
+      if !value.empty?
+        date = value
+        break
+      end
+    end
+
+    # open-ended/completed date range
+    if date.empty? and (!beginning_year.empty? or !ending_year.empty?)
+      date = "#{beginning_year} - #{ending_year}"
+    end
+
+    # open-ended/completed date range
+    if date.empty? and (!earliest_year.empty? or !latest_year.empty?)
+      date = "#{earliest_year} - #{latest_year}"
+    end
+
+    # "sometime between" date range
+    if date.empty? and (!earliest_poss_year.empty? or !latest_poss_year.empty?)
+      date = "#{earliest_poss_year} ... #{latest_poss_year}"
+    end
+
+    date = "[#{date}]" unless date.empty?
+  end
+
+end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -11,7 +11,6 @@
 
   <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
 
-
   <% content_for(:head) do -%>
     <%= render_opensearch_response_metadata %>
     <%= auto_discovery_link_tag(:rss, url_for(params.merge(:format => 'rss')), :title => t('blacklight.search.rss_feed') ) %>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,0 +1,1 @@
+<%= render :partial => "search_results_document_fields", :locals => { :document => document } %>

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -1,0 +1,18 @@
+
+<% # header bar for doc items in index view %>
+<div class="documentHeader row">
+
+  <h5 class="index_title col-sm-9 col-lg-10">
+    <% counter = document_counter_with_offset(document_counter) %>
+    <span class="glyphicon glyphicon-star-empty"></span>
+    <span class="document-counter">
+      <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+    </span>
+    <%= link_to_document document, :label => get_main_title(document), :counter => (counter + @response.params[:start].to_i) %>
+    <span class="main-title-date"><%= get_main_title_date(document) %></span>
+  </h5>
+
+  <% # bookmark functions for items/docs -%>
+  <%= render_index_doc_actions document, :wrapping_class => "index-document-functions col-sm-3 col-lg-2" %>
+</div>
+

--- a/app/views/catalog/_search_results_document_fields.html.erb
+++ b/app/views/catalog/_search_results_document_fields.html.erb
@@ -1,0 +1,12 @@
+<% fields = ["vern_title_uniform_display", "author_person_display", "imprint_display"] %>
+
+<ul class="document-metadata dl-horizontal dl-invert">
+
+  <% fields.each do |solr_fname| %>
+    <% if should_render_index_field? document, index_fields(document)[solr_fname] %>
+      <li><%= render_index_field_value document, :field => solr_fname %></li>
+    <% end %>
+  <% end %>
+
+</ul>
+

--- a/spec/features/blacklight_customizations/results_document_spec.rb
+++ b/spec/features/blacklight_customizations/results_document_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature "Results Document Metadata" do
+
+  scenario "should have correct tile with open-ended date range and metadata" do
+    visit root_path
+    first("#q").set '1'
+    click_button 'search'
+
+    within "#documents" do
+      expect(page).to have_css("a", text: "An object", visible: true)
+      expect(page).to have_css("span.main-title-date", text: "[2000 - ]", visible: false)
+
+      within "ul.document-metadata" do
+        expect(page).to have_css("li", text: "An object, aliquet sed mauris molestie, suscipit tempus", visible: true)
+        expect(page).to have_css("li", text: "Doe, Jane", visible: true)
+        expect(page).to have_css("li", text: "1990", visible: true)
+      end
+    end
+  end
+
+  scenario "should have 'sometime between' date range" do
+    visit root_path
+    first("#q").set '11'
+    click_button 'search'
+
+    within "#documents" do
+      expect(page).to have_css("span.main-title-date", text: "[1801 ... 1837]", visible: false)
+    end
+  end
+
+
+end

--- a/spec/fixtures/solr_documents/1.yml
+++ b/spec/fixtures/solr_documents/1.yml
@@ -1,11 +1,14 @@
 :id: 1
 :title_display: An object
-:author_person_display: "Doe, Jane"
+:author_person_display: Doe, Jane
+:vern_title_uniform_display: An object, aliquet sed mauris molestie, suscipit tempus
 :format: Book
 :format_main_ssim: Book
 :language: English
 :marcxml: <%= simple_856 %>
 :pub_date: 2014
+:beginning_year_isi: 2000
+:imprint_display: 1990
 :access_facet: Online
 :building_facet: Green
 :crez_course_info:

--- a/spec/fixtures/solr_documents/11.yml
+++ b/spec/fixtures/solr_documents/11.yml
@@ -1,5 +1,8 @@
 :id: 11
 :pub_date: 2008
+:earliest_poss_year_isi: 1801
+:imprint_display: 1999
+:latest_poss_year_isi: 1837
 :author_person_display: Flores, Esperanza
 :title_display: Amet ad adipisicing ex mollit pariatur minim dolore.
 :language: Spanish

--- a/spec/fixtures/solr_documents/12.yml
+++ b/spec/fixtures/solr_documents/12.yml
@@ -1,5 +1,6 @@
 :id: 12
 :pub_date: 1999
+:publication_year_isi: 1999
 :author_person_display: Mckinney, Mitzi
 :title_display: Duis reprehenderit cupidatat ad cillum cupidatat esse ad dolore.
 :language: German

--- a/spec/fixtures/solr_documents/14.yml
+++ b/spec/fixtures/solr_documents/14.yml
@@ -1,11 +1,11 @@
 :id: 14
 :pub_date: 1617
 :author_person_display: Fleming, Salazar
-:title_display: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et
-  anim.
+:title_display: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et anim.
 :language: Chinese
 :format: Book
 :format_main_ssim: Book
+:imprint_display: 1788
 :access_facet: At the Library
 :building_facet: Law (Crown)
 

--- a/spec/fixtures/solr_documents/18.yml
+++ b/spec/fixtures/solr_documents/18.yml
@@ -1,9 +1,11 @@
 :id: 18
 :pub_date: 1909
 :author_person_display: Jordan, Sheila
+:vern_title_uniform_display: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et anim aitat orediam
 :title_display: Adipisicing tempor quis ullamco enim dolore cillum velit commodo qui.
 :language: German
 :format: Image
 :format_main_ssim: Image
+:imprint_display: 1933
 :access_facet: Online
 :building_facet: "Math & Statistics"


### PR DESCRIPTION
Closes #66 
- Based on Jennifer's date calulation recipe, added customized date to the main title
- Replaced default rendering of document metadata with custom list of uniform title, author/creatorand imprint. 

PS: No MARC record specific rendering is done in this PR. 
## 

![searchworks-issue66-1](https://cloud.githubusercontent.com/assets/302258/3002652/b6a0e3d8-dd42-11e3-8b0f-474066bc077a.png)
