### PR TITLE
Change cursor to 'wait' when turbolinks requests are being made.

### DIFF
--- a/app/assets/javascripts/jquery.turbolinks-cursor.js
+++ b/app/assets/javascripts/jquery.turbolinks-cursor.js
@@ -1,0 +1,7 @@
+$(document).on('page:before-change', function(){
+  $('body').css('cursor', 'wait');
+});
+
+$(document).on('page:change', function(){
+  $('body').css('cursor', 'auto');
+});


### PR DESCRIPTION
Closes #492 

![turbolinks-cursor](https://cloud.githubusercontent.com/assets/96776/3631717/23d8af28-0eba-11e4-9e99-b1924bba2fd0.gif)
