### PR TITLE
Remove skip-to nav tab-indexes, update position and styles

### DIFF
--- a/app/assets/stylesheets/modules/skip-to-nav.css.scss
+++ b/app/assets/stylesheets/modules/skip-to-nav.css.scss
@@ -1,5 +1,5 @@
 #skip-link {
-    margin-left: -15px;
+    margin-left: 10px;
     padding-top: 4px;
     position: absolute;
     top: 0;

--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -37,6 +37,7 @@
 
   </head>
   <body class="<%= render_body_class %>">
+    <%= render 'shared/skip_to_nav' %>
 
     <div id="su-wrap"> <!-- #su-wrap start -->
       <div id="su-content"> <!-- #su-content start -->
@@ -48,7 +49,6 @@
           <%= render partial: 'shared/ajax_modal' %>
 
           <section id="main-container" role="main">
-            <%= render 'shared/skip_to_nav' %>
             <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
             <div class="row">

--- a/app/views/shared/_skip_to_nav.html.erb
+++ b/app/views/shared/_skip_to_nav.html.erb
@@ -1,11 +1,11 @@
 <%# For home & search results page %>
 <% if params['controller'] == 'catalog' and params['action'] == 'index' %>
   <div id="skip-link">
-    <a href="#search_field" class="element-invisible element-focusable" tabindex="1">Skip to search</a>
-    <a href="#main-container" class="element-invisible element-focusable" tabindex="2">Skip to main content</a>
+    <a href="#search_field" class="element-invisible element-focusable">Skip to search</a>
+    <a href="#main-container" class="element-invisible element-focusable">Skip to main content</a>
 
     <% if !params['f'].blank? or !params['q'].blank? %>
-      <a href="#documents" class="element-invisible element-focusable" tabindex="3">Skip to first result</a>
+      <a href="#documents" class="element-invisible element-focusable">Skip to first result</a>
     <% end %>
   </div>
 <% end %>
@@ -13,23 +13,23 @@
 <%# For selections page %>
 <% if params['controller'] == 'bookmarks' and params['action'] == 'index' %>
   <div id="skip-link">
-    <a href="#search_field" class="element-invisible element-focusable" tabindex="1">Skip to search</a>
-    <a href="#main-container" class="element-invisible element-focusable" tabindex="2">Skip to main content</a>
-    <a href="#documents" class="element-invisible element-focusable" tabindex="3">Skip to first result</a>
+    <a href="#search_field" class="element-invisible element-focusable">Skip to search</a>
+    <a href="#main-container" class="element-invisible element-focusable">Skip to main content</a>
+    <a href="#documents" class="element-invisible element-focusable">Skip to first result</a>
   </div>
 <% end %>
 
 <%# For record view page %>
 <% if params['controller'] == 'catalog' and params['action'] == 'show' %>
   <div id="skip-link">
-    <a href="#search_field" class="element-invisible element-focusable" tabindex="1">Skip to search</a>
-    <a href="#document" class="element-invisible element-focusable" tabindex="2">Skip to main content</a>
+    <a href="#search_field" class="element-invisible element-focusable">Skip to search</a>
+    <a href="#document" class="element-invisible element-focusable">Skip to main content</a>
   </div>
 <% end %>
 
 <%# For advanced search page %>
 <% if params['controller'] == 'advanced' and params['action'] == 'index' %>
   <div id="skip-link">
-    <a href="#advanced-search-form" class="element-invisible element-focusable" tabindex="1">Skip to advanced search form</a>
+    <a href="#advanced-search-form" class="element-invisible element-focusable">Skip to advanced search form</a>
   </div>
 <% end %>


### PR DESCRIPTION
Removed tab-indexes from skip-to navigation, moved it to top of `body` and updated position
