### PR TITLE
Fix responsive breakpoint on search results page.

### DIFF
--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -2,7 +2,7 @@
   <%= render 'constraints' %>
 </div>
 
-<div id="sidebar" class="col-md-4">
+<div id="sidebar" class="col-md-4 col-sm-5">
   <% if @response.empty? %>
     <%= render "catalog/chat_librarian_sidebar" %>
     <%= render "catalog/library_website_sidebar" %>
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<div id="content" class="col-md-8">
+<div id="content" class="col-md-8 col-sm-7">
   <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
 
   <% if page_location.access_point? %>


### PR DESCRIPTION
Fixes #280 
#### Before

---

![before-responsive](https://cloud.githubusercontent.com/assets/96776/3560814/32f70408-098f-11e4-9c1f-016652aefd84.gif)
#### After

---

![after-responsive](https://cloud.githubusercontent.com/assets/96776/3560815/38c74b7c-098f-11e4-8e26-002af03bbfbf.gif)
