### PR TITLE
Adds appropriate access panel headings

### DIFF
--- a/app/helpers/access_panel_helper.rb
+++ b/app/helpers/access_panel_helper.rb
@@ -9,7 +9,7 @@ module AccessPanelHelper
   end
 
   def thumb_for_library(library)
-    image_tag("#{library.code}.jpg", class: "pull-left", alt: library.name)
+    image_tag("#{library.code}.jpg", class: "pull-left", alt: "")
   end
 
 end

--- a/app/views/catalog/access_panels/_collection_details.html.erb
+++ b/app/views/catalog/access_panels/_collection_details.html.erb
@@ -1,7 +1,7 @@
 <% if @document.is_a_collection? %>
   <div class="panel panel-default panel-collection-details">
     <div class="panel-heading">
-      Collection details
+      <h3>Collection details</h3>
     </div>
     <div class="panel-body">
         <dl class="dl-invert">

--- a/app/views/catalog/access_panels/_course_reserve.html.erb
+++ b/app/views/catalog/access_panels/_course_reserve.html.erb
@@ -2,7 +2,9 @@
 
 <% if document.access_panels.course_reserve.present? %>
   <div class="panel panel-default panel-course-reserve">
-    <div class="panel-heading">Course reserve</div>
+    <div class="panel-heading">
+      <h3>Course reserve</h3>
+    </div>
     <div class="panel-body">
       <ul class="links">
         <% document.access_panels.course_reserve.courses.each do |course| %>

--- a/app/views/catalog/access_panels/_in_collection.html.erb
+++ b/app/views/catalog/access_panels/_in_collection.html.erb
@@ -2,7 +2,7 @@
   <% @document.parent_collections.each do |parent_collection| %>
     <div class="panel panel-default panel-in-collection">
       <div class="panel-heading">
-        In collection
+        <h3>In collection</h3>
       </div>
       <div class="panel-body">
         <%= link_to(presenter(parent_collection).document_heading, catalog_path(parent_collection[:id])) %>

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -6,7 +6,7 @@
         <div class="library-location-heading">
           <%= thumb_for_library(library) %>
           <div class="library-location-heading-text">
-            <%= link_to_library(library) %>
+            <h3><%= link_to_library(library) %></h3>
             <div class="small location-hours-today">
             </div>
           </div>

--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -7,11 +7,12 @@
 
 <div class="panel panel-default panel-online <%= visible %>">
   <div class="panel-heading">
+    <h3>
     <% if document.is_a_database? %>
       Search this database
     <% else %>
       Available online
-    <% end %>
+    <% end %></h3>
   </div>
   <div class="panel-body">
     <ul class="links">

--- a/app/views/catalog/record/_metadata_panels.html.erb
+++ b/app/views/catalog/record/_metadata_panels.html.erb
@@ -1,3 +1,4 @@
+<h2 class="sr-only">Access</h2>
 <div class="col-xs-12 row">
   <%= render "catalog/access_panels/online" %>
   <%= render "catalog/access_panels/course_reserve" %>

--- a/spec/helpers/access_panel_helper_spec.rb
+++ b/spec/helpers/access_panel_helper_spec.rb
@@ -10,7 +10,7 @@ describe AccessPanelHelper do
 
   describe "thumb_for_library" do
     it "should return the image tag for the thumbnail for the specified library" do
-      expect(helper.thumb_for_library(library)).to eq "<img alt=\"Green Library\" class=\"pull-left\" src=\"/assets/GREEN.jpg\" />"
+      expect(helper.thumb_for_library(library)).to eq "<img alt=\"\" class=\"pull-left\" src=\"/assets/GREEN.jpg\" />"
     end
   end
 end


### PR DESCRIPTION
Fixes #342 

Also removes apanel library alt tags

![screen shot 2014-06-30 at 11 50 44 am](https://cloud.githubusercontent.com/assets/1656824/3434224/c52873ae-0087-11e4-8c07-76432cb98ca7.png)
