### PR TITLE
Add 'In collection' access panel to metadata panels section.

### DIFF
--- a/app/models/concerns/druid.rb
+++ b/app/models/concerns/druid.rb
@@ -1,0 +1,12 @@
+module Druid
+  def druid
+    return nil unless purls_from_urls.present?
+    purls_from_urls.first[/\w+$/]
+  end
+  private
+  def purls_from_urls
+    [self[:url_fulltext], self[:url_suppl]].flatten.compact.select do |url|
+      url =~ /purl\.stanford\.edu/
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -12,6 +12,7 @@ class SolrDocument
   include CollectionMember
   include ModsData
   include IndexAuthors
+  include Druid
 
   include Blacklight::Solr::Document
       # The following shows how to setup this blacklight document to display marc documents

--- a/app/views/catalog/access_panels/_in_collection.html.erb
+++ b/app/views/catalog/access_panels/_in_collection.html.erb
@@ -1,0 +1,25 @@
+<% if @document.is_a_collection_member? && @document.parent_collections.present? %>
+  <% @document.parent_collections.each do |parent_collection| %>
+    <div class="panel panel-default panel-in-collection">
+      <div class="panel-heading">
+        In collection
+      </div>
+      <div class="panel-body">
+        <%= link_to(presenter(parent_collection).document_heading, catalog_path(parent_collection[:id])) %>
+        <% if parent_collection[:summary_display] %>
+          <div data-behavior='truncate'>
+            <%= parent_collection[:summary_display].join(', ') %>
+          </div>
+        <% end %>
+      </div>
+      <div class="panel-footer">
+        <dl class="dl-invert">
+          <dt>DIGITAL CONTENT</dt>
+          <dd><%= link_to_collection_members(pluralize(parent_collection.collection_members.total, 'item'), parent_collection) %></dd>
+          <dt>COLLECTION PURL<dt>
+          <dd><%= link_to("http://purl.stanford.edu/#{parent_collection.druid}", "http://purl.stanford.edu/#{parent_collection.druid}") %></dd>
+        </dl>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/catalog/record/_metadata_panels.html.erb
+++ b/app/views/catalog/record/_metadata_panels.html.erb
@@ -1,6 +1,7 @@
 <div class="col-xs-12 row">
   <%= render "catalog/access_panels/online" %>
   <%= render "catalog/access_panels/course_reserve" %>
+  <%= render "catalog/access_panels/in_collection" %>
   <%= render "catalog/access_panels/location" %>
   <%# dummy panels (to be replaced) --
   <div class="panel panel-default">

--- a/spec/features/access_panels/in_collection_spec.rb
+++ b/spec/features/access_panels/in_collection_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+feature "In collection Access Panel" do
+  scenario "for MODS derived documents" do
+    visit catalog_path('30')
+
+    within(".panel-in-collection") do
+      within(".panel-heading") do
+        expect(page).to have_content("In collection")
+      end
+      within('.panel-body') do
+        expect(page).to have_css("a", text: "Image Collection1")
+        expect(page).to have_css("[data-behavior='truncate']", text: /A collection of fixture images/)
+      end
+      within(".panel-footer") do
+        expect(page).to have_css("dt", text: "DIGITAL CONTENT")
+        expect(page).to have_css("dd a", text: /\d+ items?/)
+        expect(page).to have_css("dt", text: "COLLECTION PURL")
+        expect(page).to have_css("dd a", text: "http://purl.stanford.edu/29")
+      end
+    end
+  end
+end

--- a/spec/fixtures/solr_documents/29.yml
+++ b/spec/fixtures/solr_documents/29.yml
@@ -11,3 +11,5 @@
 :pub_date: 2014
 :beginning_year_isi: 2000
 :imprint_display: 1990
+:url_fulltext:
+  - "http://purl.stanford.edu/29"

--- a/spec/models/concerns/druid_spec.rb
+++ b/spec/models/concerns/druid_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe Druid do
+  let(:document) { SolrDocument.new(url_fulltext: ["http://purl.stanford.edu/abc123"], url_suppl: ["http://stanford.edu/blah"]) }
+  let(:another_document) { SolrDocument.new(url_fulltext: ["http://stanford.edu/blah"], url_suppl: ["http://purl.stanford.edu/abc123"]) }
+  it "should return a druid from url_fulltext" do
+    expect(document.druid).to eq "abc123"
+  end
+  it "should return a druid from the url_suppl" do
+    expect(another_document.druid).to eq "abc123"
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -32,4 +32,9 @@ describe SolrDocument do
       expect(subject).to be_kind_of IndexAuthors
     end
   end
+  describe "Druid" do
+    it "should include druid" do
+      expect(subject).to be_kind_of Druid
+    end
+  end
 end


### PR DESCRIPTION
Closes #35 

![in-collection-ap](https://cloud.githubusercontent.com/assets/96776/3125174/505f42ce-e786-11e3-88c4-64bfe8e27ebb.png)

Extent is not in the index (at least not for MODS records AFICT).  It's possible that we could use the `physical` field in the index (described in #162).

The Finding Aid link will be present in merged collections and won't be available to us until we begin using the index/request handler that returns XML in search results.
