### PR TITLE
more specific selector for .document book cover

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -143,6 +143,5 @@
 
 Blacklight.onLoad(function() {
   $('#documents').plugGoogleBookContent();
-  $('.document').plugGoogleBookContent();
+  $('div#content.show-document .document').plugGoogleBookContent();
 });
-


### PR DESCRIPTION
Adds a more specific selector for the book cover plugin so index page is not selecting each `.document` and instantiating plugin multiple times.
