### PR TITLE
Rename google preview div from btn-preview to google-preview

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -94,7 +94,7 @@
           $about            = $googleBooks.find('.about'),
           $fullView         = $googleBooks.find('.full-view'),
           $limitedView      = $googleBooks.find('.limited-preview'),
-          $previewLink      = $googleBooks.find('.btn-preview .preview-link');
+          $previewLink      = $googleBooks.find('.google-preview .preview-link');
 
       $panelOnlineBooks.removeClass('hide').addClass('show');
       $googleBooks.show();

--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -35,7 +35,7 @@
               <li><a href="" class="limited-preview">Limited preview</a></li>
             </ul>
           </div>
-          <div class="col-lg-5 col-md-12 btn-preview">
+          <div class="col-lg-5 col-md-12 google-preview">
           <%= image_tag "gbs_preview_button.gif", alt:"" %>
           </div>
         </div>


### PR DESCRIPTION
This removes `.btn-preview` class from the Google Books div (was causing a background coloring issue) and renames the dive to `google-preview` which IMO is more semantically meaningful.
