### PR TITLE
Removes duplicate results toolbar, styles the search results toolbar

### DIFF
--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -16,3 +16,25 @@ $btn-preview-border: darken($sul-btn-preview-bg, 9.8%);
   background: $cardinal-red;
   border: none;
 }
+
+.btn-sul-toolbar {
+  color: $btn-sul-toolbar-bar-color;
+  background-color: transparent;
+  margin: 0 5px;
+  padding: 3px 5px;
+  text-transform: uppercase;
+  & a {
+    text-transform: uppercase;
+    color: $btn-sul-toolbar-bar-color;
+    border-bottom: none;
+  }
+
+  &.disabled {
+    border: none;
+  }
+
+  &:hover, &:focus, &:active {
+    color: $btn-sul-toolbar-bar-color;
+    background-color: $btn-sul-toolbar-bar-hover-bg
+  }
+}

--- a/app/assets/stylesheets/modules/sort-and-per-page-toolbar.css.scss
+++ b/app/assets/stylesheets/modules/sort-and-per-page-toolbar.css.scss
@@ -1,3 +1,36 @@
-#select_all-dropdown {
-  color: $link-color;
+#sortAndPerPage {
+  background-color: $sul-sort-per-page-bar-bg;
+  border-left: 1px solid $sul-sort-per-page-bar-border;
+  border-right: 1px solid $sul-sort-per-page-bar-border;
+  border-bottom: 1px solid $sul-sort-per-page-bar-border;
+  text-transform: uppercase;
+  padding: 5px 0px;
+  margin: 0 0 15px 0px;
+
+  .container-fluid {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+
+  .dropdown-menu li > a {
+    border-bottom: none;
+    text-transform: none;
+
+    &:hover, &:focus, &:active {
+      border-bottom: none;
+    }
+  }
+
+  .page_links {
+    padding: 0 0 0 0;
+  }
+
+  .page_entries {
+    text-transform: none;
+  }
+
+  .navbar-collapse {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -45,3 +45,7 @@ $sul-h1-font-color: $cool-gray;
 $sul-h2-font-color: $cardinal-red;
 $sul-h2-border-color: $beige-30-percent;
 $sul-skip-to-nav-bg: $beige-10-percent;
+$sul-sort-per-page-bar-bg: $beige-10-percent;
+$sul-sort-per-page-bar-border: $beige-30-percent;
+$btn-sul-toolbar-bar-color: $cardinal-red;
+$btn-sul-toolbar-bar-hover-bg: $beige-30-percent;

--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -1,6 +1,6 @@
 <span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
 <div id="tools-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
     <%= t('blacklight.tools.send_to_html', current_range: current_entries_info(@response)) %>
   </button>
   <ul class="dropdown-menu" role="menu">

--- a/app/views/browse/_index_header_default.html.erb
+++ b/app/views/browse/_index_header_default.html.erb
@@ -7,7 +7,6 @@
     <%= link_to_document document, :label => get_main_title(document) %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
   </h3>
-
   <% # bookmark functions for items/docs -%>
   <%= render_index_doc_actions document, :wrapping_class => "index-document-functions col-sm-3 col-lg-2" %>
 </div>

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -2,7 +2,7 @@
 
   <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
 <div id="per_page-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
     <%= link_to(t(:'blacklight.search.per_page.button_label_html', :count => current_per_page), "#") %> <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu">

--- a/app/views/catalog/_select_all_widget.html.erb
+++ b/app/views/catalog/_select_all_widget.html.erb
@@ -1,3 +1,3 @@
-<button id="select_all-dropdown" type="button" class="btn btn-default disabled" data-no-turbolinks>
+<button id="select_all-dropdown" type="button" class="btn btn-sul-toolbar disabled" data-no-turbolinks>
   <%= t('blacklight.bookmarks.add.all_html') %>
 </button>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,24 +1,9 @@
 <div id="sortAndPerPage" class="clearfix">
   <div class="container-fluid">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle facets-toggle" data-toggle="collapse" data-target="#search-results-toolbar">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <%= render partial: "paginate_compact", object: @response %>
-    </div>
-    <div id="search-results-toolbar" class="collapse hidden-md hidden-lg text-right">
-      <ul class="nav navbar-nav navbar-right">
-        <li><%= render partial: 'sort_navbar_dropdown_widget' %><li>
-        <li><%= render partial: 'per_page_navbar_dropdown_widget' %><li>
-        <li><%= render partial: 'select_navbar_dropdown_widget' %><li>
-      </ul>
-    </div>
-    <div id="" class="search-widgets collapse navbar-collapse pull-right">
+    <%= render partial: "paginate_compact", object: @response %>
+    <div id="search-results-toolbar" class="search-widgets pull-right">
       <% if bookmarks? %>
-        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(@response)), citation_catalog_path(:sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-default', :data => {:ajax_modal => "trigger"}} %>
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(@response)), citation_catalog_path(:sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
         <%= render "bookmarks/tool_dropdown" %>
       <% end %>
       <%= render partial: 'view_type_group' %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,6 +1,6 @@
 <% if show_sort_and_per_page? and !active_sort_fields.blank? %>
 <div id="sort-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
       <%= link_to(t('blacklight.search.sort.label_html', :field =>current_sort_field.label).html_safe, "#") %> <span class="caret"></span>
   </button>
 

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -2,9 +2,11 @@
 <div class="view-type">
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div id="view-type-dropdown" class="btn-group">
-    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+    <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
+      <span class="hidden-xs hidden-sm">
+        <%= render_view_type_group_icon document_index_view_type %>
+      </span>
       <%= link_to t('blacklight.search.view.label', :field =>current_sort_field.label).html_safe, '#' %>
-      <%= render_view_type_group_icon document_index_view_type %>
       <span class="caret"></span>
     </button>
 

--- a/app/views/kaminari/blacklight_compact/_next_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_next_page.html.erb
@@ -7,7 +7,7 @@
     remote:        data-remote
 -%>
 <% if current_page.last? %>
-  <%= link_to raw(t 'views.pagination_compact.next'), "#", :rel => 'next', class: 'btn btn-default btn-sm disabled', role: 'button', :remote => remote %>
+  <%= link_to raw(t 'views.pagination_compact.next'), "#", :rel => 'next', class: 'btn btn-sul-toolbar disabled', role: 'button', :remote => remote %>
 <% else %>
-  <%= link_to raw(t 'views.pagination_compact.next'), url, :rel => 'next', class: 'btn btn-default btn-sm', role: 'button', :remote => remote %>
+  <%= link_to raw(t 'views.pagination_compact.next'), url, :rel => 'next', class: 'btn btn-sul-toolbar', role: 'button', :remote => remote %>
 <% end %>

--- a/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -20,10 +20,7 @@
   <%= paginator.render do -%>
     <div class="page_links">
       <%= prev_page_tag %>
-      <span class="page_entries hidden-xs">
-        <%= page_entries_info %>
-      </span>
-      <span class="page_entries visible-xs-inline">
+      <span class="page_entries">
         <%= page_entries_info %>
       </span>
       <%= next_page_tag %>

--- a/app/views/kaminari/blacklight_compact/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_prev_page.html.erb
@@ -7,7 +7,7 @@
     remote:        data-remote
 -%>
 <% if current_page.first? %>
-  <%= link_to raw(t 'views.pagination_compact.previous'), '#', :rel => 'prev', class: 'btn btn-default btn-sm disabled', role: 'button', :remote => remote %>
+  <%= link_to raw(t 'views.pagination_compact.previous'), '#', :rel => 'prev', class: 'btn btn-sul-toolbar disabled', role: 'button', :remote => remote %>
 <% else %>
-  <%= link_to raw(t 'views.pagination_compact.previous'), url, :rel => 'prev', class: 'btn btn-default btn-sm', role: 'button', :remote => remote %>
+  <%= link_to raw(t 'views.pagination_compact.previous'), url, :rel => 'prev', class: 'btn btn-sul-toolbar', role: 'button', :remote => remote %>
 <% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -17,17 +17,17 @@ en:
       show:
         title: '%{document_title} in %{application_name}'
       sort:
-        label_html: 'Sort<span class="hidden-sm"> by relevance</span>'
+        label_html: 'Sort<span class="hidden-xs hidden-sm"> by %{field}</span>'
       title: '%{num_results} in %{application_name}'
       view:
         label: 'View'
         brief: 'Brief'
       per_page:
-        button_label_html: '%{count}<span class="hidden-sm"> per page</span>'
+        button_label_html: '%{count}<span class="hidden-xs hidden-sm"> per page</span>'
       pagination_info:
         pages:
-          one: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong><span class="hidden-xs"> of <strong>%{total_num}</strong></span>'
-          other: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong><span class="hidden-xs"> of <strong>%{total_num}</strong></span>'
+          one: '%{start_num} - %{end_num}'
+          other: '%{start_num} - %{end_num}'
         no_items_found: "<h2>No results found in catalog</h2>"
     bookmarks:
       add:
@@ -46,8 +46,8 @@ en:
       send_to_html: 'Send %{current_range} to <span class="caret"></span>'
   views:
     pagination_compact:
-      next: '<span class="sr-only">Next </span> <i class="fa fa-chevron-right"></i>'
-      previous: '<span class="sr-only"> Previous</span> <i class="fa fa-chevron-left"></i>'
+      next: '<span class="hidden-xs">Next </span><i class="fa fa-chevron-right"></i>'
+      previous: '<i class="fa fa-chevron-left"></i><span class="hidden-xs"> Previous</span>'
     pagination:
       previous: '<i class="fa fa-chevron-left"></i> Previous'
       next: 'Next <i class="fa fa-chevron-right"></i>'

--- a/spec/features/blacklight_customizations/bookmarks_path_spec.rb
+++ b/spec/features/blacklight_customizations/bookmarks_path_spec.rb
@@ -19,8 +19,8 @@ feature "Selections Path" do
       expect(page).to have_css("h3.index_title a", count: 2)
     end
     within ".search-widgets" do
-      expect(page).to have_css("a", text: "Cite 1 - 2")
-      expect(page).to have_css("button", text: "Send 1 - 2")
+      expect(page).to have_css("a", text: "CITE 1 - 2")
+      expect(page).to have_css("button", text: "SEND 1 - 2")
       expect(page).to_not have_css("button#select_all-dropdown")
     end
   end

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -5,26 +5,21 @@ require 'spec_helper'
 feature "Results Toolbar", js: true do
   before do
     visit root_path
-    first("#q").set ''
+    fill_in "q", with: ''
     click_button 'search'
   end
   scenario "should have desktop tools visible" do
     within "#sortAndPerPage" do
       within "div.page_links" do
-        expect(page).to have_css("a.btn.btn-default.btn-sm.disabled", text: /Previous/, visible: false)
-        expect(page).to have_css("span.page_entries.hidden-xs", text: /1 - 10 of \d+/, visible: true)
-        expect(page).to have_css("a.btn.btn-default.btn-sm", text: /Next/, visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar.disabled", text: /PREVIOUS/, visible: true)
+        expect(page).to have_css("span.page_entries", text: /1 - 10/, visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar", text: /NEXT/, visible: true)
       end
       expect(page).to have_css("div#view-type-dropdown a")
-      expect(page).to have_css("div#sort-dropdown", text: "Sort by relevance", visible: true)
-      expect(page).to have_css("#select_all-dropdown", text: "Select all")
+      expect(page).to have_css("div#sort-dropdown", text: "SORT BY RELEVANCE", visible: true)
+      expect(page).to have_css("#select_all-dropdown", text: "SELECT ALL")
       expect(page).to_not have_css("a", text: /Cite/)
       expect(page).to_not have_css("button", text: /Send/)
-    end
-  end
-  scenario "should have tablet and mobile tools hidden" do
-    within "#sortAndPerPage" do
-      expect(page).to_not have_css("#search-results-toolbar", visible: true)
     end
   end
 end

--- a/spec/features/responsive/results_toolbar_spec.rb
+++ b/spec/features/responsive/results_toolbar_spec.rb
@@ -6,18 +6,29 @@ describe "Responsive results toolbar", js: true, feature: true do
     fill_in "q", with: ''
     click_button 'search'
   end
-  describe " - desktop view (> 980px)" do
+  describe " - desktop view (> 992px)" do
     it "should display correct tools" do
       within "#sortAndPerPage" do
-        expect(page).to_not have_css("#search-results-toolbar", visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "NEXT", visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "PREVIOUS", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar span.glyphicon.glyphicon-list", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "VIEW", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "SORT BY RELEVANCE", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "10 PER PAGE", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "SELECT ALL", visible: true)
       end
     end
   end
-  describe " - tablet view (768px - 980px) - " do
+  describe " - tablet view (768px - 992px) - " do
     it "should display correct tools" do
       within "#sortAndPerPage" do
         page.driver.resize("800", "800")
-        expect(page).to_not have_css("#search-results-toolbar", visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "NEXT", visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "PREVIOUS", visible: true)
+        expect(page).to_not have_css("button.btn.btn-sul-toolbar span.glyphicon.glyphicon-list", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "VIEW", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "10", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "ALL", visible: true)
       end
     end
   end
@@ -25,12 +36,12 @@ describe "Responsive results toolbar", js: true, feature: true do
     it "should display correct tools" do
       page.driver.resize("700", "700")
       within "#sortAndPerPage" do
-        find("button.navbar-toggle").click
-        within "#search-results-toolbar" do
-          expect(page).to have_css("li a", text: "Relevance", visible: true)
-          expect(page).to have_css("li a", text: "10", visible: true)
-          expect(page).to have_css("li a", text: "All on this page", visible: true)
-        end
+        expect(page).to_not have_css("a.btn.btn-sul-toolbar", text: "NEXT", visible: true)
+        expect(page).to_not have_css("a.btn.btn-sul-toolbar", text: "PREVIOUS", visible: true)
+        expect(page).to_not have_css("button.btn.btn-sul-toolbar span.glyphicon.glyphicon-list", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "VIEW", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "10", visible: true)
+        expect(page).to have_css("button.btn.btn-sul-toolbar", text: "ALL", visible: true)
       end
     end
   end

--- a/spec/features/sort_dropdown_spec.rb
+++ b/spec/features/sort_dropdown_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "Sort dropdown in results toolbar", js: true, feature: true do
+  before do
+    visit root_path
+    fill_in "q", with: ''
+    click_button 'search'
+  end
+  it "should display default correctly" do
+    within "#sortAndPerPage" do
+      expect(page).to have_css("button.btn.btn-sul-toolbar", text: "SORT BY RELEVANCE", visible: true)
+    end
+  end
+  it "should change to current sort" do
+    within "#sortAndPerPage" do
+      expect(page).to_not have_css("button.btn.btn-sul-toolbar", text: "SORT BY AUTHOR", visible: true)
+      page.find("button.btn.btn-sul-toolbar", text:"SORT BY RELEVANCE").click
+      click_link "author"
+      expect(page).to have_css("button.btn.btn-sul-toolbar", text: "SORT BY AUTHOR", visible: true)
+    end
+  end
+end


### PR DESCRIPTION
Related to #348 
Fixes #409 
Also styles bookmarks page buttons.
Needs review from @jvine too, will show in person to get :+1: with all responsive cases

![screen shot 2014-07-09 at 12 01 29 pm](https://cloud.githubusercontent.com/assets/1656824/3529617/7f1f8ab2-079b-11e4-8829-d2e4a5a1c8de.png)
