### PR TITLE
Add MHLD support

### DIFF
--- a/app/views/catalog/_accordion_section_library.html.erb
+++ b/app/views/catalog/_accordion_section_library.html.erb
@@ -5,7 +5,7 @@
 
 <% if document.access_panels.library_locations? %>
   <%
-    snippet = document.access_panels.library_locations.libraries.map(&:name).join(', ')
+    snippet = document.access_panels.library_locations.libraries.select(&:is_viewable?).map(&:name).join(', ')
   %>
   <div class="accordion-section location col-md-9">
     <a class="header" data-accordion-section-target=".<%= id %>-location">

--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -1,5 +1,5 @@
 <% if document.holdings.present? %>
-  <% document.holdings.libraries.each do |library| %>
+  <% document.holdings.libraries.select(&:is_viewable?).each do |library| %>
     <table class="table table-condensed availability" data-live-lookup-url="<%= availability_index_path %>">
       <thead>
         <tr class='active'>
@@ -9,22 +9,35 @@
       </thead>
       <tbody>
         <% library.locations.each do |location| %>
-          <% if location.more_than_one_item? %>
-            <tr>
-              <td><strong><%= location.name%></strong></td>
-              <td>
+          <tr>
+            <td>
+              <strong><%= location.name%></strong>
+              <% if location.mhld.present? %>
+                <% location.mhld.each do |mhld| %>
+                  <% if mhld.public_note.present? %>
+                    <span class='public-note'><%= mhld.public_note %></span>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </td>
+            <td>
+              <% if location.mhld.present? %>
+                <% location.mhld.each do |mhld| %>
+                  <% if mhld.latest_received.present? %>
+                    Latest: <%= mhld.latest_received%>
+                  <% end %>
+                <% end %>
+              <% end %>
+              <% if location.items.present? %>
                 <% if library.location_level_request? || location.location_level_request? %>
                   <%= link_to('Request', request_link(document, location.items.first), class: 'btn btn-info btn-xs') %>
                 <% end %>
-              </td>
-            </tr>
-          <% end %>
+              <% end %>
+            </td>
+          </tr>
           <% location.items.each do |item| %>
             <tr>
-              <td class="<%= 'indent-callnumber' if location.more_than_one_item? %>">
-                <% if location.one_item? %>
-                  <strong><%= location.name %></strong> :
-                <% end %>
+              <td class='indent-callnumber'>
                 <%= item.callnumber %>
               </td>
               <td data-live-lookup-id="<%= document[:id] %>" data-status-target=".availability-icon" data-barcode="<%= item.barcode %>" <%= "data-request-url='#{request_link(document, item)}'".html_safe if item.requestable? && !item.must_request? %>>
@@ -38,7 +51,7 @@
                   On Reserve <%= item.loan_period %>
                 <% end %>
                 <span class="request-link">
-                  <% if item.must_request? || (location.one_item? && (library.location_level_request? || location.location_level_request?)) %>
+                  <% if item.must_request? %>
                     <%= link_to('Request', request_link(document, item), class: 'btn btn-info btn-xs') %>
                   <% end %>
                 </span>

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -17,10 +17,25 @@
               <% library.locations.each do |location| %>
                 <li>
                   <strong class="location-name"><%= location.name %></strong>
-                  <% if library.location_level_request? || location.location_level_request? %>
-                    <%= link_to('Request', request_link(document, location.items.first), class: 'btn btn-info btn-xs pull-right') %>
+                  <% if location.items.present? %>
+                    <% if library.location_level_request? || location.location_level_request? %>
+                      <%= link_to('Request', request_link(document, location.items.first), class: 'btn btn-info btn-xs pull-right') %>
+                    <% end %>
                   <% end %>
                   <ul class="list-unstyled items">
