### PR TITLE
Use collection title from results in the facet breadcrumb.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,7 +71,7 @@ class CatalogController < ApplicationController
     # facet bar
     config.add_facet_field "db_az_subject", :label => "Database topic", collapse: false, show: false, limit: 21
     config.add_facet_field "access_facet", :label => "Access"
-    config.add_facet_field "collection", :label => "Collection", :show => false
+    config.add_facet_field "collection", label: "Collection", show: false, helper_method: :collection_breadcrumb_value
     config.add_facet_field "collection_type", :label => "Collection type", :show => false
     config.add_facet_field "format_main_ssim", :label => "Resource type", partial: "resource_type_facet", limit: 100
     config.add_facet_field "format_physical_ssim", :label => "Physical format", limit: 20

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -12,4 +12,15 @@ module CollectionHelper
   def collections_search_params
     { f: { collection_type: ["Digital Collection"] } }
   end
+
+  def collection_breadcrumb_value(collection_id)
+    if @document_list.present? && @document_list.first.index_parent_collections.present?
+      collection = @document_list.first.index_parent_collections.find do |coll|
+        coll[:id] == collection_id
+      end
+      return presenter(collection).document_heading if collection.present?
+    end
+    collection_id
+  end
+
 end

--- a/spec/features/blacklight_customizations/breadcrumb_spec.rb
+++ b/spec/features/blacklight_customizations/breadcrumb_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "Breadcrumb Customizations", type: :feature do
+  describe "for collections" do
+    it "should display the title of the collection and not the ID" do
+      visit root_path
+      fill_in 'q', with: '29'
+      click_button 'search'
+
+      click_link '1 - 1 of 1 item online'
+
+      within('.breadcrumb') do
+        expect(page).to have_css('.filterValue', text: 'Image Collection1')
+        expect(page).to_not have_content('29')
+      end
+    end
+  end
+end

--- a/spec/fixtures/solr_documents/mf774fs2413.yml
+++ b/spec/fixtures/solr_documents/mf774fs2413.yml
@@ -6,6 +6,8 @@
 :format_main_ssim: Image
 :collection:
   - 29
+:collection_with_title:
+  - "29 -|- Image Collection1"
 :modsxml: <%= mods_everything %>
 :pub_date: 2014
 :beginning_year_isi: 2000

--- a/spec/helpers/collection_helper_spec.rb
+++ b/spec/helpers/collection_helper_spec.rb
@@ -33,4 +33,24 @@ describe CollectionHelper do
       expect(collection_members_enumeration(no_collection_doc)).to be_nil
     end
   end
+  describe "#collection_breadcrumb_value" do
+    it "should return the collection name when present in the @document_list" do
+      helper.stub(:presenter).and_return(
+        OpenStruct.new(document_heading: 'Title2')
+      )
+      @document_list = [
+        SolrDocument.new(collection: ['12345', '54321'], collection_with_title: ['12345 -|- Title1', '54321 -|- Title2'])
+      ]
+      expect(helper.send(:collection_breadcrumb_value, '54321')).to eq 'Title2'
+    end
+    it "should return the ID if there is no @documen_list" do
+      expect(helper.send(:collection_breadcrumb_value, '54321')).to eq '54321'
+    end
+    it "should return the ID if there are no matching collections in the @document_list" do
+      @document_list = [
+        SolrDocument.new(collection: ['12345', '54321'], collection_with_title: ['12345 -|- Title1', '54321 -|- Title2'])
+      ]
+      expect(helper.send(:collection_breadcrumb_value, '11111')).to eq '11111'
+    end
+  end
 end

--- a/spec/integration/external-data/breadcrumb_spec.rb
+++ b/spec/integration/external-data/breadcrumb_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe "Breadcrumb", type: :feature, :"data-integration" => true do
+  describe "for collections" do
+    it "should display the title of the collection and not the ID" do
+      visit catalog_path('6780453')
+
+      click_link '1 - 20 of 48 items online'
+
+      within('.breadcrumb') do
+        expect(page).to have_css('.filterValue', text: 'The Reid W. Dennis Collection of California Lithographs')
+        expect(page).to_not have_content('6780453')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will still return the ID on the zero results page, otherwise we would need to make an additional call to solr to get the title.
#### Before

---

![breadcrumb-before](https://cloud.githubusercontent.com/assets/96776/3631194/df332aa2-0eb3-11e4-82a5-e497164a178c.png)
#### After

---

![breadcrumb-after](https://cloud.githubusercontent.com/assets/96776/3631196/e13ddbb2-0eb3-11e4-9776-c48a90cc371b.png)
