### PR TITLE
removes hours_route helper to give relative path for hours controller

### DIFF
--- a/app/controllers/hours_controller.rb
+++ b/app/controllers/hours_controller.rb
@@ -1,6 +1,6 @@
 class HoursController < ApplicationController
   def show
-    response = HoursRequest.new(params[:library]).get
+    response = HoursRequest.new(params[:id]).get
     respond_to do |format|
       format.json { render json: response }
     end

--- a/app/helpers/access_panel_helper.rb
+++ b/app/helpers/access_panel_helper.rb
@@ -12,8 +12,4 @@ module AccessPanelHelper
     image_tag("#{library_abbr}.jpg", class: "pull-left", alt: Constants::LIB_TRANSLATIONS[library_abbr])
   end
 
-  def hours_route(library)
-    "/hours/#{library}"
-  end
-
 end

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -2,7 +2,7 @@
 <% if document.access_panels.library_locations? %>
   <% document.access_panels.library_locations.locations.each do |location| %>
     <% if location.is_viewable? %>
-      <div class="panel panel-default panel-library-location" data-hours-route=<%= hours_route(location.library) %>>
+      <div class="panel panel-default panel-library-location" data-hours-route=<%= hour_path(location.library) %>>
         <div class="library-location-heading">
           <%= thumb_for_library(location.library) %>
           <div class="library-location-heading-text">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,7 @@ Rails.application.routes.draw do
 
   resources :selected_databases, only: :index
 
-
-  get "hours/:library", to: "hours#show"
+  resources :hours, only: :show
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/controllers/hours_controller_spec.rb
+++ b/spec/controllers/hours_controller_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe HoursController do
   describe "routes" do
     it "should route to the library action with params" do
-      expect(get: "/hours/GREEN").to route_to(controller: 'hours', action: 'show', library: 'GREEN')
+      expect(get: "/hours/GREEN").to route_to(controller: 'hours', action: 'show', id: 'GREEN')
     end
   end
   describe "GET library" do
     it "should return correct response" do
-      get :show, format: "json", library: "GREEN"
+      get :show, format: "json", id: "GREEN"
       expect(response.status).to eq 200
     end
   end

--- a/spec/helpers/access_panel_helper_spec.rb
+++ b/spec/helpers/access_panel_helper_spec.rb
@@ -13,10 +13,4 @@ describe AccessPanelHelper do
       expect(helper.thumb_for_library("GREEN")).to eq "<img alt=\"Green Library\" class=\"pull-left\" src=\"/assets/GREEN.jpg\" />"
     end
   end
-
-  describe "hours_route" do
-    it "should return correct hours api route for the library" do
-      expect(helper.hours_route("GREEN")).to eq "/hours/GREEN"
-    end
-  end
 end


### PR DESCRIPTION
fixes an issue where hours path was not relative and did not work on apps deployed on 
