### PR TITLE
Only set collection title as page title when there are results.

### DIFF
--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -15,8 +15,7 @@
   <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
 
   <% if page_location.access_point? %>
-    <% if page_location.access_point.collection? %>
-      <% get_collection %>
+    <% if page_location.access_point.collection? && get_collection.present? %>
       <% @page_title = t 'blacklight.search.masthead_title', title: "#{presenter(@parent).document_heading} Collection", application_name: application_name %>
     <% else %>
       <% @page_title = t 'blacklight.search.masthead_title', title: page_location.access_point.name, application_name: application_name %>

--- a/spec/features/collections_search_spec.rb
+++ b/spec/features/collections_search_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe "Searching within collections" do
+  it "should return the zero results page when no items are present" do
+    visit catalog_index_path( f: { collection: ['29'] } )
+
+    fill_in 'q', with: 'abcde'
+    click_button 'search'
+
+    expect(page).to have_css('h2', text: 'No results found in catalog')
+  end
+end


### PR DESCRIPTION
Fixes #429 

We don't have a way of getting the collection (as of right now) on the zero results page.  This PR only attempts to print the title of the collection if we have a collection present.
