### PR TITLE
Enable 'Digital collections' link on home page.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -66,7 +66,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "db_az_subject", :label => "Database topic", collapse: false, show: false, limit: 21
     config.add_facet_field "access_facet", :label => "Access"
     config.add_facet_field "collection", :label => "Collection", :show => false
-    #config.add_facet_field "collection_type", :label => "Collection Type", :show => false
+    config.add_facet_field "collection_type", :label => "Collection Type", :show => false
     config.add_facet_field "format_main_ssim", :label => "Resource type"
     config.add_facet_field "format_physical_ssim", :label => "Physical Format"
     config.add_facet_field "genre_ssim", :label => "Genre"

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -2,4 +2,8 @@ module CollectionHelper
   def link_to_collection_members(link_text, document, options={})
     link_to(link_text, catalog_index_path(f: { collection: [document[:id]] }))
   end
+
+  def collections_search_params
+    { f: { collection_type: ["Digital Collection"] } }
+  end
 end

--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -15,9 +15,9 @@
   <h2>Featured sets</h2>
   <ul class="media-list">
     <li class="media">
-      <%= link_to image_tag("http://placehold.it/50x50", class: "media-object"), "#", class: "pull-left disabled" %>
+      <%= link_to image_tag("http://placehold.it/50x50", class: "media-object"), catalog_index_path(collections_search_params), class: "pull-left" %>
       <div class="media-body">
-        <%= link_to "Digital collections", "#", class: "media-heading disabled" %>
+        <%= link_to "Digital collections", catalog_index_path(collections_search_params), class: "media-heading" %>
         <p>Manuscripts, images, data, etc. from the Stanford Digital Repository</p>
       </div>
     </li>

--- a/spec/features/digital_collections_spec.rb
+++ b/spec/features/digital_collections_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+feature "Digital Collections Search" do
+  before do
+    visit root_path
+    click_link "Digital collections"
+  end
+  scenario "should have the filter applied" do
+    within(".breadcrumb") do
+      expect(page).to have_css('.filterName', text: "Collection Type")
+      expect(page).to have_css('.filterValue', text: "Digital Collection")
+    end
+  end
+  scenario "should return results" do
+    expect(page).to have_css("#documents .document")
+  end
+end

--- a/spec/helpers/collection_helper_spec.rb
+++ b/spec/helpers/collection_helper_spec.rb
@@ -10,4 +10,11 @@ describe CollectionHelper do
       expect(link_to_collection_members("LinkText", document)).to match /<a href=\".*collection.*=1234\".*/
     end
   end
+  describe "#collections_search_params" do
+    it "should be the collection_type facet value of 'Digital Collection" do
+      expect(collections_search_params).to have_key(:f)
+      expect(collections_search_params[:f]).to have_key(:collection_type)
+      expect(collections_search_params[:f][:collection_type]).to eq ["Digital Collection"]
+    end
+  end
 end


### PR DESCRIPTION
There isn't an access point specified in the mocks for the search of all collections AFAICT so this PR simply enables the link on the home page and fills out the appropriate parameters.

![digital-collections](https://cloud.githubusercontent.com/assets/96776/3127425/2d3d8aac-e7be-11e3-8739-ea09bf01a04f.png)