+                    <% if location.mhld.present? %>
+                      <% location.mhld.each do |mhld| %>
+                        <% if mhld.public_note.present? %>
+                          <li class='mhld public-note'><%= mhld.public_note.html_safe %></li>
+                        <% end %>
+                        <% if mhld.latest_received.present? %>
+                          <li class='mhld'>Latest: <%= mhld.latest_received.html_safe %></li>
+                        <% end %>
+                        <% if mhld.library_has.present? %>
+                          <li class='mhld'>Library has: <%= mhld.library_has.html_safe %></li>
+                        <% end %>
+                      <% end %>
+                    <% end %>
                     <% location.items.each do |item| %>
                       <li data-status-target=".availability-icon" data-barcode="<%= item.barcode %>" <%= "data-request-url='#{request_link(document, item)}'".html_safe if item.requestable? && !item.must_request? %>>
                         <i class="availability-icon <%= item.status.availability_class %>"></i>

--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -1,12 +1,16 @@
+require 'holdings/append_mhld'
 require 'holdings/callnumber'
 require 'holdings/library'
 require 'holdings/location'
+require 'holdings/mhld'
 require 'holdings/requestable'
 require 'holdings/status'
 
 class Holdings
+  include AppendMHLD
   def initialize(document)
     @item_display = document[:item_display]
+    @mhld_display = document[:mhld_display]
   end
   def find_by_barcode(barcode)
     callnumbers.find do |callnumber|
@@ -17,21 +21,31 @@ class Holdings
     libraries.select(&:is_viewable?).any? do |library|
       library.items.any? do |callnumber|
         callnumber.callnumber.present?
-      end
+      end || library.mhld.present?
     end
   end
   def unique_callnumbers
     callnumbers.uniq(&:truncated_callnumber)
   end
   def libraries
-    @libraries ||= callnumbers.group_by(&:library).map do |library, items|
-      Holdings::Library.new(library, items)
+    unless @libraries
+      @libraries = callnumbers.group_by(&:library).map do |library, items|
+        Holdings::Library.new(library, items)
+      end
+      append_mhld(:library, @libraries, Holdings::Library)
     end
+    @libraries
   end
   def callnumbers
     return [] unless @item_display.present?
     @callnumbers ||= @item_display.map do |item_display|
       Holdings::Callnumber.new(item_display)
     end.sort_by(&:full_shelfkey)
+  end
+  def mhld
+    return [] unless @mhld_display.present?
+    @mhld ||= @mhld_display.map do |mhld_display|
+      Holdings::MHLD.new(mhld_display)
+    end
   end
 end

--- a/lib/holdings/append_mhld.rb
+++ b/lib/holdings/append_mhld.rb
@@ -1,0 +1,13 @@
+module AppendMHLD
+  def append_mhld(group_by, items, klass)
+    mhld.group_by(&group_by).map do |code, mhld|
+      if (current = items.find{|item| item.code == code})
+        current.mhld = mhld
+      else
+        current = klass.new(code)
+        current.mhld = mhld
+        items << current
+      end
+    end if mhld.present?
+  end
+end

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -1,6 +1,8 @@
 class Holdings
   class Library
+    include AppendMHLD
     attr_reader :code, :items
+    attr_accessor :mhld
     def initialize(code, items=[])
       @code = code
       @items = items
@@ -9,9 +11,13 @@ class Holdings
       Constants::LIB_TRANSLATIONS[@code]
     end
     def locations
-      @locations ||= @items.group_by(&:home_location).map do |location_code, items|
-        Holdings::Location.new(location_code, items)
+      unless @locations
+        @locations = @items.group_by(&:home_location).map do |location_code, items|
+          Holdings::Location.new(location_code, items)
+        end
+        append_mhld(:location, @locations, Holdings::Location)
       end
+      @locations
     end
     def is_viewable?
       @code.present? && !["SUL", "PHYSICS"].include?(@code)

--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -1,6 +1,7 @@
 class Holdings
   class Location
     attr_reader :code, :items
+    attr_accessor :mhld
     def initialize(code, items=[])
       @code = code
       @items = items
@@ -10,12 +11,6 @@ class Holdings
     end
     def location_level_request?
       Constants::LOCATION_LEVEL_REQUEST_LOCS.include?(@code)
