### PR TITLE
Update styling for facets (+ some global bootstrap panel override).

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -48,3 +48,4 @@ dd {
   margin-bottom: .5em;
   max-width: 45em;
 }
+

--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -4,4 +4,6 @@
 
 @import 'bootstrap-mixins';
 
+@import 'bootstrap-overrides';
+
 @import 'blacklight/blacklight';

--- a/app/assets/stylesheets/bootstrap-overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.css.scss
@@ -1,0 +1,14 @@
+.panel {
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.panel-default {
+  border-color: transparent;
+}
+.panel-body {
+  border-top: none; 
+  border-left: 1px solid $sul-panel-border;
+  border-right: 1px solid $sul-panel-border;
+  border-bottom: 1px solid $sul-panel-border-bottom;
+}

--- a/app/assets/stylesheets/modules/facets.css.scss
+++ b/app/assets/stylesheets/modules/facets.css.scss
@@ -1,8 +1,19 @@
-.facet_limit .panel-heading {
-  background: $sul-facet-bg;
-  border-bottom: 1px solid $sul-facet-border;
+.panel-group .facet_limit {
+  margin-bottom: 7px;
 }
-.facet_limit.facet_limit-active .panel-heading {
-  background: $sul-facet-active-bg;
-  border-bottom: 1px solid $sul-facet-active-border;
+.facet_limit {
+  ul {
+    margin-bottom: 0;
+  }
+  .panel-heading {
+    background: $sul-facet-bg;
+    border-bottom: 1px solid $sul-facet-border;
+    h3 {
+      font-weight: 400;
+    }
+  }
+  &.facet_limit-active .panel-heading {
+    background: $sul-facet-active-bg;
+    border-bottom: 1px solid $sul-facet-active-border;
+  }
 }

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -37,6 +37,8 @@ $sul-pagination-active-bg: $gray-41-percent;
 $sul-body-bg: $beige-5-percent;
 $sul-text-color: $gray;
 $sul-panel-bg: $white;
+$sul-panel-border: $beige-10-percent;
+$sul-panel-border-bottom: $beige-30-percent;
 $sul-facet-bg: $beige-10-percent;
 $sul-facet-border: $beige-30-percent;
 $sul-facet-active-bg: $off-green;


### PR DESCRIPTION
Closes #446 

**Note:** Added new `bootstrap-overrides` css file to handle overriding bootstrap styling that isn't governed by variables.  I understand that is not exactly the case w/ panels, however we want a granularity w/ the border styles that bootstrap doesn't appear to provide (AFAICT).  If folks don't like this approach I'm more than happy to change it if they have a good idea.

![facets-styling](https://cloud.githubusercontent.com/assets/96776/3579046/da6ded50-0bb5-11e4-9889-d4c160f94564.png)
