### PR TITLE
Refactor preview plugin into sub-plugins

### DIFF
--- a/app/assets/javascripts/jquery.filmstrip-images.js
+++ b/app/assets/javascripts/jquery.filmstrip-images.js
@@ -2,14 +2,14 @@
   /*
     jQuery plugin to render images in a collection as a filmstrip
 
-      Usage: $(selector).imgFilmStrip();
+      Usage: $(selector).renderFilmstrip();
 
     This plugin :
       - renders filmstrip view for elements with 'image-filmstrip' class
         and attaches navigation events
   */
 
-  $.fn.imgFilmStrip = function() {
+  $.fn.renderFilmstrip = function() {
 
     return this.each(function() {
       var $filmstrip = $(this),
@@ -106,6 +106,6 @@ jQuery.fn.scrollStop = function(callback) {
 
 
 Blacklight.onLoad(function() {
-  $('.image-filmstrip').imgFilmStrip();
+  $('.image-filmstrip').renderFilmstrip();
 });
 

--- a/app/assets/javascripts/jquery.preview-filmstrip.js
+++ b/app/assets/javascripts/jquery.preview-filmstrip.js
@@ -3,7 +3,7 @@
   /*
     jQuery plugin to attach preview triggers and render previews
 
-      Usage: $(selector).itemPreview();
+      Usage: $(selector).previewFilmstrip();
 
     This plugin :
       - adds preview triggers to the matched elements
@@ -14,13 +14,12 @@
   */
 
 
-  $.fn.itemPreview = function() {
+  $.fn.previewFilmstrip = function() {
 
     return this.each(function() {
       var $item = $(this),
           $previewTarget = $($item.data('preview-target')),
-          isPartOfFilmstrip = $item.data('preview-in-filmstrip') || false,
-          showPointer = $item.data('preview-show-pointer') || true,
+          showPointer = true,
           $triggerBtn, $triggerFocus, $closeBtn, $arrow, $content, $filmstrip, $viewport;
 
       init();
@@ -36,40 +35,25 @@
         var previewUrl = $item.data('preview-url'),
             $previewArrow,
             maxLeft,
-            arrowLeft;
+            arrowLeft,
+            $divContent = $('<div class="preview-content"></div>');
 
         $previewTarget.addClass('preview').empty();
-
-        appendPreviewContent(previewUrl, $previewTarget);
 
         if (showPointer) {
           appendPointer($previewTarget);
         }
 
-        if (isPartOfFilmstrip) {
-          $viewport.css('overflow-x', 'hidden');
-        }
+        PreviewContent.append(previewUrl, $divContent);
 
-        $previewTarget.append($closeBtn).show();
+        $previewTarget
+          .append($divContent)
+          .append($closeBtn)
+          .show();
+
+        $viewport.css('overflow-x', 'hidden');
 
         attachPreviewEvents();
-      }
-
-
-      function appendPreviewContent(url, $target) {
-        var request = $.ajax({
-          url: url,
-          type: 'GET',
-          dataType: 'html'
-        });
-
-        request.done(function(html) {
-          $target.append($('<div class="preview-content"></div>').append(html));
-        });
-
-        request.fail(function(jqXhr, textStatus) {
-          console.log('GET request for ' + url + ' failed: ' + textStatus);
-        });
       }
 
 
@@ -105,11 +89,9 @@
           showPreview();
         }, this));
 
-        if (isPartOfFilmstrip) {
-          $filmstrip.find('.prev, .next').on('click', $.proxy(function() {
-            closePreview();
-          }, this));
-        }
+        $filmstrip.find('.prev, .next').on('click', $.proxy(function() {
+          closePreview();
+        }, this));
       }
 
 
@@ -120,10 +102,7 @@
       }
 
       function closePreview() {
-        if (isPartOfFilmstrip) {
-          $viewport.css('overflow-x', 'scroll');
-        }
-
+        $viewport.css('overflow-x', 'scroll');
         $previewTarget.empty().hide();
       }
 
@@ -133,11 +112,8 @@
         $triggerFocus = $('<div/>').addClass('preview-trigger-focus preview-opacity').html('Preview <span class="glyphicon glyphicon-chevron-down small">');
         $closeBtn = $('<a class="preview-close"><span class="glyphicon glyphicon-remove"></span></a>');
         $arrow = $('<div class="preview-arrow"></div>');
-
-        if (isPartOfFilmstrip) {
-          $filmstrip = $item.closest('.image-filmstrip');
-          $viewport = $filmstrip.find('.viewport');
-        }
+        $filmstrip = $item.closest('.image-filmstrip');
+        $viewport = $filmstrip.find('.viewport');
       }
 
     });