-    end
-    def one_item?
-      @has_one_item ||= items.one?(&:present?)
-    end
-    def more_than_one_item?
-      @more_than_one_item ||= items.present? && !one_item?
     end
   end
 end

--- a/lib/holdings/mhld.rb
+++ b/lib/holdings/mhld.rb
@@ -1,0 +1,33 @@
+class Holdings
+  class MHLD
+    def initialize(mhld_display)
+      @mhld_display = mhld_display.split('-|-').map(&:strip)
+    end
+
+    def library
+      @mhld_display[0]
+    end
+
+    def location
+      @mhld_display[1]
+    end
+
+    def public_note
+      sanitize_mhld_data @mhld_display[2]
+    end
+
+    def library_has
+      sanitize_mhld_data @mhld_display[3]
+    end
+
+    def latest_received
+      sanitize_mhld_data @mhld_display[4]
+    end
+
+    private
+
+    def sanitize_mhld_data(data)
+      data.gsub("),","), ").gsub("-","-<wbr/>")
+    end
+  end
+end

--- a/spec/features/access_panels/library_location_spec.rb
+++ b/spec/features/access_panels/library_location_spec.rb
@@ -15,6 +15,6 @@ feature "Library Location Access Panel" do
 
   scenario "should have 3 library locations" do
     visit '/view/10'
-    expect(page).to have_css('div.panel-library-location', count:3)
+    expect(page).to have_css('div.panel-library-location', count:4)
   end
 end

--- a/spec/features/mhld_spec.rb
+++ b/spec/features/mhld_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe "MHLD", feature: true do
+  describe "record view" do
+    it "should be present in the location access panel" do
+      visit catalog_path('10')
+
+      within('[data-hours-route="/hours/CHEMCHMENG"]') do
+        expect(page).to have_css('.location-name', text: 'Current Periodicals')
+        expect(page).to have_css('li.mhld.public-note', text: 'public note2')
+        expect(page).to have_css('li.mhld', text: 'Latest: latest received2')
+        expect(page).to have_css('li.mhld', text: 'Library has: library has2')
+      end
+      within('[data-hours-route="/hours/GREEN"]') do
+        expect(page).to have_css('.location-name', text: 'Stacks')
+        expect(page).to have_css('li.mhld.public-note', text: 'public note3')
+        expect(page).to have_css('li.mhld', text: 'Latest: latest received3')
+        expect(page).to have_css('li.mhld', text: 'Library has: library has3')
+      end
+    end
+  end
+  describe "results view", js: true do
+    it "should be present in the accordion section" do
+      visit catalog_index_path(q: '10')
+
+      within(first('.document')) do
+        expect(page).to have_content('At the library')
+        within('.accordion-section.location') do
+          find('a.header').click
+          expect(page).to have_css('tr td strong', text: 'Current Periodicals')
+          expect(page).to have_css('tr td .public-note', text: 'public note1')
+          expect(page).to have_css('tr td .public-note', text: 'public note2')
+          expect(page).to have_css('tr td .public-note', text: 'public note3')
+          expect(page).to have_css('tr td', text: 'Latest: latest received1')
+          expect(page).to have_css('tr td', text: 'Latest: latest received2')
+          expect(page).to have_css('tr td', text: 'Latest: latest received3')
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/solr_documents/10.yml
+++ b/spec/fixtures/solr_documents/10.yml
@@ -16,6 +16,10 @@
   - "678 -|- EARTH-SCI -|- STACKS -|- -|- -|- -|- -|- -|- JKL -|-"
   - "123 -|- CHEMCHMENG -|- STACKS -|- -|- -|- -|- -|- -|- MNO -|-"
   - "543 -|- BIOLOGY -|- STACKS -|- -|- -|- -|- -|- -|- PQR -|-"
