### PR TITLE
fixes some issues with gallery / embedded browse and javascript plugins

### DIFF
--- a/app/assets/javascripts/embedded-call-number-browse.js
+++ b/app/assets/javascripts/embedded-call-number-browse.js
@@ -120,6 +120,8 @@
             .done(function(data){
               $galleryDoc.updateDocs();
               scrollOver();
+              Blacklight.do_bookmark_toggle_behavior();
+              $(".gallery-document h3.index_title a").trunk8({ lines: 4 });
               reorderPreviewElements();
               $galleryDoc.embedContainer.find('*[data-behavior="preview-gallery"]').previewEmbedBrowse();
               $galleryDoc.addBrowseLinkDivs();

--- a/app/assets/javascripts/preview-content.js
+++ b/app/assets/javascripts/preview-content.js
@@ -51,7 +51,6 @@ var PreviewContent = (function() {
       target.find('*[data-accordion-section-target]').accordionSection();
       target.find("[data-behavior='trunk8']").trunk8();
 
-      Blacklight.do_bookmark_toggle_behavior();
       break;
     case 'prepend':
       target
@@ -62,7 +61,6 @@ var PreviewContent = (function() {
       target.find('*[data-accordion-section-target]').accordionSection();
       target.find("[data-behavior='trunk8']").trunk8();
 
-      Blacklight.do_bookmark_toggle_behavior();
       break;
     case 'returnOnly':
       break;

--- a/spec/features/gallery_view_spec.rb
+++ b/spec/features/gallery_view_spec.rb
@@ -15,8 +15,10 @@ feature "Gallery View" do
     expect(page).to have_css(".gallery-document h3.index_title", text: "An object")
     expect(page).to have_css(".gallery-document button.btn-preview", text: "Preview")
     expect(page).to have_css("form.bookmark_toggle label.toggle_bookmark", text: "Select")
-
+    expect(page).to have_css("label[for='toggle_bookmark_1']", count: 1)
     page.first("button.btn.docid-1").click
+    expect(page).to have_css("h4", text: "An object")
+    expect(page).to have_css("label[for='toggle_bookmark_1']", count: 1)
     expect(page).to have_css("dt", text: "LANGUAGE")
     expect(page).to have_css("dd", text: "English.")
   end


### PR DESCRIPTION
Fixes #454 #456 

(#454) Duplicate labels were being added for all "Select" forms in a gallery/brief view when a user clicked on a preview. `Blacklight.do_bookmark_toggle_behavior()` doesn't check if the form is already there but just adds a new one.

(#456) Truncation wasn't instantiated on gallery titles added in the embed browse docs
