### PR TITLE
Add partial to display location (holdings) information on search results.

### DIFF
--- a/app/assets/stylesheets/modules/availability-table.css.scss
+++ b/app/assets/stylesheets/modules/availability-table.css.scss
@@ -1,0 +1,5 @@
+table.availability {
+  td.indent-callnumber {
+    padding-left: 15px;
+  }
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -7,6 +7,7 @@
 @import 'modules/access-panel-online';
 @import 'modules/additional-results';
 @import 'modules/availability-icons';
+@import 'modules/availability-table';
 @import 'modules/advanced-search';
 @import 'modules/alert';
 @import 'modules/breadcrumb';

--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -1,0 +1,41 @@
+<% if document.holdings.present? %>
+  <span class="label label-default">At the library</span> <%= document.holdings.libraries.map(&:name).join(', ') %>
+    <% document.holdings.libraries.each do |library| %>
+      <table class="table table-condensed availability">
+        <thead>
+          <tr class='active'>
+            <th><%= library.name %></th>
+            <th class='col-xs-4'>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% library.locations.each do |location| %>
+            <% if location.more_than_one_item? %>
+              <tr>
+                <td><strong><%= location.name%></strong></td>
+                <td>&nbsp;</td>
+              </tr>
+            <% end %>
+            <% location.items.each do |item| %>
+              <tr>
+                <td class="<%= 'indent-callnumber' if location.more_than_one_item? %>">
+                  <% if location.one_item? %>
+                    <strong><%= location.name %></strong> : 
+                  <% end %>
+                  <%= item.callnumber %>
+                </td>
+                <td data-barcode="<%= item.barcode %>">
+                  <i class="availability-icon <%= item.status.availability_class %>"></i>
+                  <% if item.on_reserve? %>
+                    On Reserve <%= item.loan_period %>
+                  <% else %>
+                    <%= item.status.status_text%>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+<% end %>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -944,12 +944,12 @@ module Constants
    #"SUL" => "Ignore"
    }
    TRANSLATE_STATUS = {
-     "page" => "must be paged/requested",
+     "available" => "available",
+     "page" => "request",
      "unavailable" => "unavailable",
-     "noncirc" => "in-library use only",
+     "noncirc" => "in-library use",
      "unknown" => "status unknown",
-     "no_req unavailable" => "unavailable",
-     "noncirc_page" => "must be paged/requested for in-library use only"
+     "noncirc_page" => "request for in-library use"
    }
    HIDE_1ST_IND = %W(760 762 765 767 770 772 773 774 775 776 777 780 785 786 787)
    HIDE_1ST_IND0 = %W(541 542 561 583 590)

--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -11,5 +11,11 @@ class Holdings
     def location_level_request?
       Constants::LOCATION_LEVEL_REQUEST_LOCS.include?(@code)
     end
+    def one_item?
+      @has_one_item ||= items.one?(&:present?)
+    end
+    def more_than_one_item?
+      @more_than_one_item ||= items.present? && !one_item?
+    end
   end
 end

--- a/lib/holdings/status.rb
+++ b/lib/holdings/status.rb
@@ -30,6 +30,10 @@ class Holdings
       end
     end
 
+    def status_text
+      Constants::TRANSLATE_STATUS[availability_class]
+    end
+
     # we can probably do something clever w/ method missing here
     def available?
       Holdings::Status::Available.new(@callnumber).available?

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -7,4 +7,21 @@ describe Holdings::Location do
   it "should identify location level requests" do
     expect(Holdings::Location.new("SSRC-DATA")).to be_location_level_request
   end
+  describe "enumeration helpers" do
+    let(:none) { Holdings::Location.new("STACKS") }
+    let(:one) { Holdings::Location.new("STACKS", ["something"]) }
+    let(:multiple) { Holdings::Location.new("STACKS", ["something", "else"]) }
+    it "should not return true if there are no items" do
+      expect(none).to_not be_one_item
+      expect(none).to_not be_more_than_one_item
+    end
+    it "should return true for a single item" do
+      expect(one).to be_one_item
+      expect(one).to_not be_more_than_one_item
+    end
+    it "should return true for multiple items" do
+      expect(multiple).to_not be_one_item
+      expect(multiple).to be_more_than_one_item
+    end
+  end
 end

