### PR TITLE
Removes a element from constraints element

### DIFF
--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -1,0 +1,34 @@
+<%  # Modified from Blacklight https://github.com/projectblacklight/blacklight/blob/7ee2f79630cfafa086e1a42cddff28b42f02d957/app/views/catalog/_constraints_element.html.erb
+    # local params:
+    # label
+    # value
+    # options =>
+    #   :remove => url for a remove constraint link
+    #   :classes => array of classes to add to container span
+    options ||= {}
+%>
+
+<span class="btn-group appliedFilter constraint <%= options[:classes].join(" ") if options[:classes] %>">
+  <span class="constraint-value btn btn-sm btn-default btn-disabled">
+    <% unless label.blank? %>
+      <span class="filterName"><%= label %></span>
+    <% end %>
+    <% unless value.blank? %>
+      <span class="filterValue"><%= value %></span>
+    <% end %>
+  </span>
+  <% unless options[:remove].blank? %>
+    <% accessible_remove_label = content_tag :span, class: 'sr-only' do
+        if label.blank?
+          t('blacklight.search.filters.remove.value', value: value)
+        else
+          t('blacklight.search.filters.remove.label_value', label: label, value: value)
+        end
+      end
+    %>
+
+    <%= link_to(content_tag(:span, '', class: 'glyphicon glyphicon-remove') + accessible_remove_label,
+			options[:remove], class: 'btn btn-default btn-sm remove dropdown-toggle'
+		) %>
+  <%- end -%>
+</span>

--- a/spec/views/catalog/_contraints_element.html.erb_spec.rb
+++ b/spec/views/catalog/_contraints_element.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe "catalog/_constraints_element_block.html.erb" do
+  describe "breadcrumb term should not be a link" do
+    before do
+      render :partial => "catalog/constraints_element", locals: {label: "my label", value: "my value"}
+    end
+    it "should render label and value in a span" do
+      expect(rendered).to have_css("span.constraint-value", text: /my label/)
+      expect(rendered).to_not have_css("a.constraint-value")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #272 

Overrides Blacklight `_constraints_element.html.erb` template

![screen shot 2014-06-30 at 11 32 56 am](https://cloud.githubusercontent.com/assets/1656824/3433974/fc3ecc42-0084-11e4-8f7f-7e786b4bd784.png)
