### PR TITLE
fixes issue where preview is not showing on embed browse

### DIFF
--- a/app/assets/stylesheets/modules/browse-embed.css.scss
+++ b/app/assets/stylesheets/modules/browse-embed.css.scss
@@ -17,7 +17,7 @@
 
 .embed-callnumber-browse-container{
   position: relative;
-  height: 430px;
+  height: auto;
   overflow: hidden;
   margin-top:15px;
   padding-top: 17px;


### PR DESCRIPTION
Setting the height to auto resolves this. Though some work may need to be done when we do vis/design on the side arrows.

![screen shot 2014-06-26 at 11 39 05 pm](https://cloud.githubusercontent.com/assets/1656824/3408312/c9c4a6f4-fdc5-11e3-84bb-81dea54c391b.png)