@@ -148,6 +124,6 @@
 
 
 Blacklight.onLoad(function() {
-  $('*[data-behavior="preview"]').itemPreview();
+  $('*[data-behavior="preview-filmstrip"]').previewFilmstrip();
 });
 

--- a/app/assets/javascripts/preview-content.js
+++ b/app/assets/javascripts/preview-content.js
@@ -1,0 +1,47 @@
+/*
+  JavaScript module to fetch preview content. `useCache` option enables/disables
+  caching of fetched preview content in browser
+ */
+
+var PreviewContent = (function() {
+
+  var useCache = true;
+  window.previewCache = window.previewCache || {};
+
+
+  function append(url, target) {
+    var content = window.previewCache[url];
+
+    if (useCache && typeof content !== 'undefined') {
+      target.append(content);
+    } else {
+      fetchContentViaAjaxAndAppend(url, target);
+    }
+  }
+
+
+  function fetchContentViaAjaxAndAppend(url, target) {
+    var request = $.ajax({
+      url: url,
+      type: 'GET',
+      dataType: 'html'
+    });
+
+    request.done(function(data) {
+      target.append(data);
+      if (useCache) window.previewCache[url] = data;
+    });
+
+    request.fail(function(jqXhr, textStatus) {
+      console.log('GET request for ' + url + ' failed: ' + textStatus);
+    });
+  }
+
+
+  return {
+    append: function(url, target) {
+      append(url, target);
+    }
+  }
+
+}());

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -1,8 +1,8 @@
 module PreviewHelper
 
-  def preview_data_attrs(show_preview = true, id, target)
+  def preview_data_attrs(show_preview = true, preview_type, id, target)
     if show_preview
-      attrs = "data-behavior=\"preview\" data-preview-url=\"#{preview_path(id)}\" data-preview-target=\"#{target}\""
+      attrs = "data-behavior=\"#{preview_type}\" data-preview-url=\"#{preview_path(id)}\" data-preview-target=\"#{target}\""
     end
 
     (attrs ||= '').html_safe

--- a/app/views/catalog/_image_collection_filmstrip.html.erb
+++ b/app/views/catalog/_image_collection_filmstrip.html.erb
@@ -1,5 +1,7 @@
-<% show_preview ||= true %>
-<% preview_container = 'preview-container-' + collection_document[:id] %>
+<%
+  show_preview ||= true
+  preview_container = 'preview-container-' + collection_document[:id]
+%>
 
 <div class="col-md-12 image-filmstrip" data-thumb-width="100" data=thumb-height="100">
 
@@ -16,7 +18,7 @@
       <% collection_document.collection_members.documents.each do |document| %>
 
         <% unless document.image_urls.blank? %>
-          <li <%= preview_data_attrs(show_preview, document[:id], '.' + preview_container) %> data-preview-in-filmstrip="true">
+          <li <%= preview_data_attrs(show_preview, 'preview-filmstrip', document[:id], '.' + preview_container) %>>
             <a href="<%= catalog_path(document[:id]) %>">
               <img src="" class="thumb-<%= document[:id] %>" data-url="<%= document.image_urls(:thumbnail).first %>">
             </a>

--- a/spec/features/image_collection_spec.rb
+++ b/spec/features/image_collection_spec.rb
@@ -49,8 +49,7 @@ feature "Image Collection" do
       expect(page).to have_css(".viewport .container-images")
 
       within ".viewport .container-images" do
-        expect(page).to have_css("li[data-behavior='preview']")
-        expect(page).to have_css("li[data-preview-in-filmstrip='true']")
+        expect(page).to have_css("li[data-behavior='preview-filmstrip']")
         expect(page).to have_css("a[href='/view/mf774fs2413']")
       end
     end


### PR DESCRIPTION
- Extracted preview content fetching to a separate JS module
- `jquery.preview-filmstrip.js` is now a plugin that renders previews only for filmstrip
