### PR TITLE
changes searchbar collapse hamburger to use rotate plugin

### DIFF
--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -3,9 +3,7 @@
   <div class="navbar-header">
     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#searchbar-navbar-collapse">
       <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
+      <span class="glyphicon glyphicon-align-justify icon-to-rotate"></span>
     </button>
     <div id="searchbar-topnav-menu">
       <button class="btn btn-default dropdown-toggle searchbar-topnav" type="button" data-toggle="dropdown" data-target="#searchbar-topnav-menu">


### PR DESCRIPTION
This PR Fixes #23 . This changes the way that the searchbar collapse burger button looks and operates on click and uses the rotate jquery plugin. Though... might be unnecessary if/when we switch to font awesome.  

Ref #109 and #80 here

![screen shot 2014-05-16 at 3 02 14 pm](https://cloud.githubusercontent.com/assets/1656824/3002839/403b1b9c-dd46-11e3-92b0-4f4046853b21.png)

![screen shot 2014-05-16 at 3 02 17 pm](https://cloud.githubusercontent.com/assets/1656824/3002840/4354a1fe-dd46-11e3-966a-0f888271fde4.png)
