### PR TITLE
Enable temporary selections link in search results toolbar.

### DIFF
--- a/app/views/catalog/_search_bar_nav_list.html.erb
+++ b/app/views/catalog/_search_bar_nav_list.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav navbar-nav navbar-right searchbar-right">
   <li class=""><%= render_search_bar_advanced_widget %></li>
   <li class="disabled"><%= render_search_bar_browse_widget %></li>
-  <li class="disabled"><%= render_search_bar_selections_widget %></li>
+  <li><%= render_search_bar_selections_widget %></li>
 </ul>

--- a/app/views/catalog/_search_bar_selections_widget.html.erb
+++ b/app/views/catalog/_search_bar_selections_widget.html.erb
@@ -1,3 +1,3 @@
-<a href="#" class="search-bar-widget">
-  <span class="glyphicon glyphicon-ok-circle hidden-xs"></span> Selections <span class="caret hidden-xs"></span>
-</a>
+<%= link_to selections_path, class:"search-bar-widget #{active_class_for_current_page(selections_path)}" do %>
+  <span class="glyphicon glyphicon-ok-circle hidden-xs"></span> Selections
+<% end %>

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -8,7 +8,7 @@ describe "Search toolbar", js: true, feature: true do
         expect(page.find('button.btn.btn-primary.search-btn')).to have_no_content 'Search'
         expect(page).to have_css("li a", text: "Advanced", visible: true)
         expect(page).to have_css("li.disabled a", text: "Browse", visible: true)
-        expect(page).to have_css("li.disabled a", text: "Selections", visible: true)
+        expect(page).to have_css("li a", text: /Selections/, visible: true)
       end
     end
   end

--- a/spec/features/responsive/search_toolbar_responsive_spec.rb
+++ b/spec/features/responsive/search_toolbar_responsive_spec.rb
@@ -29,7 +29,7 @@ describe "Responsive search bar", js: true, feature: true do
         within "#searchbar-navbar-collapse" do
           expect(page).to have_css("li a", text: "Advanced", visible: true)
           expect(page).to have_css("li.disabled a", text: "Browse", visible: true)
-          expect(page).to have_css("li.disabled a", text: "Selections", visible: true)
+          expect(page).to have_css("li a", text: /Selections/, visible: true)
         end
       end
     end


### PR DESCRIPTION
![selections-link](https://cloud.githubusercontent.com/assets/96776/3265874/33dd1e7e-f29d-11e3-95e3-f57b5a3922e0.png)
