### PR TITLE
Customizes selections page

### DIFF
--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,0 +1,30 @@
+module BookmarksHelper
+
+  def bookmarks?
+    if params[:controller] == 'bookmarks'
+      true
+    end
+  end
+
+  #Similar to BL page_entries_info /app/helpers/blacklight/catalog_helper_behavior.rb
+  def current_entries_info collection, options = {}
+    end_num = if collection.respond_to? :groups and render_grouped_response? collection
+      collection.groups.length
+    else
+      collection.limit_value
+    end
+
+    end_num = if collection.offset_value + end_num <= collection.total_count
+      collection.offset_value + end_num
+    else
+      collection.total_count
+    end
+    begin_num = if collection.total_count == 0
+      0
+    else
+      collection.offset_value + 1
+    end
+    "#{begin_num} - #{end_num}"
+  end
+
+end

--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -1,0 +1,23 @@
+<span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
+<div id="tools-dropdown" class="btn-group">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+    <%= t('blacklight.tools.send_to_html', current_range: current_entries_info(@response)) %>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li class="disabled">
+      <%= link_to t('blacklight.tools.sms_html'), sms_catalog_path(id: @document), {id: 'smsLink', data: {ajax_modal: "trigger"}} %>
+    </li>
+    <li class="disabled">
+      <%= link_to t('blacklight.tools.email_html'), email_catalog_path(sort: params[:sort], per_page: params[:per_page], id: @response.documents.map {|doc| doc.id}), id: "emailLink", data: {ajax_modal: "trigger"} %>
+    </li>
+    <li class="disabled">
+      <%= link_to t('blacklight.tools.refworks_html'), refworks_export_url(id: @document) %>
+    </li>
+    <li class="disabled">
+      <%= link_to t('blacklight.tools.endnote_html'), "#" %>
+    </li>
+    <li class="disabled">
+      <%= link_to t('blacklight.tools.printer_html'), "#" %>
+    </li>
+  </ul>
+</div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,20 @@
+<div id="content" class="col-md-12">
+  <div class="row">
+    <div class="col-md-12">
+      <h1 class="pull-right"><%= "#{@response.total_count} #{t('blacklight.bookmarks.selection_title').pluralize(@response.documents.length)}" %></h1>
+    </div>
+  </div>
+
+<%- if current_or_guest_user.blank? -%>
+
+  <h2><%= t('blacklight.bookmarks.need_login') %></h2>
+
+<%- elsif @document_list.blank? -%>
+
+  <h3><%= t('blacklight.bookmarks.no_bookmarks') %></h3>
+<% else %>
+  <%= render 'sort_and_per_page' %>
+  <%= render_document_index %>
+  <%= render 'results_pagination' %>
+<% end %>
+</div>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -17,10 +17,17 @@
       </ul>
     </div>
     <div id="" class="search-widgets collapse navbar-collapse pull-right">
