### PR TITLE
Change course reserve masthead markup to be dl instead of p.

### DIFF
--- a/app/assets/stylesheets/modules/course-reserve-masthead.css.scss
+++ b/app/assets/stylesheets/modules/course-reserve-masthead.css.scss
@@ -1,0 +1,6 @@
+.course-reserve-masthead {
+  dl {
+    width: 30%;
+    margin: auto;
+  }
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -18,6 +18,7 @@
 @import 'modules/browse-toolbar';
 @import 'modules/buttons';
 @import 'modules/constraints';
+@import 'modules/course-reserve-masthead';
 @import 'modules/feedback-form';
 @import 'modules/facets';
 @import 'modules/file-collection-members';

--- a/app/views/catalog/mastheads/_course_reserve.html.erb
+++ b/app/views/catalog/mastheads/_course_reserve.html.erb
@@ -1,12 +1,12 @@
 <div id="masthead" class="course-reserve-masthead">
   <% create_course %>
   <h1>Course reserve list: <%= @course_info.id %></h1>
-  <p>
-    <small class="text-muted">COURSE:</small> <%= "#{@course_info.id} -- #{@course_info.name}" %>
-  </p>
-  <p>
-    <small class="text-muted">INSTRUCTOR:</small> <%= @course_info.instructor %>
-  </p>
+  <dl class='dl-horizontal dl-invert'>
+    <dt>Course</dt>
+    <dd><%= "#{@course_info.id} -- #{@course_info.name}" %></dd>
+    <dt>Instructor</dt>
+    <dd><%= @course_info.instructor %></dd>
+  </dl>
   <p>
     <a href="#" class="disabled">Find reserve list for another course</a>
   </p>

--- a/spec/features/access_points/course_reserve_spec.rb
+++ b/spec/features/access_points/course_reserve_spec.rb
@@ -8,8 +8,10 @@ feature "Course Reserve Access Point" do
     expect(page).to have_title("Course reserves in SearchWorks")
     within("#masthead") do
       expect(page).to have_css("h1", text: "Course reserve list: CAT-401-01-01")
-      expect(page).to have_css("p", text: "CAT-401-01-01 -- Emergency Kittenz")
-      expect(page).to have_css("p", text: "INSTRUCTOR: McDonald, Ronald")
+      expect(page).to have_css("dt", text: "Instructor")
+      expect(page).to have_css("dd", text: "McDonald, Ronald")
+      expect(page).to have_css("dt", text: "Course")
+      expect(page).to have_css("dd", text: "CAT-401-01-01 -- Emergency Kittenz")
     end
     within("#content") do
       expect(page).to have_css("div.document", count:1)


### PR DESCRIPTION
Closes #478 

Adding the explicit width and `margin: auto` was the only way I could get the `dl` to play nicely w/ `text-align: center`.

![crez-masthead-dl](https://cloud.githubusercontent.com/assets/96776/3589742/fb7ec1d6-0c50-11e4-8acc-4fd0075795ab.png)

![crez-masthead-dl-markup](https://cloud.githubusercontent.com/assets/96776/3589744/fe643c1e-0c50-11e4-8a83-8c30b1715203.png)
