### PR TITLE
Add 'skip nav' links to pages

### DIFF
--- a/app/assets/stylesheets/modules/skip-to-nav.css.scss
+++ b/app/assets/stylesheets/modules/skip-to-nav.css.scss
@@ -1,0 +1,33 @@
+#skip-link {
+    margin-left: -15px;
+    padding-top: 4px;
+    position: absolute;
+    top: 0;
+    z-index: 1;
+
+    .element-invisible {
+      position: absolute !important;
+      clip: rect(1px,1px,1px,1px);
+      overflow: hidden;
+      height: 1px;
+    }
+
+    .element-invisible.element-focusable:active, .element-invisible.element-focusable:focus {
+      position: static !important;
+      clip: auto;
+      overflow: visible;
+      height: auto;
+    }
+
+    a:focus {
+      background-color: $sul-skip-to-nav-bg;
+      border-radius: 0 0 6px 6px;
+      box-shadow: 0 0 6px #000000;
+      padding: 6px 15px;
+      margin: 0;
+      -moz-border-radius: 0 0 6px 6px;
+      -moz-box-shadow: 0 0 6px #000000;
+      -webkit-border-radius: 0 0 6px 6px;
+      -webkit-box-shadow: 0 0 6px #000000;
+    }
+  }

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -32,6 +32,7 @@
 @import 'modules/results-documents';
 @import 'modules/search-bar';
 @import 'modules/selected-databases';
+@import 'modules/skip-to-nav';
 @import 'modules/sort-and-per-page-toolbar';
 @import 'modules/sul-footer';
 @import 'modules/sul-icons';

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -44,3 +44,4 @@ $sul-btn-preview-bg: $cadet-blue;
 $sul-h1-font-color: $cool-gray;
 $sul-h2-font-color: $cardinal-red;
 $sul-h2-border-color: $beige-30-percent;
+$sul-skip-to-nav-bg: $beige-10-percent;

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -6,7 +6,7 @@
   </div>
 <% end %>
 
-<%= form_tag catalog_index_path, :class => 'advanced form-horizontal', :method => :get do  %>
+<%= form_tag catalog_index_path, :id => 'advanced-search-form', :class => 'advanced form-horizontal', :method => :get do  %>
 
   <%= render_hash_as_hidden_fields(params_for_search(advanced_search_context, {})) %>
 

--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -1,4 +1,5 @@
 <% @page_title= t 'blacklight.home.title' %>
+
 <h1 class="sr-only">SearchWorks</h1>
 <div class="col-md-8 col-sm-6 home-page-facets" data-home-page-facet-collapse='true'>
   <h2>Limit your search</h2>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -6,11 +6,11 @@
 
     <span class="input-group-addon">
       <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
-      <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field") %>
+      <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :id=>"search_field", :class=>"search_field") %>
       </span>
     <% end %>
       <label for="q" class="sr-only"><%= t('blacklight.search.form_label') %></label>
-       <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box? %>
+       <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q form-control", :id => "q" %>
 
     <span class="input-group-btn">
       <button type="submit" class="btn btn-primary search-btn" id="search">

--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -37,6 +37,7 @@
 
   </head>
   <body class="<%= render_body_class %>">
+
     <div id="su-wrap"> <!-- #su-wrap start -->
       <div id="su-content"> <!-- #su-content start -->
         <div id="outer-container" class="container">
@@ -47,6 +48,7 @@
           <%= render partial: 'shared/ajax_modal' %>
 
           <section id="main-container" role="main">
+            <%= render 'shared/skip_to_nav' %>
             <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
             <div class="row">

