### PR TITLE
[PROPOSAL] Change routes to be /view

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   root :to => "catalog#index"
-  blacklight_for :catalog
+
+  get "view/:id" => "catalog#show", :as => :catalog
+  get "view/:id" => "catalog#show", :as => :solr_document
+  get "view/:id/librarian_view" => "catalog#librarian_view", as: :librarian_view
+
+  blacklight_for(:catalog)
   Blacklight::Marc.add_routes(self)
   devise_for :users
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -11,6 +11,20 @@ describe CatalogController do
     end
   end
   describe "routes" do
+    describe "customized from Blacklight" do
+      it "should route /view/:id properly" do
+        expect({get: '/view/1234'}).to route_to(controller: 'catalog', action: 'show', id: '1234')
+      end
+      it "should route catalog_path to /view" do
+        expect(catalog_path('1234')).to eq '/view/1234'
+      end
+      it "should route solr_document_path to /view" do
+        expect(solr_document_path('1234')).to eq '/view/1234'
+      end
+      it "should route the librarian view properly" do
+        expect({get: '/view/1234/librarian_view' }).to route_to(controller: 'catalog', action: 'librarian_view', id: '1234')
+      end
+    end
     describe "/databases" do
       it "should route to the database format" do
         expect({get: "/databases"}).to route_to(controller: 'catalog', action: 'index', f: { "format" => ["Database"] })

--- a/spec/features/access_panels/course_reserve_spec.rb
+++ b/spec/features/access_panels/course_reserve_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature "Course Reserve Access Panel" do
 
   scenario "should have 3 course reservations" do
-    visit '/catalog/1'
+    visit '/view/1'
     within "div.panel-course-reserve" do
       expect(page).to have_css('div.course-reserve-course', count: 3, text: "COURSE:")
       expect(page).to have_css('span.course-reserve-title', text: "COURSE:")
@@ -13,7 +13,7 @@ feature "Course Reserve Access Panel" do
   end
 
   scenario "should have 1 course reservations" do
-    visit '/catalog/2'
+    visit '/view/2'
     within "div.panel-course-reserve" do
       expect(page).to have_css('div.course-reserve-course', count: 1, text: "CAT-401-01-01 -- Emergency Kittenz")
       expect(page).to have_css('span.course-reserve-title', text: "COURSE:")
@@ -23,7 +23,7 @@ feature "Course Reserve Access Panel" do
   end
 
   scenario "should have 0 course reservations" do
-    visit '/catalog/3'
+    visit '/view/3'
     expect(page.has_no_css?('div.panel-course-reserve')).to eql true
 
   end

--- a/spec/features/access_panels/library_location_spec.rb
+++ b/spec/features/access_panels/library_location_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature "Library Location Access Panel" do
 
   scenario "should have 1 library location" do
-    visit '/catalog/1'
+    visit '/view/1'
     expect(page).to have_css('div.panel-library-location', count:1)
     within "div.panel-library-location" do
       within "div.library-location-heading" do
@@ -14,7 +14,7 @@ feature "Library Location Access Panel" do
   end
 
   scenario "should have 3 library locations" do
-    visit '/catalog/10'
+    visit '/view/10'
     expect(page).to have_css('div.panel-library-location', count:3)
   end
 end

--- a/spec/features/access_panels/online_books_spec.rb
+++ b/spec/features/access_panels/online_books_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature "Record view" do
   before do
-    visit('/catalog/10')
+    visit('/view/10')
   end
 
   scenario "should have online books panel with Google links", js: true do

--- a/spec/features/blacklight_customizations/record_metadata_spec.rb
+++ b/spec/features/blacklight_customizations/record_metadata_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature "Record view" do
   before do
-    visit('/catalog/10')
+    visit('/view/10')
   end
 
   scenario "should have correct cover image attributes", js: true do

--- a/spec/features/blacklight_customizations/record_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/record_toolbar_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature "Record Toolbar" do
   before do
-    visit('/catalog/1')
+    visit('/view/1')
   end
 
   scenario "should have record toolbar visible", js: true do

--- a/spec/features/image_collection_spec.rb
+++ b/spec/features/image_collection_spec.rb
@@ -29,7 +29,7 @@ feature "Image Collection" do
       expect(page).to have_css(".viewport .container-images")
 
       within ".viewport .container-images" do
-        expect(page).to have_css("a[href='/catalog/mf774fs2413']")
+        expect(page).to have_css("a[href='/view/mf774fs2413']")
       end
     end
 
@@ -51,7 +51,7 @@ feature "Image Collection" do
       within ".viewport .container-images" do
         expect(page).to have_css("li[data-behavior='preview']")
         expect(page).to have_css("li[data-preview-in-filmstrip='true']")
-        expect(page).to have_css("a[href='/catalog/mf774fs2413']")
+        expect(page).to have_css("a[href='/view/mf774fs2413']")
       end
     end
   end

--- a/spec/features/responsive/record_toolbar_responsive_spec.rb
+++ b/spec/features/responsive/record_toolbar_responsive_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 # TODO revisit on individual viewports, visible: true/false functionality not working correctly
 describe "Record toolbar", js: true, feature: true do
   before do
-    visit('/catalog/1')
+    visit('/view/1')
   end
 
   describe " - tablet view (768px - 980px) - " do


### PR DESCRIPTION
Closes #99 

Override routes to record view to be `view/:id`.
Also overriding librarian_view but keeping all other resources at `catalog/:id`.

This PR takes a pretty different (and simplified) approach to the routes than in the current codebase.

Routes are taken _first come first serve_ so by mapping `view/:id` to the correct action and naming it the same as Blacklight will (e.g. `catalog_path` and `solr_document_path`) then Blacklight will use our overridden path when linking to records.

One thing to note is that I've directly mapped the `view/:id/librarian_view` as I think it _might_ be something that people will hand craft the URL to go to.  The other things that will still reside at a `catalog` url are things that users won't go directly to because they are either backend integration points for external services or are in modal pop-ups (e.g. refworks/endnote exports, email forms, citations, etc).

If we feel like any of those routes should also have `view` then we can add them as they come up.
