### PR TITLE
styles access points

### DIFF
--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -4,14 +4,6 @@
   padding: 0 0;
 }
 
-#masthead {
-  min-height: 100px;
-  border-bottom: 1px solid $panel-inner-border;
-  margin-left: -15px;
-  margin-right: -15px;
-  padding: 0 15px;
-}
-
 #main-flashes{
   padding-top: 10px;
 }

--- a/app/assets/stylesheets/modules/course-reserve-masthead.css.scss
+++ b/app/assets/stylesheets/modules/course-reserve-masthead.css.scss
@@ -1,6 +1,0 @@
-.course-reserve-masthead {
-  dl {
-    width: 30%;
-    margin: auto;
-  }
-}

--- a/app/assets/stylesheets/modules/mastheads.css.scss
+++ b/app/assets/stylesheets/modules/mastheads.css.scss
@@ -1,0 +1,17 @@
+#masthead {
+  background-color: $sul-masthead-bg;
+  border: 1px solid $sul-masthead-border;
+  border-radius: 5px;
+  margin: 15px 0;
+  padding: 0 15px;
+
+  h1 {
+    margin: 0;
+  }
+
+  .pagination > .active > a {
+    color: $white;
+    background-color: $sul-pagination-active-bg-border;
+    border-color: $sul-pagination-active-bg-border;
+  }
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -19,7 +19,6 @@
 @import 'modules/buttons';
 @import 'modules/clear-input-text';
 @import 'modules/constraints';
-@import 'modules/course-reserve-masthead';
 @import 'modules/feedback-form';
 @import 'modules/facets';
 @import 'modules/file-collection-members';
@@ -28,6 +27,7 @@
 @import 'modules/home-page';
 @import 'modules/image-collection-filmstrip';
 @import 'modules/item-preview';
+@import 'modules/mastheads';
 @import 'modules/open-seadragon';
 @import 'modules/online-resource-links';
 @import 'modules/recent-selections';

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -62,6 +62,9 @@ $sul-gallery-fakecover-bg: $beige-5-percent;
 $sul-gallery-fakecover-border: $beige-10-percent;
 $sul-clear-input-icon-color: $gray-70-percent;
 $sul-clear-input-icon-hover-color: $cardinal-red;
+$sul-masthead-bg: $off-green;
+$sul-masthead-border: $pantone-5665;
+$sul-pagination-active-bg-border: $gray-41-percent;
 
 // Sizes
 $gallery-document-width: 176px;

--- a/app/views/catalog/mastheads/_callnumber_browse.html.erb
+++ b/app/views/catalog/mastheads/_callnumber_browse.html.erb
@@ -1,10 +1,12 @@
-<div id="masthead" class="browse-masthead">
-  <h1>Browse nearby
-    <% if params[:barcode] %>
-      <%= @original_doc.holdings.find_by_barcode(params[:barcode]).callnumber %>
-    <% else %>
-      <%= @original_doc.holdings.callnumbers.first.callnumber %>
-    <% end %>
-  </h1>
-  <%= link_to(presenter(@original_doc).document_heading, catalog_path(@original_doc)) %>
+<div id="masthead-container">
+  <div id="masthead" class="browse-masthead">
+    <h1>Browse nearby
+      <% if params[:barcode] %>
+        <%= @original_doc.holdings.find_by_barcode(params[:barcode]).callnumber %>
+      <% else %>
+        <%= @original_doc.holdings.callnumbers.first.callnumber %>
+      <% end %>
+    </h1>
+    <%= link_to(presenter(@original_doc).document_heading, catalog_path(@original_doc)) %>
+  </div>
 </div>

--- a/app/views/catalog/mastheads/_collection.html.erb
+++ b/app/views/catalog/mastheads/_collection.html.erb
@@ -1,31 +1,33 @@
 <% get_collection %>
 <% if !@parent.nil? %>
-  <div id="masthead" class="collection-masthead">
-    <h1><%= @parent[:title_display] %></h1>
-    <div class="row">
-      <div class="col-xs-8">
-        <% if @parent[:summary_display] %>
-          <div data-behavior='truncate'>
-            <%= @parent[:summary_display].join(', ') %>
-          </div>
-        <% end %>
-      </div>
-      <div class="col-xs-4">
-        <dl class="dl-horizontal dl-invert">
-          <% if @parent.collection_members.present? %>
-            <dt>Digital content</dt>
-            <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
+  <div id="masthead-container">
+    <div id="masthead" class="collection-masthead">
+      <h1><%= @parent[:title_display] %></h1>
+      <div class="row">
+        <div class="col-xs-8">
+          <% if @parent[:summary_display] %>
+            <div data-behavior='truncate'>
+              <%= @parent[:summary_display].join(', ') %>
+            </div>
           <% end %>