+:mhld_display:
+  - "CHEMCHMENG -|- STACKS -|- public note1 -|- library has1 -|- latest received1"
+  - "CHEMCHMENG -|- CURRENTPER -|- public note2 -|- library has2 -|- latest received2"
+  - "GREEN -|- STACKS -|- public note3 -|- library has3 -|- latest received3"
 :isbn_display:
   - "0393040801"
   - "9780393040807"

--- a/spec/integration/external-data/mhld_spec.rb
+++ b/spec/integration/external-data/mhld_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe "MHLD", feature: true, :"data-integration" => true do
+  describe "record view" do
+    it "should be present in the location access panel" do
+      visit catalog_path('492502')
+
+      within('.access-panel.panel-library-location') do
+        expect(page).to have_css('li.mhld', text: 'Library has: v.1(1985)-v.20(2012)')
+        expect(page).to have_css('li.mhld.public-note', text: 'Latest issues in CURRENT PERIODICALS; earlier issues in STACKS.')
+        expect(page).to have_css('li.mhld', text: 'Latest: v.21:no.4 (2013)')
+        expect(page).to have_css('li.mhld', text: 'Library has: v.21(2013)-')
+      end
+    end
+  end
+  describe "results view", js: true do
+    it "should be present in the accordion section" do
+      visit catalog_index_path(q: '492502')
+
+      within(first('.document')) do
+        expect(page).to have_content('At the library')
+        within('.accordion-section.location') do
+          find('a.header').click
+          expect(page).to have_css('tr td strong', text: 'Current Periodicals')
+          expect(page).to have_css('tr td .public-note', text: 'Latest issues in CURRENT PERIODICALS; earlier issues in STACKS.')
+          expect(page).to have_css('tr td', text: 'Latest: v.21:no.4 (2013)')
+        end
+        
+      end
+    end
+  end
+end

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -41,4 +41,12 @@ describe Holdings::Library do
       end
     end
   end
+  describe "#mhld" do
+    let(:library) {Holdings::Library.new("GREEN")}
+    it "should be an accessible attribute" do
+      expect(library.mhld).to_not be_present
+      library.mhld = "something"
+      expect(library.mhld).to be_present
+    end
+  end
 end

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -7,21 +7,12 @@ describe Holdings::Location do
   it "should identify location level requests" do
     expect(Holdings::Location.new("SSRC-DATA")).to be_location_level_request
   end
-  describe "enumeration helpers" do
-    let(:none) { Holdings::Location.new("STACKS") }
-    let(:one) { Holdings::Location.new("STACKS", ["something"]) }
-    let(:multiple) { Holdings::Location.new("STACKS", ["something", "else"]) }
-    it "should not return true if there are no items" do
-      expect(none).to_not be_one_item
-      expect(none).to_not be_more_than_one_item
-    end
-    it "should return true for a single item" do
-      expect(one).to be_one_item
-      expect(one).to_not be_more_than_one_item
-    end
-    it "should return true for multiple items" do
-      expect(multiple).to_not be_one_item
-      expect(multiple).to be_more_than_one_item
+  describe "#mhld" do
+    let(:location) {Holdings::Location.new("STACKS")}
+    it "should be an accessible attribute" do
+      expect(location.mhld).to_not be_present
+      location.mhld = "something"
+      expect(location.mhld).to be_present
     end
   end
 end

