### PR TITLE
Adds result page resource icon, and implements logic for showing icon wh...

### DIFF
--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -25,7 +25,11 @@ module FacetsHelper
     return my_params
   end
 
-  def render_resource_icon(value)
+  def render_resource_icon(values)
+    values = Array(values).flatten.compact
+    values.delete("Database") if values.length > 1
+    values.delete("Book") if values.length > 1
+    value = values.first
     if Constants::SUL_ICONS.has_key?(value)
       content_tag(:span, "", class:"sul-icon sul-icon-#{Constants::SUL_ICONS[value]}")
     end

--- a/app/views/browse/_index_header_default.html.erb
+++ b/app/views/browse/_index_header_default.html.erb
@@ -3,7 +3,7 @@
 <div class="documentHeader row">
 
   <h3 class="index_title col-sm-9 col-lg-10">
-    <span class="glyphicon glyphicon-star-empty"></span>
+    <%= render_resource_icon document[document.format_key] %>
     <%= link_to_document document, :label => get_main_title(document) %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
   </h3>

--- a/app/views/catalog/_index_brief.html.erb
+++ b/app/views/catalog/_index_brief.html.erb
@@ -8,7 +8,7 @@
   <div class="row container-fluid brief-container">
     <h3 class="index_title">
       <% counter = document_counter_with_offset(document_counter) %>
-      <span class="glyphicon glyphicon-star-empty"></span>
+      <%= render_resource_icon document[document.format_key] %>
       <span class="document-counter">
         <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
       </span>

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -4,9 +4,7 @@
 
   <h3 class="index_title col-sm-9 col-lg-10">
     <% counter = document_counter_with_offset(document_counter) %>
-    <% if document.has_key?(:format_main_ssim) %>
-      <%= render_resource_icon document[:format_main_ssim].first %>
-    <% end %>
+    <%= render_resource_icon document[document.format_key] %>
     <span class="document-counter">
       <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
     </span>

--- a/app/views/catalog/_index_header_gallery.html.erb
+++ b/app/views/catalog/_index_header_gallery.html.erb
@@ -7,9 +7,7 @@
   </div>
   <h3 class="index_title">
     <% counter = document_counter_with_offset(document_counter) %>
-    <% if document.has_key?(:format_main_ssim) %>
-      <%= render_resource_icon document[:format_main_ssim].first %>
-    <% end %>
+    <%= render_resource_icon document[document.format_key] %>
     <%= link_to_document document, label: get_main_title(document), counter: (counter + @response.params[:start].to_i) %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
   </h3>

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,0 +1,4 @@
+<h1>
+  <%= render_resource_icon document[document.format_key] %>
+  <%= render_document_heading(document, :tag => :span) %>
+</h1>

--- a/app/views/preview/_show_header_default.html.erb
+++ b/app/views/preview/_show_header_default.html.erb
@@ -1,1 +1,4 @@
-<h4><%= link_to_document document, :label => get_main_title(document) %></h4>
+<h4>
+  <%= render_resource_icon document[document.format_key] %>
+  <%= link_to_document document, :label => get_main_title(document) %>
+</h4>

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -7,4 +7,7 @@ feature "Search Results Page" do
   scenario "should have correct page title" do
     expect(page).to have_title("An object in SearchWorks")
   end
+  scenario "should have resource type icon" do
+    expect(page).to have_css("li span.sul-icon")
+  end
 end

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -43,11 +43,23 @@ describe FacetsHelper do
     end
   end
   describe "#render_resource_icon" do
+    it "should not render anything if format_main_ssim field is not present" do
+      expect(helper.render_resource_icon(nil)).to be_nil
+    end
+    it "should render a book before a database" do
+      expect(helper.render_resource_icon(['Database', 'Book'])).to eq '<span class="sul-icon sul-icon-book-1"></span>'
+    end
+    it "should render an image before a book" do
+      expect(helper.render_resource_icon(['Book', 'Image'])).to eq '<span class="sul-icon sul-icon-photos-1"></span>'
+    end
+    it "should render the first resource type icon" do
+      expect(helper.render_resource_icon(['Video', 'Image'])).to eq '<span class="sul-icon sul-icon-film-2"></span>'
+    end
     it "should render an icon that is in Constants::SUL_ICON" do
-      expect(helper.render_resource_icon('Book')).to eq '<span class="sul-icon sul-icon-book-1"></span>'
+      expect(helper.render_resource_icon(['Book'])).to eq '<span class="sul-icon sul-icon-book-1"></span>'
     end
     it "should not render anything for something not in Constants::SUL_ICON" do
-      expect(helper.render_resource_icon('iPad')).to be_nil
+      expect(helper.render_resource_icon(['iPad'])).to be_nil
     end
   end
 end


### PR DESCRIPTION
Fixes #364 
adds result page resource icon, and implements logic for showing icon when item has more than one resource type

![screen shot 2014-07-08 at 1 59 56 pm](https://cloud.githubusercontent.com/assets/1656824/3516596/d7ec7a1a-06e2-11e4-897c-eaa296f84786.png)

![screen shot 2014-07-08 at 2 00 45 pm](https://cloud.githubusercontent.com/assets/1656824/3516605/f5b9609e-06e2-11e4-951c-8438311341fb.png)
