### PR TITLE
Add styles for documents in search results

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -5,6 +5,7 @@
 
 // SUL Style Variables/Mixins
 @import 'sul-variables';
+@import 'searchworks-mixins';
 
 @import 'blacklight';
 @import 'searchworks';

--- a/app/assets/stylesheets/modules/brief-view.css.scss
+++ b/app/assets/stylesheets/modules/brief-view.css.scss
@@ -1,7 +1,9 @@
 .brief-document {
-  border: 1px solid #ccc;
-  margin-bottom: 10px;
-  padding: 10px;
+  @include document;
+
+  h3.index_title {
+    @include h3-index-title;
+  }
 
   .preview {
     border-radius: 0;

--- a/app/assets/stylesheets/modules/gallery-view.css.scss
+++ b/app/assets/stylesheets/modules/gallery-view.css.scss
@@ -31,13 +31,15 @@ $gallery-document-width: 184px;
   }
 
   .gallery-document {
-    position: relative;
-    margin: 0px 5px 15px 5px;
-    float: left;
+    @include document;
+
     display: inline;
-    width: $gallery-document-width;
+    float: left;
     height: 400px;
-    border: 1px solid $panel-inner-border;
+    margin: 0px 5px 15px 5px;
+    padding: 5px;
+    position: relative;
+    width: $gallery-document-width;
 
     h3.index_title {
       font-size: 1.1em;
@@ -67,7 +69,7 @@ $gallery-document-width: 184px;
     .preview-button {
       position: absolute;
       bottom: 0px;
-      right: 8px;
+      right: 12px;
     }
   }
   .stacks-image {

--- a/app/assets/stylesheets/modules/results-documents.css.scss
+++ b/app/assets/stylesheets/modules/results-documents.css.scss
@@ -1,6 +1,11 @@
 #documents {
 
   .document {
+    @include document;
+
+    h3.index_title {
+      @include h3-index-title;
+    }
 
     .document-metadata {
       list-style-type: none;

--- a/app/assets/stylesheets/searchworks-mixins.css.scss
+++ b/app/assets/stylesheets/searchworks-mixins.css.scss
@@ -1,0 +1,13 @@
+@mixin document {
+  background-color: $white;
+  border-top: 1px solid $sul-document-border-color;
+  border-right: 1px solid $sul-document-border-color;
+  border-bottom: 1px solid $sul-document-border-bottom-color;
+  border-left: 1px solid $sul-document-border-color;
+  margin-bottom: 15px;
+  padding: 15px 15px 15px 40px;
+}
+
+@mixin h3-index-title {
+  text-indent: -13px;
+}

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -49,3 +49,5 @@ $sul-sort-per-page-bar-bg: $beige-10-percent;
 $sul-sort-per-page-bar-border: $beige-30-percent;
 $btn-sul-toolbar-bar-color: $cardinal-red;
 $btn-sul-toolbar-bar-hover-bg: $beige-30-percent;
+$sul-document-border-color: $beige-10-percent;
+$sul-document-border-bottom-color: $beige-30-percent;


### PR DESCRIPTION
Closes #431 
- Add styles to documents in `list`, `gallery` and `brief` views

---

![image](https://cloud.githubusercontent.com/assets/302258/3535234/ec23c108-07fc-11e4-88ae-66d833517374.png)

---

![image](https://cloud.githubusercontent.com/assets/302258/3535243/03fba2fa-07fd-11e4-9c27-0ef0da2d4eca.png)

---

![image](https://cloud.githubusercontent.com/assets/302258/3535247/1ac05e4a-07fd-11e4-9dac-5e76c34baa59.png)
