### PR TITLE
Override blacklight paginator for local customizations.

### DIFF
--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+-%>
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <%= prev_page_tag %>
+    <%= next_page_tag  %>
+    <% each_relevant_page do |page| -%>
+      <% if page.left_outer? ||  page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>  
+  </ul>
+<% end -%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -24,3 +24,6 @@ en:
     pagination_compact:
       next: '&#9658;'
       previous: '&#9668;'
+    pagination:
+      previous: '&#9668; Previous'
+      next: 'Next &#9658;'

--- a/spec/features/blacklight_customizations/pagination_spec.rb
+++ b/spec/features/blacklight_customizations/pagination_spec.rb
@@ -1,0 +1,25 @@
+# encoding: UTF-8
+
+require "spec_helper"
+
+feature "Pagination customization", :"data-integration" => true do
+  before do
+    visit root_path
+    within(first('.home-facet')) do
+      click_link 'Book'
+    end
+  end
+  scenario "should not have deep paging links" do
+    within('ul.pagination') do
+      expect(page).to have_css('li a', count: 8) # would be 10 w/ deep paging links
+      expect(page).to_not have_css('li a', text: /\d{3},\d{3}/) # should not contain a link in the 100k range
+      expect(page).to_not have_css('li a', text: /\d{1,3}.\d{3},\d{3}/) # should not contain a link in the million range
+    end
+  end
+  scenario "should have an overridden character" do
+    within('ul.pagination') do
+      expect(page).to have_css('li a', text: "◄ Previous")
+      expect(page).to have_css('li a', text: "Next ►")
+    end
+  end
+end


### PR DESCRIPTION
Closes #44 

Remove deep paging links
Change i18n value used in next/previous links to add custom character

![custom-pagination](https://cloud.githubusercontent.com/assets/96776/3168524/42bd91f6-eb83-11e3-97ba-3a36fc770a07.png)
