### PR TITLE
modifies preview display to be consistent with list view

### DIFF
--- a/app/assets/stylesheets/modules/item-preview.css.scss
+++ b/app/assets/stylesheets/modules/item-preview.css.scss
@@ -62,6 +62,13 @@
 
   .preview-content {
     overflow: auto;
+
+    dt {
+      width: auto;
+    }
+    dd {
+      margin: 0;
+    }
   }
 
   .preview-img {

--- a/app/assets/stylesheets/modules/results-documents.css.scss
+++ b/app/assets/stylesheets/modules/results-documents.css.scss
@@ -6,16 +6,6 @@
     h3.index_title {
       @include h3-index-title;
     }
-    dt {
-      width: auto;
-    }
-    dd {
-      margin: 0;
-    }
-    .document-metadata {
-      list-style-type: none;
-      padding-left: 0;
-    }
 
     .main-title-date {
       color: $sul-main-title-date-color;
@@ -31,16 +21,28 @@
       border: 1px solid #ddd;
       display: none;
     }
+  }
 
-    .stacks-image {
-      max-height: 200px;
-      max-width: 200px;
-    }
+  dt {
+    width: auto;
+  }
+  dd {
+    margin: 0;
   }
 
   .cursor-pointer {
     cursor: pointer;
   }
