### PR TITLE
Adds support for when a search term is not given

### DIFF
--- a/app/controllers/concerns/callnumber_search.rb
+++ b/app/controllers/concerns/callnumber_search.rb
@@ -10,7 +10,7 @@ module CallnumberSearch
   private
 
   def quote_and_downcase_callnumber_search
-    if params[:search_field] == 'call_number'
+    if params[:search_field] == 'call_number' && params[:q]
       params[:q].downcase!
       params[:q] = "\"#{params[:q]}\"" unless params[:q].include?('"')
     end

--- a/spec/controllers/concerns/callnumber_search_spec.rb
+++ b/spec/controllers/concerns/callnumber_search_spec.rb
@@ -39,5 +39,15 @@ describe CallnumberSearch do
         expect(params[:q]).to eq 'ABC 123'
       end
     end
+    describe "when a search term is not given" do
+      let(:params) { {search_field: 'call_number'} }
+      before do
+        subject.stub(:params).and_return( params)
+      end
+      it "should not change any parameters" do
+        subject.send(:quote_and_downcase_callnumber_search)
+        expect(params).to eq params
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes the scenario when a user removes the search term `q` parameter from the search while `search_field` is still defined as `callnumber`
