### PR TITLE
Move  into link text for MARC 856 links.

### DIFF
--- a/app/models/concerns/marc_links.rb
+++ b/app/models/concerns/marc_links.rb
@@ -13,7 +13,7 @@ module MarcLinks
       link_fields.map do |link_field|
         link = process_link(link_field)
         SearchWorks::Links::Link.new(
-          text: [link[:before], "<a title='#{link[:title]}' href='#{link[:href]}'>#{link[:text]}</a>", "#{'(source: Casalini)' if link[:casalini_toc]}"].compact.join(' '),
+          text: ["<a title='#{link[:title]}' href='#{link[:href]}'>#{link[:text]}</a>", "#{'(source: Casalini)' if link[:casalini_toc]}"].compact.join(' '),
           fulltext: link_is_fulltext?(link_field),
           stanford_only: stanford_only?(link),
           finding_aid: link_is_finding_aid?(link_field)
@@ -54,15 +54,14 @@ module MarcLinks
           url_host = url.host
         end
         if field["x"] and field["x"] == "CasaliniTOC"
-          {:before=>nil,
-           :text=>field["3"],
+          {:text=>field["3"],
            :title=>"",
            :href=>field["u"],
            :casalini_toc => true
           }
         else
-          {:before=>sub3,
-           :text=>(suby.blank? ? url_host : suby),
+          link_text = (!suby.present? && !sub3.present?) ? url_host : [sub3, suby].compact.join(' ')
+          {:text=>link_text,
            :title=>subz.join(" "),
            :href=>field["u"],
            :casalini_toc => false
@@ -92,7 +91,7 @@ module MarcLinks
     end
 
     def stanford_only?(link)
-      [link[:before], link[:title]].join.downcase =~ stanford_affiliated_regex
+      [link[:text], link[:title]].join.downcase =~ stanford_affiliated_regex
     end
 
     def stanford_affiliated_regex

--- a/spec/fixtures/marc_records/marc_856_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_856_fixtures.rb
@@ -3,9 +3,9 @@ module Marc856Fixtures
     <<-xml
       <record>
         <datafield tag='856' ind1='0' ind2='0'>
-          <subfield code='3'>Before text</subfield>
+          <subfield code='3'>Link text 1</subfield>
           <subfield code='u'>http://library.stanford.edu</subfield>
-          <subfield code='y'>Link text</subfield>
+          <subfield code='y'>Link text 2</subfield>
           <subfield code='z'>Title text1</subfield>
           <subfield code='z'>Title text2</subfield>
         </datafield>

--- a/spec/models/concerns/marc_links_spec.rb
+++ b/spec/models/concerns/marc_links_spec.rb
@@ -13,11 +13,8 @@ describe MarcLinks do
     let(:document) { SolrDocument.new(marcxml: simple_856) }
     let(:no_label_document) { SolrDocument.new(marcxml: labelless_856) }
     let(:link_text) { document.marc_links.all.first.text }
-    it "should place the $3 before the link" do
-      expect(link_text).to match /^Before text/
-    end
-    it "should place the $y as the link text" do
-      expect(link_text).to match /<a.*>Link text<\/a>/
+    it "should place the $3 and $y as the link text" do
+      expect(link_text).to match /<a.*>Link text 1 Link text 2<\/a>/
     end
     it "should place the $z as the link title attribute" do
       expect(link_text).to match /<a.*title='Title text1 Title text2'.*>/


### PR DESCRIPTION
Closes #74 
### Before

---

![before](https://cloud.githubusercontent.com/assets/96776/3461541/1150dabc-0224-11e4-996b-91e30eda7125.png)
### After

---

![after](https://cloud.githubusercontent.com/assets/96776/3461543/18510ce2-0224-11e4-8e6f-d00349d14a2f.png)