--- a/app/views/shared/_skip_to_nav.html.erb
+++ b/app/views/shared/_skip_to_nav.html.erb
@@ -1,0 +1,35 @@
+<%# For home & search results page %>
+<% if params['controller'] == 'catalog' and params['action'] == 'index' %>
+  <div id="skip-link">
+    <a href="#search_field" class="element-invisible element-focusable" tabindex="1">Skip to search</a>
+    <a href="#main-container" class="element-invisible element-focusable" tabindex="2">Skip to main content</a>
+
+    <% if !params['f'].blank? or !params['q'].blank? %>
+      <a href="#documents" class="element-invisible element-focusable" tabindex="3">Skip to first result</a>
+    <% end %>
+  </div>
+<% end %>
+
+<%# For selections page %>
+<% if params['controller'] == 'bookmarks' and params['action'] == 'index' %>
+  <div id="skip-link">
+    <a href="#search_field" class="element-invisible element-focusable" tabindex="1">Skip to search</a>
+    <a href="#main-container" class="element-invisible element-focusable" tabindex="2">Skip to main content</a>
+    <a href="#documents" class="element-invisible element-focusable" tabindex="3">Skip to first result</a>
+  </div>
+<% end %>
+
+<%# For record view page %>
+<% if params['controller'] == 'catalog' and params['action'] == 'show' %>
+  <div id="skip-link">
+    <a href="#search_field" class="element-invisible element-focusable" tabindex="1">Skip to search</a>
+    <a href="#document" class="element-invisible element-focusable" tabindex="2">Skip to main content</a>
+  </div>
+<% end %>
+
+<%# For advanced search page %>
+<% if params['controller'] == 'advanced' and params['action'] == 'index' %>
+  <div id="skip-link">
+    <a href="#advanced-search-form" class="element-invisible element-focusable" tabindex="1">Skip to advanced search form</a>
+  </div>
+<% end %>

--- a/spec/features/skip_to_nav_spec.rb
+++ b/spec/features/skip_to_nav_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+feature "Skip-to Navigation" do
+
+  scenario "should have skip-to navigation links to search field and main container in home page" do
+    visit root_url
+    within "#skip-link" do
+      expect(page).to have_css("a[href='#search_field']", text: "Skip to search")
+      expect(page).to have_css("a[href='#main-container']", text: "Skip to main content")
+    end
+  end
+
+  scenario "should have skip-to navigation links to search field, main container and records in results page" do
+    visit root_url
+    fill_in "q", with: "20"
+    click_button 'search'
+
+    within "#skip-link" do
+      expect(page).to have_css("a[href='#search_field']", text: "Skip to search")
+      expect(page).to have_css("a[href='#main-container']", text: "Skip to main content")
+      expect(page).to have_css("a[href='#documents']", text: "Skip to first result")
+    end
+  end
+
+  scenario "should have skip-to navigation links to search field, main container and records in selections page", js: true do
+    visit root_path
+    fill_in 'q', with: '20'
+    click_button 'search'
+    find(:css, '#toggle_bookmark_20').set(true)
+    visit selections_path
+
+    within "#skip-link" do
+      expect(page).to have_css("a[href='#search_field']", text: "Skip to search")
+      expect(page).to have_css("a[href='#main-container']", text: "Skip to main content")
+      expect(page).to have_css("a[href='#documents']", text: "Skip to first result")
+    end
+  end
+
+  scenario "should have skip-to navigation links to search field, main container and records in record view page" do
+    visit catalog_path 20
+
+    within "#skip-link" do
+      expect(page).to have_css("a[href='#search_field']", text: "Skip to search")
+      expect(page).to have_css("a[href='#document']", text: "Skip to main content")
+    end
+  end
+
+  scenario "should have skip-to navigation links to form in advanced search page" do
+    visit advanced_search_path
+
+    within "#skip-link" do
+      expect(page).to have_css("a[href='#advanced-search-form']", text: "Skip to advanced search form")
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #337 

Had to disable search box `autofocus` to make 'skip nav' links to work. Investigating on how to enable search box `autofocus` back, 

---
## ![image](https://cloud.githubusercontent.com/assets/302258/3505693/592294a4-0664-11e4-9133-fb7be4fdd5f3.png)
## ![image](https://cloud.githubusercontent.com/assets/302258/3505698/7290e486-0664-11e4-8e23-d91e0895c208.png)

![image](https://cloud.githubusercontent.com/assets/302258/3505703/85a6200e-0664-11e4-919d-4fb3d9a52f98.png)
