### PR TITLE
Change configuration usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
-config/settings.yml

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,10 +24,10 @@ set :log_level, :info
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{.hostname config/database.yml config/solr.yml config/settings.yml}
+set :linked_files, %w{.hostname config/database.yml config/solr.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{bin log settings tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+HOURS_API: <%= ENV['HOURS_API'] || 'http://example.com' %>
+EMAIL_TO: "fake-email@kittenz.com"
+HOSTNAME: "HOST"
+STACKS_URL: "https://stacks.stanford.edu/image"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,1 @@
-EMAIL_TO: "fake-email@kittenz.com"
 HOSTNAME: "DEV-HOST"
-STACKS_URL: "https://stacks.stanford.edu/image"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,2 @@
-HOURS_API: "http://test"
-EMAIL_TO: "fake-email@kittenz.com"
 HOSTNAME: "TEST-HOST"
 STACKS_URL: https://stacks-test.stanford.edu/image

--- a/spec/integration/external-data/library_location_hours_spec.rb
+++ b/spec/integration/external-data/library_location_hours_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe "Library location hours", feature: true, js: true, :"data-integration" => true do
   it "should display today's hours" do
-    pending("Needs settings fix in #229 to pass")
     visit catalog_path("10365287")
     within "div.location-hours-today" do
       expect(page).to have_content("Today's hours:")

--- a/spec/lib/hours_request_spec.rb
+++ b/spec/lib/hours_request_spec.rb
@@ -15,7 +15,7 @@ describe HoursRequest do
 
   it "should receive " do
     # Fake URL that resolves for testing
-    expect(Faraday).to receive(:new).with({ url: "http://test/green/location/green_library/hours/for/today" }).and_return(struct)
+    expect(Faraday).to receive(:new).with({ url: "http://example.com/green/location/green_library/hours/for/today" }).and_return(struct)
     expect(HoursRequest.new("GREEN").get).to eq("test")
   end
 


### PR DESCRIPTION
Closes #229 

Un-ignore settings.yml and put ALL base settings in there.
Add optional HOURS_API env variable to set during the jenkins build.
Move a few environment specific settings into environment settings files.
Fix a few tests to match the new settings.
Don't symlink base settings.yml file on deploy, symlink settings directory instead.
