### PR TITLE
Add summary and topics for databases.

### DIFF
--- a/app/views/catalog/_index_marc.html.erb
+++ b/app/views/catalog/_index_marc.html.erb
@@ -1,6 +1,24 @@
 <%= render :partial => "search_results_document_fields", :locals => { :document => document } %>
 
 <dl class="dl-horizontal dl-invert">
+  <% if document.is_a_database? %>
+    <% if document[:summary_display].present? %>
+      <dt>DATABASE SUMMARY:</dt>
+      <dd>
+        <div data-behavior='truncate'>
+          <%= document[:summary_display].join(' ') %>
+        </div>
+      </dd>
+    <% end %>
+    <% if document[:db_az_subject].present? %>
+      <dt>DATABASE TOPICS:</dt>
+      <dd>
+        <%= document[:db_az_subject].map do |subject| %>
+          <% link_to(subject, catalog_index_path(f: {db_az_subject: [subject], document.format_key => ['Database']})) %>
+        <% end.join('; ').html_safe %>
+      </dd>
+    <% end %>
+  <% end %>
   <% if document.extent.present? %>
     <dt><%= document.extent_label %>:</dt>
     <dd><%= document.extent %></dd>

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -12,4 +12,12 @@ feature "Databases Access Point" do
       end
     end
   end
+  scenario "database topics should be present" do
+    expect(page).to have_css('dt', text: "DATABASE TOPICS:")
+    expect(page).to have_css('dd a', text: "Biology")
+  end
+  scenario "database summaries should be present" do
+    expect(page).to have_css('dt', text: "DATABASE SUMMARY:")
+    expect(page).to have_css('dd', text: "A summary of the database")
+  end
 end

--- a/spec/fixtures/solr_documents/20.yml
+++ b/spec/fixtures/solr_documents/20.yml
@@ -7,5 +7,9 @@
 :format: Database
 :format_main_ssim: Database
 :db_az_subject: Biology
+:summary_display:
+  - A summary of the database
+:display_type:
+  - sirsi
 :access_facet: Online
 :building_facet: Law (Crown)

--- a/spec/views/catalog/_index_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_index_marc.html.erb_spec.rb
@@ -2,12 +2,37 @@ require "spec_helper"
 
 describe "catalog/_index_marc.html.erb" do
   before do
-    view.stub(:document).and_return(SolrDocument.new(physical: ["The Physical Extent"], format_main_ssim: ['Book']))
     view.stub(:blacklight_config).and_return( Blacklight::Configuration.new )
-    render
   end
-  it "should include the physical extent" do
-    expect(rendered).to have_css("dt", text: "BOOK:")
-    expect(rendered).to have_css("dd", text: "The Physical Extent")
+  describe "physical extent" do
+    before do
+      view.stub(:document).and_return(SolrDocument.new(physical: ["The Physical Extent"], format_main_ssim: ['Book']))
+      render
+    end
+    it "should include the physical extent" do
+      expect(rendered).to have_css("dt", text: "BOOK:")
+      expect(rendered).to have_css("dd", text: "The Physical Extent")
+    end
+  end
+  describe "databases" do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          format_main_ssim: ["Database"],
+          summary_display: ["The summary of the object"],
+          db_az_subject: ["Subject1", "Subject2"]
+        )
+      )
+      render
+    end
+    it "should display their summary" do
+      expect(rendered).to have_css('dt', text: "DATABASE SUMMARY:")
+      expect(rendered).to have_css('dd', text: "The summary of the object")
+    end
+    it "should display the database topics" do
+      expect(rendered).to have_css('dt', text: "DATABASE TOPICS:")
+      expect(rendered).to have_css('dd a', text: "Subject1")
+      expect(rendered).to have_css('dd a', text: "Subject2")
+    end
   end
 end


### PR DESCRIPTION
Closes #264 

Haven't taken out the date that would make ERIC match the mockup but I think that'll settle down after we close out the other search results related tickets in the sprint.
### Examples

---

![eric](https://cloud.githubusercontent.com/assets/96776/3407450/ac29e664-fdab-11e3-9844-bf4bb9d089e3.png)

![topics](https://cloud.githubusercontent.com/assets/96776/3407449/abe445dc-fdab-11e3-80c7-70654f41ba10.png)