+      <% if bookmarks? %>
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(@response)), citation_catalog_path(:sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-default', :data => {:ajax_modal => "trigger"}} %>
+        <%= render "bookmarks/tool_dropdown" %>
+      <% end %>
       <%= render partial: 'view_type_group' %>
       <%= render partial: 'sort_widget' %>
       <%= render partial: 'per_page_widget' %>
-      <%= render partial: 'select_all_widget' %>
+      <% unless bookmarks? %>
+        <%= render partial: 'select_all_widget' %>
+      <% end %>
     </div>
   </div>
 </div>
+<%=  %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -21,6 +21,15 @@ en:
       add:
         all: 'Select all'
         all_small: '&#10004; all'
+      selection_title: 'selection'
+    tools:
+      sms_html: '<span class="glyphicon glyphicon-phone"> </span>  text'
+      email_html: '<span class="glyphicon glyphicon-envelope"> </span>  email'
+      refworks_html: '<span class="glyphicon glyphicon-asterisk"> </span>  RefWorks'
+      endnote_html: '<span class="glyphicon glyphicon-asterisk"> </span>  EndNote'
+      printer_html: '<span class="glyphicon glyphicon-print"> </span>  printer'
+      cite_entries: 'Cite %{current_range}'
+      send_to_html: 'Send %{current_range} to <span class="caret"></span>'
   views:
     pagination_compact:
       next: '&#9658;'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
 
   resources :preview, only: :show
 
+  get "selections" => "bookmarks#index"
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/features/blacklight_customizations/bookmarks_path_spec.rb
+++ b/spec/features/blacklight_customizations/bookmarks_path_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+feature "Selections Path" do
+
+  scenario "should render bookmarks page" do
+    visit selections_path
+    expect(page).to have_css("h1", text: "0 selections")
+    expect(page).to have_css("h3", text: "You have no bookmarks")
+  end
+
+  scenario "should render some bookmarks and toolbar", js: true do
+    visit catalog_index_path f: {format: ["Book"]}, view: "default"
+    page.all('label.toggle_bookmark')[0].click
+    page.all('label.toggle_bookmark')[1].click
+    expect(page).to have_css("label.toggle_bookmark span", text: "Selected", count: 2)
+    visit selections_path
+    expect(page).to have_css("h1", text: "2 selections")
+    within "#documents" do
+      expect(page).to have_css("h5.index_title a", count: 2)
+    end
+    within ".search-widgets" do
+      expect(page).to have_css("a", text: "Cite 1 - 2")
+      expect(page).to have_css("button", text: "Send 1 - 2")
+      expect(page).to_not have_css("button#select_all-dropdown")
+    end
+  end
+end

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -20,6 +20,8 @@ feature "Results Toolbar", js: true do
       within "#select_all-dropdown" do
         expect(page).to have_css("span.visible-md.visible-lg", text: "Select all")
       end
+      expect(page).to_not have_css("a", text: /Cite/)
+      expect(page).to_not have_css("button", text: /Send/)
     end
   end
   scenario "should have tablet and mobile tools hidden" do

--- a/spec/helpers/bookmarks_helper_spec.rb
+++ b/spec/helpers/bookmarks_helper_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+describe BookmarksHelper do
+
+  # From BL /spec/helpers/catalog_helper_spec.rb
+  def mock_response args
+    current_page = args[:current_page] || 1
+    per_page = args[:rows] || args[:per_page] || 10
+    total = args[:total]
+    start = (current_page - 1) * per_page
+
+    mock_docs = (1..total).to_a.map { {}.with_indifferent_access }
+
+    mock_response = Kaminari.paginate_array(mock_docs).page(current_page).per(per_page)
+
+    mock_response.stub(:docs).and_return(mock_docs.slice(start, per_page))
+    mock_response
+  end
+
+  describe "bookmarks?" do
+    it "should return true if bookmarks controller" do
+      params[:controller] = "bookmarks"
+      expect(helper.bookmarks?).to be_true
+    end
+    it "should return false if not bookmarks controller" do
+      params[:controller] = "catalog"
+      expect(helper.bookmarks?).to be_false
+    end
+  end
+  describe "current_entries_info" do
+    it "with no results" do
+      @response = mock_response total: 0
+      expect(current_entries_info(@response)).to eq '0 - 0'
+    end
+    it "with one result" do
+      @response = mock_response total: 1
+      expect(current_entries_info(@response)).to eq '1 - 1'
+    end
+    it "with one page of results" do
+      @response = mock_response total: 8
+      expect(current_entries_info(@response)).to eq '1 - 8'
+    end
+    it "first page of multiple results" do
+      @response = mock_response total: 15, per_page: 10
+      expect(current_entries_info(@response)).to eq '1 - 10'
+    end
+    it "second page of multiple results" do
+      @response = mock_response total: 47, per_page: 10, current_page: 2
+      expect(current_entries_info(@response)).to eq '11 - 20'
+    end
+    it "last page of multiple results" do
+      @response = mock_response total: 47, per_page: 10, current_page: 5
+      expect(current_entries_info(@response)).to eq '41 - 47'
+    end
+  end
+
+
+end


### PR DESCRIPTION
Resolves #20

Adds customized selections page at `/selections` with toolbar placeholders

![screen shot 2014-06-12 at 11 32 58 am](https://cloud.githubusercontent.com/assets/1656824/3261984/1e8b6d1a-f260-11e3-83d3-e3cb4ce61658.png)
![screen shot 2014-06-12 at 11 33 04 am](https://cloud.githubusercontent.com/assets/1656824/3261985/246ef116-f260-11e3-8a66-e68fc7804084.png)