-          <% # this stuff is temporary until we have item level merge (mods + marc) %>
-          <% if @parent.extent.present? %>
-            <dt><%= @parent.extent_label %></dt>
-            <dd><%= @parent.extent %></dd>
-          <% end %>
-          <% if @parent.index_links.finding_aid.present? %>
-            <dt>Finding aid</dt>
-            <dd><%= @parent.index_links.finding_aid.first.text.html_safe %></dd>
-          <% end %>
-        </dl>
+        </div>
+        <div class="col-xs-4">
+          <dl class="dl-horizontal dl-invert">
+            <% if @parent.collection_members.present? %>
+              <dt>Digital content</dt>
+              <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
+            <% end %>
+            <% # this stuff is temporary until we have item level merge (mods + marc) %>
+            <% if @parent.extent.present? %>
+              <dt><%= @parent.extent_label %></dt>
+              <dd><%= @parent.extent %></dd>
+            <% end %>
+            <% if @parent.index_links.finding_aid.present? %>
+              <dt>Finding aid</dt>
+              <dd><%= @parent.index_links.finding_aid.first.text.html_safe %></dd>
+            <% end %>
+          </dl>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/catalog/mastheads/_course_reserve.html.erb
+++ b/app/views/catalog/mastheads/_course_reserve.html.erb
@@ -1,13 +1,15 @@
-<div id="masthead" class="course-reserve-masthead">
-  <% create_course %>
-  <h1>Course reserve list: <%= @course_info.id %></h1>
-  <dl class='dl-horizontal dl-invert'>
-    <dt>Course</dt>
-    <dd><%= "#{@course_info.id} -- #{@course_info.name}" %></dd>
-    <dt>Instructor</dt>
-    <dd><%= @course_info.instructor %></dd>
-  </dl>
-  <p>
-    <a href="#" class="disabled">Find reserve list for another course</a>
-  </p>
+<div id="masthead-container">
+  <div id="masthead" class="course-reserve-masthead">
+    <% create_course %>
+    <h1>Course reserve list: <%= @course_info.id %></h1>
+    <dl class='dl-horizontal dl-invert'>
+      <dt>Course</dt>
+      <dd><%= "#{@course_info.id} -- #{@course_info.name}" %></dd>
+      <dt>Instructor</dt>
+      <dd><%= @course_info.instructor %></dd>
+    </dl>
+    <p>
+      <a href="#" class="disabled">Find reserve list for another course</a>
+    </p>
+  </div>
 </div>

--- a/app/views/catalog/mastheads/_databases.html.erb
+++ b/app/views/catalog/mastheads/_databases.html.erb
@@ -1,6 +1,8 @@
-<div id="masthead" class="databases-masthead">
-  <h1>Databases</h1>
-  <p>Licensed resources are for the non-profit educational use of Stanford University. Use of these resources is governed by copyright law and individual license agreements. Systematic downloading, distributing, or retaining substantial portions of information is prohibited.</p>
-  <p><%= link_to "Selected databases", selected_databases_path %> | <%= link_to "Connect from off campus", "http://library.stanford.edu/using/connect-campus" %> | <%= link_to "Report a connection problem", "http://library.stanford.edu/ask/email/connection-problems" %></p>
-  <%= render "catalog/database_prefix" %>
+<div id="masthead-container">
+  <div id="masthead" class="databases-masthead">
+    <h1>Databases</h1>
+    <p>Licensed resources are for the non-profit educational use of Stanford University. Use of these resources is governed by copyright law and individual license agreements. Systematic downloading, distributing, or retaining substantial portions of information is prohibited.</p>
+    <p><%= link_to "Selected databases", selected_databases_path %> | <%= link_to "Connect from off campus", "http://library.stanford.edu/using/connect-campus" %> | <%= link_to "Report a connection problem", "http://library.stanford.edu/ask/email/connection-problems" %></p>
+    <%= render "catalog/database_prefix" %>
+  </div>
 </div>

--- a/app/views/catalog/mastheads/_selected_databases.html.erb
+++ b/app/views/catalog/mastheads/_selected_databases.html.erb
@@ -1,5 +1,7 @@
-<div id="masthead" class="selected-databases-masthead">
-  <h1>Selected Databases</h1>
-  <p>If you're not sure where to start your research, try one of these databases.</p>
-  <p><%= link_to "All databases", databases_path %> | <%= link_to "Connect from off campus", "http://library.stanford.edu/using/connect-campus" %> | <%= link_to "Report a connection problem", "http://library.stanford.edu/ask/email/connection-problems" %></p>
+<div id="masthead-container">
+  <div id="masthead" class="selected-databases-masthead">
+    <h1>Selected Databases</h1>
+    <p>If you're not sure where to start your research, try one of these databases.</p>
+    <p><%= link_to "All databases", databases_path %> | <%= link_to "Connect from off campus", "http://library.stanford.edu/using/connect-campus" %> | <%= link_to "Report a connection problem", "http://library.stanford.edu/ask/email/connection-problems" %></p>
+  </div>
 </div>


### PR DESCRIPTION
Fixes #442 

I opted to add the `#masthead-container` div in the individual masthead containers rather than once in `searchworks.html.erb` so that we weren't rendering another empty div on most pages.

![screen shot 2014-07-17 at 5 49 06 pm](https://cloud.githubusercontent.com/assets/1656824/3620144/34b2e12e-0dfc-11e4-9aa0-c89bbc1a543f.png)
