### PR TITLE
modify $grey-light bs color

### DIFF
--- a/app/assets/stylesheets/bootstrap-variables.css.scss
+++ b/app/assets/stylesheets/bootstrap-variables.css.scss
@@ -37,6 +37,9 @@ $btn-danger-color: $white;
 $btn-danger-bg: $boston-university-red;
 $btn-danger-border: darken($btn-danger-bg, 9.8%);
 
+// Colors
+$gray-light: #737373;
+
 // Navbar
 $navbar-default-link-color: $cardinal-red;
 $navbar-default-link-hover-color: $cardinal-red;


### PR DESCRIPTION
Fixes #449 

This modifies the bootstrap default variable which is setting styles to #99999.   @jvine Does this meet our threshold in all situations? I am unable to find a situation which has a white background.

```
.text-muted, .appliedFilter .filterName:after, .facet-values li .remove, .search_history .filterName, .search_history .filterSeparator {
  color: #737373;
}
```
