### PR TITLE
Split linked and unlinked series.

### DIFF
--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -63,6 +63,11 @@
   <%= render_field_from_marc(date_range) %>
 <% end %>
 
+<% series_490 = get_data_with_label_from_marc(document.to_marc, 'Series', '490') %>
+<% unless series_490.nil? %>
+  <%= render_field_from_marc(series_490) %>
+<% end %>
+
 <% note_500 = get_data_with_label_from_marc(document.to_marc, "Note", '500') %>
 <% unless note_500.nil? %>
   <%= render_field_from_marc(note_500) %>
@@ -426,14 +431,6 @@
 <%- related_work_799 = get_data_with_label_from_marc(document.to_marc, "Related Work", '799') -%>
 <%- unless related_work_799.nil? -%>
   <%= render_field_from_marc(related_work_799) %>
-<%- end -%>
-
-<%- series = link_to_series_from_marc(document.to_marc) -%>
-<%- unless series.nil? -%>
-  <dt>Series</dt>
-  <dd>
-    <%= series.join("<br/>").html_safe -%>
-  </dd>
 <%- end -%>
 
 <%- isbn = get_data_with_label(document, "ISBN", 'isbn_display') -%>

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -53,5 +53,13 @@
     <%- unless physical_desc.nil? -%>
       <%= render "field_from_index", :fields => physical_desc %>
     <%- end -%>
+
+    <% series = link_to_series_from_marc(document.to_marc) %>
+    <% if series.present? %>
+      <dt>Series:</dt>
+      <dd>
+        <%= series.join("<br/>").html_safe %>
+      </dd>
+    <% end %>
   </dl>
 <% end %>

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -673,6 +673,33 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+  def marc_single_series_fixture
+    <<-xml
+      <record>
+        <datafield tag="440" ind1=" " ind2=" ">
+          <subfield code="a">Name</subfield>
+          <subfield code="v">SubV</subfield>
+          <subfield code="z">SubZ</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+  def marc_multi_series_fixture
+    <<-xml
+      <record>
+        <datafield tag="440" ind1=" " ind2=" ">
+          <subfield code="a">440 $a</subfield>
+          <subfield code="v">440 $v</subfield>
+          <subfield code="x">440 $x</subfield>
+        </datafield>
+        <datafield tag="800" ind1=" " ind2=" ">
+          <subfield code="a">Name</subfield>
+          <subfield code="v">SubV800</subfield>
+          <subfield code="z">SubZ</subfield>
+        </datafield>
+      </record>
+    xml
+  end
   def no_fields_fixture
     "<record></record>"
   end

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -427,4 +427,18 @@ describe MarcHelper do
       expect(data["Current publication"].first).to eq "SubfieldA SubfieldB"
     end
   end
+  describe "#link_to_series_from_marc" do
+    let(:single_series_record) { SolrDocument.new(marcxml: marc_single_series_fixture ) }
+    let(:multi_series_record) { SolrDocument.new(marcxml: marc_multi_series_fixture ) }
+    it "should return a valid series" do
+      data = link_to_series_from_marc(single_series_record.to_marc)
+      data.length.should == 1
+      data.first.should match(/<a href=.*q=%22Name\+SubZ%22.*search_field=search_series.*>Name SubZ<\/a> SubV/)
+    end
+    it "should not include $x or $v" do
+      data = link_to_series_from_marc(multi_series_record.to_marc)
+      data.length.should == 2
+      data.first.should match(/<a href=.*%22440\+%24a%22.*search_field=search_series.*>440 \$a<\/a> 440 \$v 440 \$x/)
+    end
+  end
 end

--- a/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe "catalog/record/_marc_upper_metadata_items.html.erb" do
+  include MarcMetadataFixtures
+  describe "series" do
+    before do
+      assign(:document, SolrDocument.new(marcxml: marc_multi_series_fixture))
+      render
+    end
+    it "link to series" do
+      expect(rendered).to have_css('dt', text: "Series:")
+      expect(rendered).to have_css('dd a', text: "440 $a")
+      expect(rendered).to have_css('dd a', text: "Name SubZ")
+    end
+  end
+end


### PR DESCRIPTION
Closes #94 Closes #103 

Remove MARC 490 from linked series and display it separately in bibliographic section.
Moved the rest of the series to the upper metadata section.
### Linked in upper metadata section

---

![linked-series](https://cloud.githubusercontent.com/assets/96776/3207412/134b79e6-ede1-11e3-8e24-b636e32eb5e7.png)
### Unlinked in bibliographic section

---

![unlinked-series](https://cloud.githubusercontent.com/assets/96776/3207413/16bafae8-ede1-11e3-9c6b-321a1f703430.png)
