### PR TITLE
Move explicit render of mods_metadata_sections from show_image partial...

### DIFF
--- a/app/views/catalog/_show_image.html.erb
+++ b/app/views/catalog/_show_image.html.erb
@@ -1,2 +1,1 @@
 <%= render 'catalog/record/mods_upper_metadata_section' %>
-<%= render 'catalog/record/mods_metadata_sections' %>

--- a/app/views/catalog/record/_record_metadata_image.html.erb
+++ b/app/views/catalog/record/_record_metadata_image.html.erb
@@ -1,0 +1,22 @@
+<div class="record-browse-nearby col-md-12 row">
+  <%# browse nearby placeholder --
+  <div class="panel panel-default">
+    <div class="panel-body">Browse nearby</div>
+  </div>
+  %>
+</div>
+
+<div class="record-metadata col-md-12 row">
+  <div class="record-panels col-md-4 col-xs-12 row">
+    <%= render "catalog/record/metadata_panels" %>
+  </div>
+  <div class="record-sections col-md-8 col-xs-12">
+    <% if @document[:modsxml] %>
+      <%= render 'catalog/record/mods_metadata_sections' %>
+    <% end %>
+  </div>
+</div>
+
+<%# technical details placeholder - librarian view, catkey etc %>
+<div class="record-technical-details col-md-12 row">
+</div>


### PR DESCRIPTION
...to automatically rendered _record_metadata_{display_type} partial.

This makes the partials rendered more in line w/ how we structure MARC records.
#### Before

---

![a](https://cloud.githubusercontent.com/assets/96776/3119267/c03b58ae-e744-11e3-965b-8514afaa60c5.png)
#### After

---

![b](https://cloud.githubusercontent.com/assets/96776/3119277/cdf93470-e744-11e3-9a68-df277de274f4.png)