--- a/spec/lib/holdings/mhld_spec.rb
+++ b/spec/lib/holdings/mhld_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Holdings::MHLD do
+  let(:mhld_display) { 'GREEN -|- STACKS -|- mhld public note -|- mhld library has -|- mhld latest received' }
+  let(:special_mhld) { 'GREEN -|- STACKS -|- (public),(note) -|- library-has-with-hyphens -|- ' }
+  it "should return the correct elements from the MHLD combined field" do
+    mhld = Holdings::MHLD.new(mhld_display)
+    expect(mhld.library).to eq "GREEN"
+    expect(mhld.location).to eq "STACKS"
+    expect(mhld.public_note).to eq "mhld public note"
+    expect(mhld.library_has).to eq "mhld library has"
+    expect(mhld.latest_received).to eq "mhld latest received"
+  end
+  it "should replace '),(' with '), ('" do
+    expect(Holdings::MHLD.new(special_mhld).public_note).to match /\), \(/
+  end
+  it "should append <wbr/> to hyphens" do
+    expect(Holdings::MHLD.new(special_mhld).library_has).to include('-<wbr/>')
+  end
+end

--- a/spec/views/catalog/_accordion_section_library.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_library.html.erb_spec.rb
@@ -19,8 +19,9 @@ describe "catalog/_accordion_section_library.html.erb" do
       expect(rendered).to have_css('.accordion-section.location')
       expect(rendered).to have_css('.accordion-section.location a.header', text: "At the library")
       expect(rendered).to have_css('.accordion-section.location span.snippet', text: "Green Library")
-      expect(rendered).to have_css('.accordion-section .details tbody tr', count: 1)
-      expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /Stacks\s*:\s*ABC 123/)
+      expect(rendered).to have_css('.accordion-section .details tbody tr', count: 2)
+      expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /Stacks/)
+      expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /ABC 123/)
     end
   end
 

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -17,26 +17,6 @@ describe "catalog/_index_location.html.erb" do
       expect(rendered).to have_css('tbody td i.page')
     end
   end
