### PR TITLE
Use accordion section style markup for selected database online section.

### DIFF
--- a/app/assets/stylesheets/modules/accordion-sections.css.scss
+++ b/app/assets/stylesheets/modules/accordion-sections.css.scss
@@ -66,6 +66,9 @@
 .accordion-section.online {
   .header {
     background-color: $sul-access-online-bg;
+    &.selected-database {
+      width: 10.7em;
+    }
   }
 
   .details {

--- a/app/views/selected_databases/index.html.erb
+++ b/app/views/selected_databases/index.html.erb
@@ -14,11 +14,22 @@
             <div class="panel-body">
               <h3><%= link_to(database['title_245a_display'], catalog_path(database[:id])) %></h3>
               <span class="subjects">(<%= database.selected_database_subjects.join(', ') %>)</span>
-              <p>
-                <span class="label label-success">Search database</span>
-                <%= database.index_links.first.text.html_safe %>
-              </p>
-              <p><%= database.selected_database_description %></p>
+              <div class="accordion-section online">
+                <a class="header selected-database" data-accordion-section-target=".<%= database[:id] %>-selected-database">
+                  Search database (<%= database.index_links.all.length %>) <i class="fa fa-caret-right"></i>
+                </a>
+                <span class="snippet <%= database[:id] %>-selected-database-snippet" data-behavior="trunk8">
+                  <%= database.index_links.first.text.html_safe %>
+                </span>
+                <div class="details <%= database[:id] %>-selected-database">
+                  <ul class="links">
+                    <% database.index_links.each do |link| %>
+                      <li><%= link.text.html_safe %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              </div>
+              <div><%= database.selected_database_description %></div>
             </div>
           </div>
         <% end %>

--- a/spec/features/access_points/selected_databases_spec.rb
+++ b/spec/features/access_points/selected_databases_spec.rb
@@ -23,7 +23,7 @@ feature "Selected Databases Access Point" do
       within(first(".panel")) do
         expect(page).to have_css("h3 a", text: /Selected Database \d/)
         expect(page).to have_css("span.subjects", text: /\(.*\)/)
-        expect(page).to have_css("span.label.label-success", text: "Search database")
+        expect(page).to have_css("a.header", text: "Search database (1)")
         expect(page).to have_css("a", text: /\.stanford\.edu/)
       end
     end


### PR DESCRIPTION
Closes #465 in conjunction with previously accepted PR to handle heading.

![selected-databases](https://cloud.githubusercontent.com/assets/96776/3623175/4b05c648-0e48-11e4-9f25-fbe2c346247d.png)
