### PR TITLE
Add view type list dropdown and 'brief' view

### DIFF
--- a/app/assets/javascripts/jquery.preview-brief.js
+++ b/app/assets/javascripts/jquery.preview-brief.js
@@ -1,0 +1,70 @@
+(function($) {
+
+  /*
+    jQuery plugin to attach preview triggers and render previews in
+    brief view
+
+      Usage: $(selector).previewBrief();
+
+    This plugin :
+      - adds preview triggers to the brief preview button
+      - on preview click event, fetches preview content from
+        'data-preview-url' data attribute value and renders it
+  */
+
+
+  $.fn.previewBrief = function() {
+
+    return this.each(function() {
+      var $item = $(this),
+          $previewTarget = $($item.data('preview-target')),
+          previewUrl = $item.data('preview-url'),
+          $triggerBtn, $briefTarget;
+
+      init();
+      attachTriggerEvents();
+
+      function showPreview() {
+        $previewTarget.addClass('preview').empty();
+
+        PreviewContent.append(previewUrl, $previewTarget);
+
+        $triggerBtn
+          .addClass('preview-open')
+          .html('<span class="glyphicon glyphicon-chevron-up"></span> Close');
+
+        $briefTarget.hide();
+        $previewTarget.show();
+      }
+
+
+      function attachTriggerEvents() {
+        $item.find($triggerBtn).on('click', function() {
+          $(this).hasClass('preview-open') ? closePreview() : showPreview();
+        });
+      }
+
+      function closePreview() {
+        $previewTarget.removeClass('preview').hide();
+        $briefTarget.show();
+
+        $triggerBtn
+          .removeClass('preview-open')
+          .html('<span class="glyphicon glyphicon-chevron-right"></span> Preview');
+      }
+
+      function init() {
+        $triggerBtn = $item.find('*[data-behavior="preview-button-trigger"]');
+        $briefTarget = $item.find('.brief-container');
+      }
+
+    });
+
+  };
+
+})(jQuery);
+
+
+Blacklight.onLoad(function() {
+  $('*[data-behavior="preview-brief"]').previewBrief();
+});

