### PR TITLE
Don't show any page entry info when we don't have any pagination.

### DIFF
--- a/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -18,7 +18,7 @@
   <%# #render checks if total_pages > 1, so we can't put our fallback
   in here .. -%>
   <%= paginator.render do -%>
-    <div class="page_links">
+    <div class="page_links pull-left">
       <%= prev_page_tag %>
       <span class="page_entries">
         <%= page_entries_info %>
@@ -26,10 +26,4 @@
       <%= next_page_tag %>
     </div>
   <% end -%>
-<% else -%>
-    <div class="page_links">
-      <span class="page_entries">
-        <%= page_entries_info %>
-      </span>
-    </div>
 <% end -%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,8 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    entry_name:
+      default: 'result'
     home:
       title: 'SearchWorks : Stanford University Libraries catalog'
     search:
@@ -28,6 +30,7 @@ en:
         pages:
           one: '%{start_num} - %{end_num}'
           other: '%{start_num} - %{end_num}'
+        single_item_found: ''
         no_items_found: "<h2>No results found in catalog</h2>"
     bookmarks:
       add:

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 feature "Results Toolbar", js: true do
-  before do
+  scenario "should have desktop tools visible" do
     visit root_path
     fill_in "q", with: ''
     click_button 'search'
-  end
-  scenario "should have desktop tools visible" do
+
     within "#sortAndPerPage" do
       within "div.page_links" do
         expect(page).to have_css("a.btn.btn-sul-toolbar.disabled", text: /Previous/, visible: true)
@@ -20,6 +19,28 @@ feature "Results Toolbar", js: true do
       expect(page).to have_css("#select_all-dropdown", text: "Select all")
       expect(page).to_not have_css("a", text: /Cite/)
       expect(page).to_not have_css("button", text: /Send/)
+    end
+  end
+  scenario "pagination links for single items should not have any number of results info" do
+    visit root_path
+    fill_in "q", with: '24'
+    click_button 'search'
+
+    within('.sul-toolbar') do
+      expect(page).to_not have_css('.page_links')
+      expect(page).to_not have_content('1 entry')
+    end
+  end
+  scenario "pagination links for multiple items but no pages should not have any number of results info" do
+    visit root_path
+    fill_in "q", with: '34'
+    click_button 'search'
+
+    expect(page).to have_css('h2', text: '4 results')
+
+    within('.sul-toolbar') do
+      expect(page).to_not have_css('.page_links')
+      expect(page).to_not have_content('1 - 4')
     end
   end
 end


### PR DESCRIPTION
Closes #528 

Also changing underlying (now unused) i18n strings in case they're used anywhere else around the app unbeknownst to us.
#### One result

---

![one-result](https://cloud.githubusercontent.com/assets/96776/3697138/6598187e-139f-11e4-988a-1484b93575af.png)
#### Multiple results (no paging)

---

![multi-results-no-pages](https://cloud.githubusercontent.com/assets/96776/3697140/6e0b221c-139f-11e4-805f-4d9436b123bf.png)
#### Pagination

---

![pages](https://cloud.githubusercontent.com/assets/96776/3697141/74bcb9f4-139f-11e4-9dff-6fc033c8f19a.png)