+}
+
+.document-metadata {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.stacks-image {
+  max-height: 200px;
+  max-width: 200px;
 }
 
 #content {

--- a/app/views/catalog/_index_file.html.erb
+++ b/app/views/catalog/_index_file.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "mods_search_results_document_fields", :locals => { :document => document } %>
+<%= render :partial => "catalog/mods_search_results_document_fields", :locals => { :document => document } %>
 
 <dl class="dl-horizontal dl-invert">
   <% if document.extent.present? %>
@@ -15,4 +15,4 @@
   <% end %>
 </dl>
 
-<%= render :partial => "search_results_accordion_sections", :locals => { :document => document } %>
+<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>

--- a/app/views/catalog/_index_image.html.erb
+++ b/app/views/catalog/_index_image.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "mods_search_results_document_fields", :locals => { :document => document } %>
+<%= render :partial => "catalog/mods_search_results_document_fields", :locals => { :document => document } %>
 
 <dl class="dl-horizontal dl-invert">
   <% if document.extent.present? %>
@@ -16,4 +16,4 @@
   <% end %>
 </dl>
 
-<%= render :partial => "search_results_accordion_sections", :locals => { :document => document } %>
+<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>

--- a/app/views/preview/_show_file.html.erb
+++ b/app/views/preview/_show_file.html.erb
@@ -1,20 +1,3 @@
 <% document ||= @document %>
 
-<%= render :partial => "catalog/mods_search_results_document_fields", :locals => { :document => document } %>
-
-<dl class="dl-horizontal dl-invert">
-  <% if document.extent.present? %>
-    <dt><%= document.extent_label %></dt>
-    <dd><%= document.extent %></dd>
-  <% end %>
-  <% if document.index_parent_collections.present? %>
-    <dt>Collection</dt>
-    <dd>
-      <% document.index_parent_collections.each do |collection| %>
-        <%= link_to(presenter(collection).document_heading, catalog_path(collection))%>
-      <% end %>
-    </dd>
-  <% end %>
-</dl>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
+<%= render partial: "catalog/index_file", locals: { document: document } %>

--- a/app/views/preview/_show_file_collection.html.erb
+++ b/app/views/preview/_show_file_collection.html.erb
@@ -1,18 +1,3 @@
 <% document ||= @document %>
 
-<%= render :partial => "catalog/mods_search_results_document_fields", :locals => { :document => document } %>
-
-<dl class="dl-horizontal dl-invert">
-  <% if document.collection_members(rows: 3).present? %>
-    <dt>Digital content</dt>
-    <dd><%= link_to_collection_members(pluralize(document.collection_members.total, 'item'), document) %></dd>
-  <% end %>
-
-  <% if document.extent.present? %>
-    <dt><%= document.extent_label %></dt>
-    <dd><%= document.extent %></dd>
-  <% end %>
-</dl>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
-<%= render 'catalog/file_collection_members' %>
+<%= render partial: "catalog/index_file_collection", locals: { document: document } %>

--- a/app/views/preview/_show_header_default.html.erb
+++ b/app/views/preview/_show_header_default.html.erb
@@ -1,4 +1,4 @@
-<h4>
+<h3>
   <%= render_resource_icon document[document.format_key] %>
   <%= link_to_document document, :label => get_main_title(document) %>
-</h4>
+</h3>

--- a/app/views/preview/_show_image.html.erb
+++ b/app/views/preview/_show_image.html.erb
@@ -1,27 +1,6 @@
 <% document ||= @document %>
 
-<div class="row">
-  <div class="col-md-6">
-    <img class="preview-img" src="<%= @document.image_urls(:large).first %>">
-  </div>
-  <div class="col-md-6">
-    <%= render :partial => "catalog/mods_search_results_document_fields", :locals => { :document => document } %>
-    <dl class="dl-horizontal dl-invert">
-      <% if document.extent.present? %>
-        <dt><%= document.extent_label %></dt>
-        <dd><%= document.extent %></dd>
-      <% end %>
-
-      <% if document.index_parent_collections.present? %>
-        <dt>Collection</dt>
-        <dd>
-          <% document.index_parent_collections.each do |collection| %>
-            <%= link_to(presenter(collection).document_heading, catalog_path(collection))%>
-          <% end %>
-        </dd>
-      <% end %>
-    </dl>
-  </div>
+<div class="document-thumbnail">
+  <img class="stacks-image" src="<%= @document.image_urls(:large).first %>">
 </div>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
+<%= render partial: "catalog/index_image", locals: { document: document } %>

--- a/app/views/preview/_show_image_collection.html.erb
+++ b/app/views/preview/_show_image_collection.html.erb
@@ -1,21 +1,3 @@
 <% document ||= @document %>
 
-<%= render :partial => "catalog/mods_search_results_document_fields", :locals => { :document => document } %>
-
-<dl class="dl-horizontal dl-invert">
-  <% if document.collection_members.present? %>
-    <dt>Digital content</dt>
-    <dd><%= link_to_collection_members(pluralize(document.collection_members.total, 'item'), document) %></dd>
-  <% end %>
-
-  <% if document.extent.present? %>
-    <dt><%= document.extent_label %></dt>
-    <dd><%= document.extent %></dd>
-  <% end %>
-</dl>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
-
-<% if document.collection_members.present? %>
-  <%= render :partial => "image_collection_filmstrip", :locals => { :collection_document => document } %>
-<% end %>
+<%= render partial: "catalog/index_image_collection", locals: { document: document } %>

--- a/app/views/preview/_show_marc.html.erb
+++ b/app/views/preview/_show_marc.html.erb
@@ -1,29 +1,7 @@
 <% document ||= @document %>
 
-<div class="row">
-  <div class="col-sm-2">
-    <%= render_cover_image(@document) %>
-  </div>
-  <div class="col-sm-10">
-    <%= render :partial => "catalog/marc_search_results_document_fields", :locals => { :document => document } %>
-
-    <dl class="dl-horizontal dl-invert">
-      <% if document.is_a_database? %>
-        <% if document[:db_az_subject].present? %>
-          <dt>Database topics</dt>
-          <dd>
-            <%= document[:db_az_subject].map do |subject| %>
-              <% link_to(subject, catalog_index_path(f: {db_az_subject: [subject], document.format_key => ['Database']})) %>
-            <% end.join('; ').html_safe %>
-          </dd>
-        <% end %>
-      <% end %>
-      <% if document.extent.present? %>
-        <dt><%= document.extent_label %></dt>
-        <dd><%= document.extent %></dd>
-      <% end %>
-    </dl>
-  </div>
+<div class="document-thumbnail">
+  <%= render_cover_image(@document) %>
 </div>
 
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
+<%= render partial: "catalog/index_marc", locals: { document: document } %>

--- a/app/views/preview/_show_merged_file_collection.html.erb
+++ b/app/views/preview/_show_merged_file_collection.html.erb
@@ -1,26 +1,3 @@
 <% document ||= @document %>
 
-<%= render :partial => "catalog/marc_search_results_document_fields", :locals => { :document => document } %>
-
-<dl class="dl-horizontal dl-invert">
-  <% if document.collection_members(rows: 3).present? %>
-    <dt>Digital content</dt>
-    <dd><%= link_to_collection_members(pluralize(document.collection_members.total, 'item'), document) %></dd>
-  <% end %>
-
-  <% if document.extent.present? %>
-    <dt><%= document.extent_label %></dt>
-    <dd><%= document.extent %></dd>
-  <% end %>
-
-  <% if document.index_links.finding_aid.present? %>
-    <dt>Finding aid</dt>
-    <dd><%= document.index_links.finding_aid.first.text.html_safe %></dd>
-  <% end %>
-</dl>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
-
-<% if document.collection_members(rows: 3).present? %>
-  <%= render 'catalog/file_collection_members' %>
-<% end %>
+<%= render partial: "catalog/index_merged_file_collection", locals: { document: document } %>

--- a/app/views/preview/_show_merged_image.html.erb
+++ b/app/views/preview/_show_merged_image.html.erb
@@ -1,27 +1,3 @@
 <% document ||= @document %>
 
-<div class="row">
-  <div class="col-md-6">
-    <img class="preview-img" src="<%= document.image_urls(:large).first %>">
-  </div>
-  <div class="col-md-6">
-    <%= render :partial => "catalog/marc_search_results_document_fields", :locals => { :document => document } %>
-    <dl class="dl-horizontal dl-invert">
-      <% if document.extent.present? %>
-        <dt><%= document.extent_label %></dt>
-        <dd><%= document.extent %></dd>
-      <% end %>
-
-      <% if document.index_parent_collections.present? %>
-        <dt>Collection</dt>
-        <dd>
-          <% document.index_parent_collections.each do |collection| %>
-            <%= link_to(presenter(collection).document_heading, catalog_path(collection))%>
-          <% end %>
-        </dd>
-      <% end %>
-    </dl>
-  </div>
-</div>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
+<%= render partial: "catalog/index_merged_image", locals: { document: document } %>

--- a/app/views/preview/_show_merged_image_collection.html.erb
+++ b/app/views/preview/_show_merged_image_collection.html.erb
@@ -1,26 +1,3 @@
 <% document ||= @document %>
 
-<%= render :partial => "catalog/marc_search_results_document_fields", :locals => { :document => document } %>
-
-<dl class="dl-horizontal dl-invert">
-  <% if document.collection_members.present? %>
-    <dt>Digital content</dt>
-    <dd><%= link_to_collection_members(pluralize(document.collection_members.total, 'item'), document) %></dd>
-  <% end %>
-
-  <% if document.extent.present? %>
-    <dt><%= document.extent_label %></dt>
-    <dd><%= document.extent %></dd>
-  <% end %>
-
-  <% if document.index_links.finding_aid.present? %>
-    <dt>Finding aid</dt>
-    <dd><%= document.index_links.finding_aid.first.text.html_safe %></dd>
-  <% end %>
-</dl>
-
-<%= render :partial => "catalog/search_results_accordion_sections", :locals => { :document => document } %>
-
-<% if document.collection_members.present? %>
-  <%= render :partial => "image_collection_filmstrip", :locals => { :collection_document => document } %>
-<% end %>
+<%= render partial: "catalog/index_merged_image_collection", locals: { document: document } %>

--- a/app/views/preview/show.html.erb
+++ b/app/views/preview/show.html.erb
@@ -1,11 +1,3 @@
 <% document ||= @document %>
 
-<div class="col-md-12 show-preview">
-
-  <div id="document" class="document <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">
-    <div id="doc_<%= @document.id.to_s.parameterize %>">
-
-      <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
-    </div>
-  </div>
-</div>
+<%= render_document_partials @document, blacklight_config.view_config(:show).partials %>

--- a/spec/features/gallery_view_spec.rb
+++ b/spec/features/gallery_view_spec.rb
@@ -17,8 +17,10 @@ feature "Gallery View" do
     expect(page).to have_css("form.bookmark_toggle label.toggle_bookmark", text: "Select")
     expect(page).to have_css("label[for='toggle_bookmark_1']", count: 1)
     page.first("button.btn.docid-1").click
-    expect(page).to have_css("h4", text: "An object")
     expect(page).to have_css("label[for='toggle_bookmark_1']", count: 1)
-    expect(page).to have_css("li", text: "1990")
+    within ".preview-container" do
+      expect(page).to have_css("h3", text: "An object")
+      expect(page).to have_css("li", text: "1990")
+    end
   end
 end

--- a/spec/features/preview_spec.rb
+++ b/spec/features/preview_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 feature "Preview routes functionality" do
   scenario "at show route" do
     visit preview_path(1)
-    expect(page).to have_css("h4 a", text: "An object")
+    expect(page).to have_css("h3 a", text: "An object")
   end
 end
 


### PR DESCRIPTION
Fixes #411 

Preview content is now consistent with list view (default) search results view of an item. This should reduce the amount of duplicated code.

@jvine let me know your thoughts.

![screen shot 2014-07-29 at 2 55 22 pm](https://cloud.githubusercontent.com/assets/1656824/3742615/a4ccf72e-176b-11e4-86b7-5a3e14148869.png)
![screen shot 2014-07-29 at 2 57 37 pm](https://cloud.githubusercontent.com/assets/1656824/3742616/a70952b2-176b-11e4-9258-02ffe8cbb8a7.png)
![screen shot 2014-07-29 at 2 57 48 pm](https://cloud.githubusercontent.com/assets/1656824/3742617/a98ebfe0-176b-11e4-9318-868cd25a59fc.png)
![screen shot 2014-07-29 at 2 58 08 pm](https://cloud.githubusercontent.com/assets/1656824/3742620/ac23539c-176b-11e4-8b9e-a750bb614d8d.png)
![screen shot 2014-07-29 at 2 59 21 pm](https://cloud.githubusercontent.com/assets/1656824/3742622/af9621ee-176b-11e4-8133-a225da73599d.png)
