### PR TITLE
Add CallnumberSearch controller concern...

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,8 @@ class CatalogController < ApplicationController
 
   include DatabaseAccessPoint
 
+  include CallnumberSearch
+
   helper Openseadragon::OpenseadragonHelper
 
   before_filter :add_show_partials

--- a/app/controllers/concerns/callnumber_search.rb
+++ b/app/controllers/concerns/callnumber_search.rb
@@ -1,0 +1,18 @@
+module CallnumberSearch
+  extend ActiveSupport::Concern
+
+  included do
+    if self.respond_to?(:before_filter)
+      before_filter :quote_and_downcase_callnumber_search, only: :index
+    end
+  end
+
+  private
+
+  def quote_and_downcase_callnumber_search
+    if params[:search_field] == 'call_number'
+      params[:q].downcase!
+      params[:q] = "\"#{params[:q]}\"" unless params[:q].include?('"')
+    end
+  end
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -4,6 +4,9 @@ describe CatalogController do
   it "should include the DatabaseAccessPoint concern" do
     expect(subject).to be_kind_of(DatabaseAccessPoint)
   end
+  it "should include the CallnumberSearch concern" do
+    expect(subject).to be_kind_of(CallnumberSearch)
+  end
   describe "#index" do
     it "should set the search modifier" do
       get :index

--- a/spec/controllers/concerns/callnumber_search_spec.rb
+++ b/spec/controllers/concerns/callnumber_search_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+class CallnumberSearchTestClass
+  include CallnumberSearch
+end
+
+describe CallnumberSearch do
+  let(:subject) { CallnumberSearchTestClass.new }
+  describe "#quote_and_downcase_callnumber_search" do
+    let(:params) { {search_field: 'call_number', q: 'ABC 123'} }
+    before do
+      subject.stub(:params).and_return( params )
+      subject.send(:quote_and_downcase_callnumber_search)
+    end
+    it "should downcase the q parameter" do
+      expect(params[:q]).to match /abc 123/
+      expect(params[:q]).to_not include "ABC"
+    end
+    it "should quote the q parameter" do
+      expect(params[:q]).to eq '"abc 123"'
+    end
+    describe "when already quoted" do
+      let(:params) { {search_field: 'call_number', q: '"ABC 123"'} }
+      before do
+        subject.stub(:params).and_return( params )
+        subject.send(:quote_and_downcase_callnumber_search)
+      end
+      it "should not double quote" do
+        expect(params[:q]).to eq '"abc 123"'
+      end
+    end
+    describe "when not a callnumber search" do
+      let(:params) { {search_field: 'not_callnumber', q: 'ABC 123'} }
+      before do
+        subject.stub(:params).and_return( params )
+      end
+      it "should not change the q parameter" do
+        subject.send(:quote_and_downcase_callnumber_search)
+        expect(params[:q]).to eq 'ABC 123'
+      end
+    end
+  end
+end

--- a/spec/integration/external-data/callnumber_search_spec.rb
+++ b/spec/integration/external-data/callnumber_search_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "Callnumber Search", feature: true, :"data-integration" => true do
+  before do
+    visit root_path
+    fill_in 'q', with: 'JQ1879 .A15 D385'
+    select 'Call number', from: 'search_field'
+    click_button 'search'
+  end
+  it "should quote and downcase the callnumber" do
+    expect(find('#q').value).to eq '"jq1879 .a15 d385"'
+    within('.breadcrumb') do
+      expect(page).to have_css('.filterName', text: 'Call number')
+      expect(page).to have_css('.filterValue', text: '"jq1879 .a15 d385"')
+    end
+  end
+  it "should return the relevant result" do
+    expect(page).to have_css('.document', count: 1)
+    expect(page).to have_css('.index_title', text: /African world histories/)
+  end
+end


### PR DESCRIPTION
... to downcase and quote callnumber searches.

Closes #254 

A callnumber search for `JQ1879 .A15 D385` will yield the following:

![callnumber-search](https://cloud.githubusercontent.com/assets/96776/3276192/bc7a9bdc-f345-11e3-8849-bdcf45f5f23a.png)
