### PR TITLE
Change backend lookup path to custom action.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,6 +239,14 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 5
   end
+
+  def backend_lookup
+    (@response, @document_list) = get_search_results
+    respond_to do |format|
+      format.json { render json: render_search_results_as_json }
+    end
+  end
+
   private
 
   def set_search_query_modifier

--- a/app/views/catalog/_additional_results_block.html.erb
+++ b/app/views/catalog/_additional_results_block.html.erb
@@ -4,13 +4,13 @@
     <p>
       <span>Modify your search:</span>
       <% if @search_modifier.has_filters? %>
-        <%= link_to("Remove limit(s)", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_index_path(@search_modifier.params_without_filters.merge({format: 'json'}))}"}) %>
+        <%= link_to("Remove limit(s)", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"}) %>
       <% end %>
       <% if @search_modifier.fielded_search? %>
-        <%= link_to("Search all fields", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_index_path(@search_modifier.params_without_fielded_search_and_filters.merge({format: 'json'}))}"}) %>
+        <%= link_to("Search all fields", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"}) %>
       <% end %>
       <% if @search_modifier.query_has_stopwords? %>
-        <%= link_to("Search without #{SearchQueryModifier.stopwords.map{|w| "\"#{w}\""}.join(' ')}", catalog_index_path(@search_modifier.params_without_stopwords), data: {behavior: "backend-lookup", lookup: "#{catalog_index_path(@search_modifier.params_without_stopwords.merge({format: 'json'}))}"}) %>
+        <%= link_to("Search without #{SearchQueryModifier.stopwords.map{|w| "\"#{w}\""}.join(' ')}", catalog_index_path(@search_modifier.params_without_stopwords), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_stopwords)}"}) %>
       <% end %>
     </p>
     <% if @search_modifier.has_query? %>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -11,12 +11,12 @@
       </li>
       <% if @search_modifier.has_filters? %>
         <li><%= t 'blacklight.search.zero_results.limit_fields' %>
-        <%= link_to "#{search_field_label(params)}: #{params[:q]}", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_index_path(@search_modifier.params_without_filters.merge({format: 'json'}))}"} %>
+        <%= link_to "#{search_field_label(params)}: #{params[:q]}", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"} %>
         </li>
       <% end %>
       <% if @search_modifier.fielded_search? %>
         <li><%= t 'blacklight.search.zero_results.search_fields' %>
-        <%= link_to "All fields: #{params[:q]}", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_index_path(@search_modifier.params_without_fielded_search_and_filters.merge({format: 'json'}))}"} %>
+        <%= link_to "All fields: #{params[:q]}", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"} %>
         </li>
       <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resource :feedback_form, path: "feedback", only: [:new, :create]
 
   get "feedback" => "feedback_forms#new"
+  get "backend_lookup" => "catalog#backend_lookup", defaults: {format: :json}, as: :catalog_backend_lookup
 
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -16,5 +16,10 @@ describe CatalogController do
         expect({get: "/databases"}).to route_to(controller: 'catalog', action: 'index', f: { "format" => ["Database"] })
       end
     end
+    describe "/backend_lookup" do
+      it "should route to the backend lookup path as json" do
+        expect({get: "/backend_lookup"}).to route_to(controller: 'catalog', action: 'backend_lookup', format: :json)
+      end
+    end
   end
 end


### PR DESCRIPTION
When making json requests agains the index action the
search context for the user is updated.  This causes the
"Back to Search" link and the pagination on the record view
to use the context of the last ajax request made from the
additional results block on the result set that the record came from.
