### PR TITLE
Proposed gallery truncate

### DIFF
--- a/app/assets/javascripts/truncate.js
+++ b/app/assets/javascripts/truncate.js
@@ -1,7 +1,7 @@
 Blacklight.onLoad(function(){
   $("[data-behavior='truncate']").responsiveTruncate({height: 60});
   $("[data-behavior='trunk8']").trunk8();
-  $(".gallery-document h3.index_title a").trunk8({ lines: 4 });
+  $(".gallery-document .caption h3").trunk8({ lines: 4 });
 });
 
 $(window).resize(function() {

--- a/app/assets/stylesheets/modules/gallery-view.css.scss
+++ b/app/assets/stylesheets/modules/gallery-view.css.scss
@@ -25,11 +25,6 @@ $gallery-document-width: 184px;
     padding-right: 4px;
   }
 
-  .caption h5 {
-    overflow:hidden;
-    max-height: 4.4em;
-  }
-
   .gallery-document {
     position: relative;
     margin: 0px 5px 15px 5px;


### PR DESCRIPTION
@jchristo4 This is my proposal for the gallery view heading issue. By changing the selector to `h3` it will include the years which sometimes overlap the preview button.

![screen shot 2014-07-07 at 1 58 35 pm](https://cloud.githubusercontent.com/assets/1656824/3501715/818b0df4-0619-11e4-808a-cc9c6b7cdbba.png)

Also removing vestigial css that is no longer relevant.
