### PR TITLE
updates feedback form cancel button

### DIFF
--- a/app/assets/javascripts/feedback_form.js
+++ b/app/assets/javascripts/feedback_form.js
@@ -15,6 +15,7 @@ Blacklight.onLoad(function(){
     No available options
 
     This plugin :
+      - changes feedback form link to button
       - submits an ajax request for the feedback form
       - displays alert on response from feedback form
   */
@@ -74,12 +75,34 @@ Blacklight.onLoad(function(){
       });
     }
 
+    function replaceLink(form, link) {
+      var attrs = {};
+      $.each(link[0].attributes, function(idx, attr) {
+          attrs[attr.nodeName] = attr.nodeValue;
+      });
+      attrs.class = 'cancel-link btn btn-link';
+
+      // Replace the cancel link with a button
+      link.replaceWith(function() {
+        return $('<button />', attrs).append($(this).contents());
+      });
+
+      // Cancel link should not submit form
+      form.find('button.cancel-link').on('click', function(e){
+        e.preventDefault();
+      });
+    }
+
     Plugin.prototype = {
 
         init: function() {
           $el = $(this.element);
           $form = $($el).find('form');
           $action = $($form).attr('action');
+          $cancelLink = $($el).find(".cancel-link");
+
+          // Replace "Cancel" link with link styled button
+          replaceLink($el, $cancelLink);
 
           //Add listener for form submit
           submitListener($el,$form);

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -10,7 +10,7 @@ body {
   font-family: 'Source Sans Pro', sans-serif;
 }
 
-a, a:hover, a:focus, .btn-link, .btn-link:hover, .btn-link:focus {
+a, a:hover, a:focus {
 	text-decoration: none;
   border-bottom: 1px dotted $sul-link-color-border;
 }

--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -12,3 +12,8 @@
     border-color: darken($sul-btn-primary-border, 10%);
   }
 }
+
+.btn-link, .btn-link:hover, .btn-link:focus {
+  color: $sul-link-color;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/modules/feedback-form.css.scss
+++ b/app/assets/stylesheets/modules/feedback-form.css.scss
@@ -12,8 +12,9 @@
   font-size: $font-size-small;
 }
 
-.cancel-link{
+.cancel-link .btn .btn-link {
   margin-left:12px;
+  border-bottom: none;
 }
 
 #feedback-form{

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -11,6 +11,7 @@ feature "Feedback form (js)", js: true do
     pending("Passes locally, not on Travis.") if ENV['CI']
     click_link "Feedback"
     expect(page).to have_css("#feedback-form", visible: true)
+    expect(page).to have_css("button", text: "Cancel")
     within "form.feedback-form" do
       fill_in("message", with: "This is only a test")
       fill_in("name", with: "Ronald McDonald")
@@ -28,6 +29,7 @@ feature "Feedback form (no js)" do
   scenario "feedback form should be shown filled out and submitted" do
     click_link "Feedback"
     expect(page).to have_css("#feedback-form", visible: true)
+    expect(page).to have_css("a", text: "Cancel")
     within "form.feedback-form" do
       fill_in("message", with: "This is only a test")
       fill_in("name", with: "Ronald McDonald")


### PR DESCRIPTION
Fixes #232 

Changes feedback form cancel button from link to button when javascript is enabled. Styles button to look like a link.

Note: @jvine styled button link does not have `border-bottom` because it looked too funky 

![screen shot 2014-07-02 at 3 40 42 pm](https://cloud.githubusercontent.com/assets/1656824/3463456/ee31459c-0239-11e4-8634-e3f5e42e898b.png)

![screen shot 2014-07-02 at 3 41 13 pm](https://cloud.githubusercontent.com/assets/1656824/3463467/fe125550-0239-11e4-80c1-b62602ec0d0f.png)
