### PR TITLE
fixes issue with facet icon padding

### DIFF
--- a/app/assets/stylesheets/modules/sul-icons.css.scss
+++ b/app/assets/stylesheets/modules/sul-icons.css.scss
@@ -25,5 +25,5 @@ $sul-icon-prefix: 'sul-icon';
 }
 
 .facet-values .#{$sul-icon-prefix} + .facet-label {
-  padding-left: 0px;
+  padding-left: 20px;
 }


### PR DESCRIPTION
I think this was introduced with the BL upgrade

Before:

![screen shot 2014-07-14 at 6 35 32 pm](https://cloud.githubusercontent.com/assets/1656824/3578284/634d37c0-0ba7-11e4-9d40-a75abeafb85d.png)

After:
![screen shot 2014-07-14 at 6 35 46 pm](https://cloud.githubusercontent.com/assets/1656824/3578286/69cb1842-0ba7-11e4-8147-b28324fb0677.png)
