### PR TITLE
Remove duplicate image links from search results

### DIFF
--- a/app/assets/javascripts/search-context.js
+++ b/app/assets/javascripts/search-context.js
@@ -1,0 +1,5 @@
+Blacklight.onLoad(function() {
+  $(".document-thumbnail div[data-context-href], .item-thumb div[data-context-href]")
+    .addClass('cursor-pointer')
+    .on('click.search-context', Blacklight.handleSearchContextMethod);
+});

--- a/app/assets/stylesheets/modules/results-documents.css.scss
+++ b/app/assets/stylesheets/modules/results-documents.css.scss
@@ -11,6 +11,12 @@
       color: #999;
     }
 
+    .cover-image-wrapper {
+      margin: 0;
+      overflow: auto;
+      padding: 0;
+    }
+
     .cover-image {
       border: 1px solid #ddd;
       display: none;
@@ -20,6 +26,10 @@
       max-height: 200px;
       max-width: 200px;
     }
+  }
+
+  .cursor-pointer {
+    cursor: pointer;
   }
 }
 

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,7 +1,18 @@
-<% preview_container = 'preview-container-' + document.id %>
+<%
+  preview_container = 'preview-container-' + document.id
+  counter = document_counter_with_offset(document_counter)
+  options = {
+    :counter => counter,
+    :suppress_link => true
+  }
+  context_href = (document_link_params(document, {:counter => counter}))[:data][:"context-href"]
+%>
+
 <div class="gallery-document" <%= preview_data_attrs(true, "preview-gallery", document[:id], ".#{preview_container}") %> data-preview-in-gallery="true" data-doc-id=<%= document.id %> >
   <div class="item-thumb">
-    <%= render_thumbnail_tag(document, {}, {tabindex: '-1', counter: document_counter_with_offset(document_counter)}) %>
+    <div class="cover-image-wrapper" data-target="<%= catalog_path document %>" data-context-href="<%= context_href %>">
+      <%= render_thumbnail_tag(document, {}, options) %>
+    </div>
   </div>
   <div class="caption">
     <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, document_counter: document_counter %>

--- a/app/views/catalog/_thumbnail_default.html.erb
+++ b/app/views/catalog/_thumbnail_default.html.erb
@@ -1,5 +1,16 @@
-<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, {:counter => document_counter_with_offset(document_counter), tabindex: '-1'}) %>
+<%
+  counter = document_counter_with_offset(document_counter)
+  options = {
+    :counter => counter,
+    :suppress_link => true
+  }
+  context_href = (document_link_params(document, {:counter => counter}))[:data][:"context-href"]
+%>
+
+<% if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, options) %>
   <div class="document-thumbnail">
-    <%= tn %>
+    <div class="cover-image-wrapper" data-target="<%= catalog_path document %>" data-context-href="<%= context_href %>">
+      <%= tn %>
+    </div>
   </div>
-<%- end %>
+<% end %>

--- a/spec/features/blacklight_customizations/results_document_spec.rb
+++ b/spec/features/blacklight_customizations/results_document_spec.rb
@@ -40,6 +40,20 @@ feature "Results Document Metadata" do
     end
   end
 
+  scenario "should have the correct cover image wrapper attributes" do
+    visit root_path
+    first("#q").set '10'
+    click_button 'search'
+
+    within "#documents" do
+      within "div.document" do
+        expect(page).to have_css("div.cover-image-wrapper", visible: true)
+        expect(page).to have_css("div.cover-image-wrapper[data-target='/view/10']")
+        expect(page).to have_css("div.cover-image-wrapper[data-context-href^='/catalog/10/track?']")
+      end
+    end
+  end
+
   scenario "should have the stacks image for objects with image behavior" do
     visit root_path
     first("#q").set '35'
@@ -47,11 +61,12 @@ feature "Results Document Metadata" do
 
     within 'div.document' do
       within('.document-thumbnail') do
-        expect(page).to have_css('a[tabindex="-1"]')
         expect(page).to have_css('img.stacks-image')
         expect(page).to have_css('img.stacks-image[alt=""]')
       end
     end
   end
+
+
 
 end


### PR DESCRIPTION
Closes #235 
- Removed duplicate image links from search results (`list` and `gallery` views)
- Added JavaScript based links to images. Used a copy a `Blacklight` JavaScript method and modified it to fit our needs. 
