### PR TITLE
Fix for gallery title overflow

### DIFF
--- a/app/assets/javascripts/truncate.js
+++ b/app/assets/javascripts/truncate.js
@@ -1,6 +1,7 @@
 Blacklight.onLoad(function(){
   $("[data-behavior='truncate']").responsiveTruncate({height: 60});
   $("[data-behavior='trunk8']").trunk8();
+  $(".gallery-document h3.index_title").trunk8({ lines: 4 });
 });
 
 $(window).resize(function() {

--- a/app/assets/stylesheets/modules/gallery-view.css.scss
+++ b/app/assets/stylesheets/modules/gallery-view.css.scss
@@ -25,11 +25,6 @@ $gallery-document-width: 184px;
     padding-right: 4px;
   }
 
-  .caption h5 {
-    overflow:hidden;
-    max-height: 4.4em;
-  }
-
   .gallery-document {
     position: relative;
     margin: 0px 5px 15px 5px;
@@ -38,6 +33,12 @@ $gallery-document-width: 184px;
     width: $gallery-document-width;
     height: 400px;
     border: 1px solid $panel-inner-border;
+
+    .index_title {
+      a {
+        word-break: break-all;
+      }
+    }
   }
 
   .document-counter {


### PR DESCRIPTION
Proposal for gallery view heading overflow. Changes selector to h3 rather than a so that date is also included in truncation which sometimes conflicted with preview button. Also removes vestigial css.

![screen shot 2014-07-07 at 1 58 35 pm](https://cloud.githubusercontent.com/assets/1656824/3501819/8cbdfaaa-061a-11e4-9c42-ea7f0a3d788a.png)