-  describe "single item in a location" do
-    before do
-      view.stub(:document).and_return(
-        SolrDocument.new(
-          id: '123',
-          item_display: [
-            '123 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123'
-          ]
-        )
-      )
-      render
-    end
-    it "should display the location and item in a single table row" do
-      expect(rendered).to have_css('tbody tr', count: 1)
-      expect(rendered).to have_css('tbody tr td', text: /Stacks\s*:\s*ABC 123/)
-    end
-    it "should not have the indentation class" do
-      expect(rendered).to_not have_css('.indent-callnumber')
-    end
-  end
   describe "multiple items in a location" do
     before do
       view.stub(:document).and_return(
@@ -60,24 +40,40 @@ describe "catalog/_index_location.html.erb" do
       expect(rendered).to have_css('tbody tr td.indent-callnumber', count: 2)
     end
   end
+  describe "mhld" do
+    describe "with matching library/location" do
+      before do
+        view.stub(:document).and_return(SolrDocument.new(
+          id: '123',
+          item_display: ['321 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123'],
+          mhld_display: ['GREEN -|- STACKS -|- public note -|- library has -|- latest received']
+        ))
+        render
+      end
+      it "should include the matched MHLD" do
+        expect(rendered).to have_css('tbody tr', count: 2)
+        expect(rendered).to have_css('tbody tr td', text: /Stacks.*public note/m)
+        expect(rendered).to have_css('tbody tr td', text: "ABC 123")
+        expect(rendered).to have_css('tbody tr td', text: "Latest: latest received")
+      end
+    end
+    describe "that has no matching library/location" do
+      before do
+        view.stub(:document).and_return(SolrDocument.new(
+          id: '123',
+          mhld_display: ['GREEN -|- STACKS -|- public note -|- library has -|- latest received']
+        ))
+        render
+      end
+      it "should invoke a library block w/ the appropriate mhld data" do
+        expect(rendered).to have_css('tbody tr', count: 1)
+        expect(rendered).to have_css('tbody tr td', text: /Stacks.*public note/m)
+        expect(rendered).to have_css('tbody tr td', text: "Latest: latest received")
+      end
+    end
+  end
   describe "request links" do
     describe "location level request links" do
-      describe "for a single item" do
-        before do
-          view.stub(:document).and_return(
-            SolrDocument.new(
-              id: '123',
-              item_display: [
-                '123 -|- SAL3 -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123'
-              ]
-            )
-          )
-          render
-        end
-        it "should put the request link with the status icon (since the line is collapsed)" do
-          expect(rendered).to have_css('tbody td[data-barcode] a', text: 'Request')
-        end
-      end
       describe "for multiple items" do
         before do
           view.stub(:document).and_return(

--- a/spec/views/catalog/access_panels/_location.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_location.html.erb_spec.rb
@@ -57,6 +57,42 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       end
     end
   end
+  describe "mhld" do
+    describe "with matching library/location" do
+      before do
+        assign(:document, SolrDocument.new(
+          id: '123',
+          item_display: ['321 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123'],
+          mhld_display: ['GREEN -|- STACKS -|- public note -|- library has -|- latest received']
+        ))
+        render
+      end
+      it "should include the matched MHLD" do
+        expect(rendered).to have_css('h3 a', text: "Green Library", count: 1)
+        expect(rendered).to have_css('li .location-name', text: "Stacks", count: 1)
+        expect(rendered).to have_css('ul.items li.mhld.public-note', text: "public note")
+        expect(rendered).to have_css('ul.items li.mhld', text: "Latest: latest received")
+        expect(rendered).to have_css('ul.items li.mhld', text: "Library has: library has")
+        expect(rendered).to have_css('ul.items li', text: "ABC 123")
+      end
+    end
+    describe "that has no matching library/location" do
+      before do
+        assign(:document, SolrDocument.new(
+          id: '123',
+          mhld_display: ['GREEN -|- STACKS -|- public note -|- library has -|- latest received']
+        ))
+        render
+      end
+      it "should invoke a library block w/ the appropriate mhld data" do
+        expect(rendered).to have_css('h3 a', text: "Green Library")
+        expect(rendered).to have_css('li .location-name', text: "Stacks")
+        expect(rendered).to have_css('ul.items li.mhld.public-note', text: "public note")
+        expect(rendered).to have_css('ul.items li.mhld', text: "Latest: latest received")
+        expect(rendered).to have_css('ul.items li.mhld', text: "Library has: library has")
+      end
+    end
+  end
   describe "request links" do
     describe "location level request links" do
       before do

--- a/spec/views/preview/_show_file.html.erb_spec.rb
+++ b/spec/views/preview/_show_file.html.erb_spec.rb
@@ -29,8 +29,9 @@ describe "preview/_show_file.html.erb" do
   it "should display library accordion section" do
     expect(rendered).to have_css('.accordion-section.location a.header', text: "At the library")
     expect(rendered).to have_css('.accordion-section.location span.snippet', text: "Green Library")
-    expect(rendered).to have_css('.accordion-section .details tbody tr', count: 1)
-    expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /Stacks\s*:\s*ABC 123/)
+    expect(rendered).to have_css('.accordion-section .details tbody tr', count: 2)
+    expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /Stacks/)
+    expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /ABC 123/)
   end
 
   it "should display online accordion section" do

--- a/spec/views/preview/_show_image.html.erb_spec.rb
+++ b/spec/views/preview/_show_image.html.erb_spec.rb
@@ -37,8 +37,9 @@ describe "preview/_show_image.html.erb" do
   it "should display library accordion section" do
     expect(rendered).to have_css('.accordion-section.location a.header', text: "At the library")
     expect(rendered).to have_css('.accordion-section.location span.snippet', text: "Green Library")
-    expect(rendered).to have_css('.accordion-section .details tbody tr', count: 1)
-    expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /Stacks\s*:\s*ABC 123/)
+    expect(rendered).to have_css('.accordion-section .details tbody tr', count: 2)
+    expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /Stacks/)
+    expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /ABC 123/)
   end
 
   it "should display online accordion section" do


### PR DESCRIPTION
Closes #321 

Good Example: 492502

Also, browse Resource Type of Periodical or Microform and At the library can yield some MHLD data.
#### Record view

---

![mhld-record](https://cloud.githubusercontent.com/assets/96776/3548927/0971b7ae-08bd-11e4-9ca8-71e316f12b39.png)
#### Results view

---

![mhld-results](https://cloud.githubusercontent.com/assets/96776/3548929/0fcc8a8e-08bd-11e4-9c47-015026049f37.png)
