### PR TITLE
fix checkbox placement, aligns buttons for js and non-js

### DIFF
--- a/app/assets/stylesheets/modules/gallery-view.css.scss
+++ b/app/assets/stylesheets/modules/gallery-view.css.scss
@@ -70,20 +70,23 @@
     height: 30px;
     width: 100%;
     position: absolute;
-    bottom: 6px;
+    bottom: 2px;
     display: inline-block;
 
     .preview-button {
       position: absolute;
-      bottom: 0px;
       margin-left: 8px;
       margin-bottom: 3px;
     }
 
     form {
       position: absolute;
-      left: 120px;
+      left: 106px;
       font-size: .9em;
+
+      .toggle_bookmark {
+        bottom: 4px;
+      }
     }
   }
   .stacks-image {


### PR DESCRIPTION
Fixes #575 

Does not position from right as it does not work with non-js.
Also changes positioning so that buttons are aligned for non-js browsers.
# JS

![screen shot 2014-07-28 at 11 49 30 am](https://cloud.githubusercontent.com/assets/1656824/3725405/5e649924-1688-11e4-987a-d4119d68e450.png)
# Non-JS (Firefox)

![screen shot 2014-07-28 at 11 49 22 am](https://cloud.githubusercontent.com/assets/1656824/3725408/6e5e6c60-1688-11e4-9d00-44933b242161.png)