--- a/app/assets/javascripts/preview-content.js
+++ b/app/assets/javascripts/preview-content.js
@@ -6,14 +6,14 @@
 var PreviewContent = (function() {
 
   var useCache = true;
-  window.previewCache = window.previewCache || {};
 
+  window.previewCache = window.previewCache || {};
 
   function append(url, target) {
     var content = window.previewCache[url];
 
     if (useCache && typeof content !== 'undefined') {
-      target.append(content);
+      plugContentAndPlugins(target, content);
     } else {
       fetchContentViaAjaxAndAppend(url, target);
     }
@@ -28,7 +28,7 @@ var PreviewContent = (function() {
     });
 
     request.done(function(data) {
-      target.append(data);
+      plugContentAndPlugins(target, data);
       if (useCache) window.previewCache[url] = data;
     });
 
@@ -37,6 +37,13 @@ var PreviewContent = (function() {
     });
   }
 
+
+  function plugContentAndPlugins(target, content) {
+    target
+      .append(content)
+      .plugGoogleBookContent()
+      .find('.image-filmstrip').renderFilmstrip();
+  }
 
   return {
     append: function(url, target) {

--- a/app/assets/stylesheets/modules/brief-view.css.scss
+++ b/app/assets/stylesheets/modules/brief-view.css.scss
@@ -1,0 +1,12 @@
+.brief-document {
+  border: 1px solid #ccc;
+  margin-bottom: 10px;
+  padding: 10px;
+
+  .preview {
+    border-radius: 0;
+    border-width: 0;
+    margin-top: 0;
+    padding: 0;
+  }
+}

--- a/app/assets/stylesheets/modules/view-type-group.css.scss
+++ b/app/assets/stylesheets/modules/view-type-group.css.scss
@@ -1,0 +1,8 @@
+#view-type-dropdown {
+
+  .dropdown-menu {
+    li span.view-type-label {
+      text-transform: lowercase;
+    }
+  }
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -2,15 +2,20 @@
 @import 'base';
 @import 'layout';
 
-@import 'modules/alert';
-@import 'modules/feedback-form';
-@import 'modules/access-panel-library-locations';
 @import 'modules/access-panel-course-reserve';
+@import 'modules/access-panel-library-locations';
 @import 'modules/access-panel-online';
 @import 'modules/additional-results';
 @import 'modules/availability-icons';
+@import 'modules/advanced-search';
+@import 'modules/alert';
 @import 'modules/breadcrumb';
 @import 'modules/browse-toolbar';
+@import 'modules/feedback-form';
+@import 'modules/file-collection-members';
+@import 'modules/file-list-table';
+@import 'modules/gallery-view';
+@import 'modules/brief-view';
 @import 'modules/image-collection-filmstrip';
 @import 'modules/item-preview';
 @import 'modules/open-seadragon';
@@ -19,9 +24,6 @@
 @import 'modules/results-documents';
 @import 'modules/search-bar';
 @import 'modules/selected-databases';
-@import 'modules/file-list-table';
-@import 'modules/file-collection-members';
-@import 'modules/zero-results';
-@import 'modules/gallery-view';
-@import 'modules/advanced-search';
 @import 'modules/sort-and-per-page-toolbar';
+@import 'modules/view-type-group';
+@import 'modules/zero-results';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,4 +1,4 @@
-# -*- encoding : utf-8 -*-
+ # -*- encoding : utf-8 -*-
 #
 class CatalogController < ApplicationController
 
@@ -277,6 +277,8 @@ class CatalogController < ApplicationController
     config.view.delete_field("slideshow")
 
     config.view.gallery.partials = [:index]
+    config.view.brief.partials = [:index]
+    config.view.brief.icon_class = "glyphicon-align-justify"
   end
 
   def backend_lookup

--- a/app/views/catalog/_document_brief.html.erb
+++ b/app/views/catalog/_document_brief.html.erb
@@ -1,0 +1,4 @@
+<% # container for all documents in index view -%>
+<div id="documents">
+  <%= render :collection => documents, :as => :document, :partial => 'index_brief' %>
+</div>

--- a/app/views/catalog/_index_brief.html.erb
+++ b/app/views/catalog/_index_brief.html.erb
@@ -1,0 +1,37 @@
+<%
+  preview_container = 'preview-container-' + document.id
+  preview_attrs = preview_data_attrs(true, "preview-brief", document[:id], '.' + preview_container)
+%>
+
+<div class=" brief-document" <%= preview_attrs %>>
+
+  <div class="row container-fluid brief-container">
+    <h5 class="index_title">
+      <% counter = document_counter_with_offset(document_counter) %>
+      <span class="glyphicon glyphicon-star-empty"></span>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+      </span>
+      <%= link_to_document document, :label => get_main_title(document), :counter => (counter + @response.params[:start].to_i) %>
+      <span class="main-title-date"><%= get_main_title_date(document) %></span>
+    </h5>
+  </div>
+
+  <div class="container-fluid <%= preview_container %>">
+  </div>
+
+  <div class="row container-fluid">
+    <div class="col-lg-8 col-md-6 col-sm-6">
+      <% # column for availability info %>
+    </div>
+    <div class="col-lg-2 col-md-3 col-sm-3">
+      <button class="btn btn-sm btn-primary preview-button docid-<%= document.id %>" data-behavior="preview-button-trigger">
+        <span class="glyphicon glyphicon-chevron-down"></span> Preview
+      </button>
+    </div>
+    <div class="col-lg-2 col-md-3 col-sm-3">
+      <%= render_index_doc_actions document, :wrapping_class => "index-document-functions" %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -1,0 +1,23 @@
+<% if has_alternative_views? %>
+<div class="view-type">
+  <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
+  <div id="view-type-dropdown" class="btn-group">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+      <%= link_to t('blacklight.search.view.label', :field =>current_sort_field.label).html_safe, '#' %>
+      <%= render_view_type_group_icon document_index_view_type %>
+      <span class="caret"></span>
+    </button>
+
+    <ul class="dropdown-menu" role="menu">
+      <%  document_index_views.each do |view, config| %>
+      <li>
+        <%= link_to url_for(params.merge(:view => view)), :title => t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), :class => "view-type-#{ view.to_s.parameterize }" do %>
+          <%= render_view_type_group_icon view %>
+          <span class="view-type-label"><%= t("blacklight.search.view.#{view}") %></span>
+        <% end %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+</div>
+<% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -10,6 +10,9 @@ en:
         submit: ''
       sort:
         label_small: 'Sort'
+      view:
+        label: 'View'
+        brief: 'Brief'
       per_page:
         button_label_small: '%{count}'
       pagination_info:

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -15,7 +15,7 @@ feature "Results Toolbar", js: true do
         expect(page).to have_css("span.page_entries.hidden-xs", text: /1 - 10 of \d+/, visible: true)
         expect(page).to have_css("a.btn.btn-default.btn-sm", text: "►", visible: true)
       end
-      expect(page).to have_css("div.view-type-group a")
+      expect(page).to have_css("div#view-type-dropdown a")
       expect(page).to have_css("div#sort-dropdown", text: "Sort by relevance", visible: true)
       within "#select_all-dropdown" do
         expect(page).to have_css("span.visible-md.visible-lg", text: "Select all")

--- a/spec/features/blacklight_customizations/view_options_spec.rb
+++ b/spec/features/blacklight_customizations/view_options_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+feature "View options" do
+  scenario "should include our custom options" do
+    visit root_path
+    fill_in 'q', with: ''
+    click_button 'search'
+
+    within('#view-type-dropdown') do
+      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'List')
+      expect(page).to have_css("li a.view-type-list span.glyphicon.glyphicon-list.view-icon-list")
+
+      expect(page).to have_css("li a.view-type-gallery span.view-type-label", text: 'Gallery')
+      expect(page).to have_css("li a.view-type-gallery span.glyphicon.glyphicon-gallery.view-icon-gallery")
+
+      expect(page).to have_css("li a.view-type-brief span.view-type-label", text: 'Brief')
+      expect(page).to have_css("li a.view-type-brief span.glyphicon.glyphicon-align-justify")
+    end
+  end
+end

--- a/spec/features/brief_view_spec.rb
+++ b/spec/features/brief_view_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+feature "Brief View" do
+  scenario "Search results", js: true do
+    visit catalog_index_path f: {format: ["Book"]}
+    page.find('#view-type-dropdown button.dropdown-toggle a').click
+    page.find('#view-type-dropdown .dropdown-menu li a.view-type-brief').click
+
+    expect(page).to have_css("span.glyphicon.glyphicon-align-justify")
+    expect(page).to have_css(".brief-document h5.index_title", text: "An object")
+    expect(page).to have_css(".brief-document button.btn-primary", text: "Preview")
+    expect(page).to have_css("form.bookmark_toggle label.toggle_bookmark", text: "Select")
+
+    page.find("button.btn.docid-1").click
+    expect(page).to have_css("dt", text: "Language:")
+    expect(page).to have_css("dd", text: "English.")
+  end
+end

--- a/spec/features/gallery_view_spec.rb
+++ b/spec/features/gallery_view_spec.rb
@@ -2,16 +2,18 @@ require "spec_helper"
 
 feature "Gallery View" do
   scenario "Search results", js: true do
-    visit catalog_index_path f: {format: ["Book"]}, view: "default"
-    click_link "Gallery"
+    visit catalog_index_path f: {format: ["Book"]}
+    page.find('#view-type-dropdown button.dropdown-toggle a').click
+    page.find('#view-type-dropdown .dropdown-menu li a.view-type-gallery').click
+
     expect(page).to have_css("span.glyphicon.glyphicon-gallery.view-icon-gallery")
-    expect(page).to have_css("span.caption", text: "Gallery")
     expect(page).to have_css(".gallery-document a span.fake-cover", text: "An object", visible: true)
     expect(page).to_not have_css(".gallery-document a div.fake-cover-text", text: "Car : a drama of the American workplace", visible: true)
     expect(page).to have_css(".gallery-document h5.index_title", text: "An object")
     expect(page).to have_css(".gallery-document button.btn-primary", text: "Preview")
     expect(page).to have_css("form.bookmark_toggle label.toggle_bookmark", text: "Select")
-    page.first(".docid-1").click
+
+    page.first("button.btn.docid-1").click
     expect(page).to have_css("dt", text: "Language:")
     expect(page).to have_css("dd", text: "English.")
   end


### PR DESCRIPTION
Closes #25, #40 
- Adds new `brief` search result view
- Adds preview to brief view
- Replaces button group view types with dropdown
## 
## ![image](https://cloud.githubusercontent.com/assets/302258/3330119/6148a90c-f7cd-11e3-8788-48db2a9d0bdc.png)
## ![searchworks-issue40-1](https://cloud.githubusercontent.com/assets/302258/3330184/09e6f730-f7ce-11e3-8410-7835816c29fc.png)

![image](https://cloud.githubusercontent.com/assets/302258/3330123/6cc95d26-f7cd-11e3-8436-3b18c9add8a2.png)
