### PR TITLE
Add uniform title MARC parsing logic into the search results partial.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -114,8 +114,6 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field "title_uniform_display", :label => "Title"
-    config.add_index_field "vern_title_uniform_display", :label => "Title"
     config.add_index_field "author_person_display", :label => "Author/Creator"
     config.add_index_field "vern_author_person_display", :label => "Author/Creator"
     config.add_index_field "author_corp_display", :label => "Corporate Author"

--- a/app/views/catalog/_search_results_document_fields.html.erb
+++ b/app/views/catalog/_search_results_document_fields.html.erb
@@ -1,4 +1,19 @@
 <ul class="document-metadata dl-horizontal dl-invert">
+  <% if document.respond_to?(:to_marc) %>
+    <% uniform_title = get_uniform_title(document.to_marc, ["240","130"]) %>
+    <% unless uniform_title.nil? %>
+      <% uniform_title[:fields].each do |field| %>
+        <li><%= field[:field] %></li>
+        <% if field[:vernacular] %>
+          <li><%= field[:vernacular] %></li>
+        <% end %>
+      <% end if uniform_title[:fields].present? %>
+      <% uniform_title[:unmatched_vernacular].each do |field| %>
+        <li><%= field %></li>
+      <% end if uniform_title[:unmatched_vernacular].present? %>
+    <% end %>
+  <% end %>
+
   <% index_fields(document).each do |solr_fname, field| -%>
     <% if should_render_index_field? document, field %>
       <li><%= render_index_field_value document, :field => solr_fname %></li>

--- a/spec/features/blacklight_customizations/results_document_spec.rb
+++ b/spec/features/blacklight_customizations/results_document_spec.rb
@@ -12,7 +12,6 @@ feature "Results Document Metadata" do
       expect(page).to have_css("span.main-title-date", text: "[2000 - ]", visible: false)
 
       within "ul.document-metadata" do
-        expect(page).to have_css("li", text: "An object, aliquet sed mauris molestie, suscipit tempus", visible: true)
         expect(page).to have_css("li", text: "Doe, Jane", visible: true)
         expect(page).to have_css("li", text: "1990", visible: true)
       end

--- a/spec/features/marc_results_metadata_spec.rb
+++ b/spec/features/marc_results_metadata_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "MARC Metadata in search results" do
+  describe "uniform title" do
+    before do
+      visit root_path
+      fill_in 'q', with: '18'
+      click_button 'search'
+    end
+    it "should link the uniform title" do
+      within(first('.document')) do
+        within('ul.document-metadata') do
+          expect(page).to have_css('li', text: 'Instrumental music. Selections')
+          expect(page).to have_css('li a', text: 'Instrumental music.')
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -700,6 +700,16 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+  def uniform_title_fixture
+    <<-xml
+      <record>
+        <datafield tag="240" ind1=" " ind2=" ">
+          <subfield code="a">Instrumental music.</subfield>
+          <subfield code="k">Selections</subfield>
+        </datafield>
+      </record>
+    xml
+  end
   def no_fields_fixture
     "<record></record>"
   end

--- a/spec/fixtures/solr_documents/18.yml
+++ b/spec/fixtures/solr_documents/18.yml
@@ -6,6 +6,9 @@
 :language: German
 :format: Image
 :format_main_ssim: Image
+:display_type:
+  - sirsi
+:marcbib_xml: <%= uniform_title_fixture %>
 :imprint_display: 1933
 :access_facet: Online
 :building_facet: "Math & Statistics"


### PR DESCRIPTION
Closes #262 

![uniform-titles](https://cloud.githubusercontent.com/assets/96776/3407605/a5889058-fdb0-11e3-9b0c-8be8529ec05e.png)
