### PR TITLE
Swap location/in-collection access panels.

### DIFF
--- a/app/views/catalog/record/_metadata_panels.html.erb
+++ b/app/views/catalog/record/_metadata_panels.html.erb
@@ -1,16 +1,6 @@
 <div class="col-xs-12 row">
   <%= render "catalog/access_panels/online" %>
   <%= render "catalog/access_panels/course_reserve" %>
-  <%= render "catalog/access_panels/in_collection" %>
   <%= render "catalog/access_panels/location" %>
-  <%# dummy panels (to be replaced) --
-  <div class="panel panel-default">
-    <div class="panel-heading">Course reserves</div>
-    <div class="panel-body"></div>
-  </div>
-  <div class="panel panel-default">
-    <div class="panel-heading">Library</div>
-    <div class="panel-body"></div>
-  </div>
-  %>
+  <%= render "catalog/access_panels/in_collection" %>
 </div>


### PR DESCRIPTION
Closes #243 

Everything was in the correct order except for location and in collection.

![access-panel-order](https://cloud.githubusercontent.com/assets/96776/3265170/448207e2-f28b-11e3-84a1-f1c339e12e89.png)

*course reserves will show up between online and location, I swear.