--- a/spec/lib/holdings/status_spec.rb
+++ b/spec/lib/holdings/status_spec.rb
@@ -9,6 +9,9 @@ describe Holdings::Status do
     it "should have the available class" do
       expect(status.availability_class).to eq 'available'
     end
+    it "should have the available status text" do
+      expect(status.status_text).to eq 'available'
+    end
     it "should be available" do
       expect(status).to be_available
     end
@@ -19,6 +22,9 @@ describe Holdings::Status do
     end
     it "should have the noncirc class" do
       expect(status.availability_class).to eq 'noncirc'
+    end
+    it "should have the noncirc status text" do
+      expect(status.status_text).to eq 'in-library use'
     end
     it "should be noncirc" do
       expect(status).to be_noncirc
@@ -31,6 +37,9 @@ describe Holdings::Status do
     it "should have the noncirc_page class" do
       expect(status.availability_class).to eq 'noncirc_page'
     end
+    it "should have the noncirc_page status text" do
+      expect(status.status_text).to eq 'request for in-library use'
+    end
     it "should be noncirc_page" do
       expect(status).to be_noncirc_page
     end
@@ -41,6 +50,9 @@ describe Holdings::Status do
     end
     it "should have the page class" do
       expect(status.availability_class).to eq 'page'
+    end
+    it "should have the page status text" do
+      expect(status.status_text).to eq 'request'
     end
     it "should be pageable" do
       expect(status).to be_pageable
@@ -53,6 +65,9 @@ describe Holdings::Status do
     it "should have the unavailable class" do
       expect(status.availability_class).to eq 'unavailable'
     end
+    it "should have the unavailable status text" do
+      expect(status.status_text).to eq 'unavailable'
+    end
     it "should be unavailable" do
       expect(status).to be_unavailable
     end
@@ -63,6 +78,9 @@ describe Holdings::Status do
     end
     it "should have the unavailable class" do
       expect(status.availability_class).to eq 'unknown'
+    end
+    it "should have the unknown status text" do
+      expect(status.status_text).to eq 'status unknown'
     end
     it "should be unavailable" do
       expect(status).to be_unknown

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe "catalog/_index_location.html.erb" do
+  describe "status icon" do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          item_display: [
+            '123 -|- SAL3 -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123'
+          ]
+        )
+      )
+      render
+    end
+    it "should include the status icon and text" do
+      expect(rendered).to have_css('tbody td i.page')
+      expect(rendered).to have_css('tbody td', text: "request")
+    end
+  end
+  describe "single item in a location" do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          item_display: [
+            '123 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123'
+          ]
+        )
+      )
+      render
+    end
+    it "should display the location and item in a single table row" do
+      expect(rendered).to have_css('tbody tr', count: 1)
+      expect(rendered).to have_css('tbody tr td', text: /Stacks\s*:\s*ABC 123/)
+    end
+    it "should not have the indentation class" do
+      expect(rendered).to_not have_css('.indent-callnumber')
+    end
+  end
+  describe "multiple items in a location" do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          item_display: [
+            '123 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123',
+            '456 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 456'
+          ]
+        )
+      )
+      render
+    end
+    it "should display the location and items in separate table rows" do
+      expect(rendered).to have_css('tbody tr', count: 3)
+      expect(rendered).to have_css('tbody tr td', text: "Stacks")
+      expect(rendered).to have_css('tbody tr td', text: "ABC 123")
+      expect(rendered).to have_css('tbody tr td', text: "ABC 456")
+    end
+    it "should add an class for indentation" do
+      expect(rendered).to have_css('tbody tr td.indent-callnumber', count: 2)
+    end
+  end
+end


### PR DESCRIPTION
#### Note: This PR does not actually implement anything in the UI.  #291 will pull this (or part of this) partial into the results display in the accordion.

Partial can be rendered in a result by:

```
<%= render partial: 'catalog/index_location', locals: { document: document } %>
```

Keeping #292 open until something is implemented in the UI.
### Single Item

---

![single-item](https://cloud.githubusercontent.com/assets/96776/3336562/fd23b1f8-f833-11e3-8508-df53c3849309.png)
### Multiple libraries

---

![multi-library](https://cloud.githubusercontent.com/assets/96776/3336563/fd256868-f833-11e3-94ae-2b6b4eda9b12.png)
### Multiple locations (and reserve)

---

![multi-location-and-reserve](https://cloud.githubusercontent.com/assets/96776/3336564/fd25ea18-f833-11e3-9a6b-5fd2708525f9.png)
