### PR TITLE
Remove empty access panels column for image collections.

### DIFF
--- a/app/views/catalog/record/_record_metadata_image_collection.html.erb
+++ b/app/views/catalog/record/_record_metadata_image_collection.html.erb
@@ -6,11 +6,8 @@
   %>
 </div>
 
-<div class="record-metadata col-md-12 row">
-  <div class="record-panels col-md-4 col-xs-12 row">
-    <%= render "catalog/record/metadata_panels" %>
-  </div>
-  <div class="record-sections col-md-8 col-xs-12">
+<div class="record-metadata col-xs-12 row">
+  <div class="record-sections">
     <% if @document[:modsxml] %>
       <%= render "catalog/record/mods_metadata_sections" %>
     <% end %>


### PR DESCRIPTION
Per @jvine (non-merged) File and Image collections should not have anything that would invoke an access panel so we should not have an empty column reserved for it on the page.
### Before

---

![before](https://cloud.githubusercontent.com/assets/96776/3127343/9ccc55c2-e7bb-11e3-8fff-aac893ac780f.png)
### After

---

![after](https://cloud.githubusercontent.com/assets/96776/3127345/a2aec2e0-e7bb-11e3-9e75-7c223c9c8eec.png)
