### PR TITLE
Removes <a> tags from button dropdowns in search results

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -1,14 +1,13 @@
 <% if show_sort_and_per_page? and !blacklight_config.per_page.blank? %>
-
   <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
-<div id="per_page-dropdown" class="btn-group">
-  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
-    <%= link_to(t(:'blacklight.search.per_page.button_label_html', :count => current_per_page), "#") %> <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu" role="menu">
-    <%- per_page_options_for_select.each do |(label, count)| %>
-      <li><%= link_to(label, url_for(params_for_search(:per_page => count))) %></li>
-    <%- end -%>
-  </ul>
-</div>
+  <div id="per_page-dropdown" class="btn-group">
+    <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
+      <%= t(:'blacklight.search.per_page.button_label_html', :count => current_per_page).html_safe %> <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <%- per_page_options_for_select.each do |(label, count)| %>
+        <li><%= link_to(label, url_for(params_for_search(:per_page => count))) %></li>
+      <%- end -%>
+    </ul>
+  </div>
 <% end %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,13 +1,13 @@
 <% if show_sort_and_per_page? and !active_sort_fields.blank? %>
-<div id="sort-dropdown" class="btn-group">
-  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
-      <%= link_to(t('blacklight.search.sort.label_html', :field =>current_sort_field.label).html_safe, "#") %> <span class="caret"></span>
-  </button>
+  <div id="sort-dropdown" class="btn-group">
+    <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
+      <%= t('blacklight.search.sort.label_html', :field =>current_sort_field.label).html_safe %> <span class="caret"></span>
+    </button>
 
-  <ul class="dropdown-menu" role="menu">
-    <%- active_sort_fields.each do |sort_key, field| %>
-      <li><%= link_to(field.label, url_for(params_for_search(:sort => sort_key))) %></li>
-    <%- end -%>
-  </ul>
-</div>
+    <ul class="dropdown-menu" role="menu">
+      <%- active_sort_fields.each do |sort_key, field| %>
+        <li><%= link_to(field.label, url_for(params_for_search(:sort => sort_key))) %></li>
+      <%- end -%>
+    </ul>
+  </div>
 <% end %>

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -6,7 +6,7 @@
       <span class="hidden-xs hidden-sm">
         <%= render_view_type_group_icon document_index_view_type %>
       </span>
-      <%= link_to t('blacklight.search.view.label', :field =>current_sort_field.label).html_safe, '#' %>
+      <%= t('blacklight.search.view.label', :field =>current_sort_field.label).html_safe %>
       <span class="caret"></span>
     </button>
 

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -15,7 +15,7 @@ feature "Results Toolbar", js: true do
         expect(page).to have_css("span.page_entries", text: /1 - 20/, visible: true)
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: /Next/, visible: true)
       end
-      expect(page).to have_css("div#view-type-dropdown a")
+      expect(page).to have_css("div#view-type-dropdown button.dropdown-toggle")
       expect(page).to have_css("div#sort-dropdown", text: "Sort by relevance", visible: true)
       expect(page).to have_css("#select_all-dropdown", text: "Select all")
       expect(page).to_not have_css("a", text: /Cite/)

--- a/spec/features/brief_view_spec.rb
+++ b/spec/features/brief_view_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 feature "Brief View" do
   scenario "Search results", js: true do
     visit catalog_index_path f: {format: ["Book"]}
-    page.find('#view-type-dropdown button.dropdown-toggle a').click
+    page.find('#view-type-dropdown button.dropdown-toggle').click
     page.find('#view-type-dropdown .dropdown-menu li a.view-type-brief').click
 
     expect(page).to have_css("i.fa.fa-align-justify")

--- a/spec/features/gallery_view_spec.rb
+++ b/spec/features/gallery_view_spec.rb
@@ -4,7 +4,7 @@ feature "Gallery View" do
   scenario "Search results", js: true do
     pending("Passes locally, not on Travis.") if ENV['CI']
     visit catalog_index_path f: {format: ["Book"]}
-    page.find('#view-type-dropdown button.dropdown-toggle a').click
+    page.find('#view-type-dropdown button.dropdown-toggle').click
     page.find('#view-type-dropdown .dropdown-menu li a.view-type-gallery').click
 
     expect(page).to have_css("i.fa.fa-th")


### PR DESCRIPTION
Closes #540 

---

![image](https://cloud.githubusercontent.com/assets/302258/3678721/05779e72-129d-11e4-97d3-2df9a1e83e5b.png)
