### PR TITLE
Split multiple items in a single dt/dd into multiple dds...

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -140,8 +140,7 @@ module MarcHelper
             temp_text << " #{relator_text.join(" ")}" unless relator_text.blank?
             vernacular = get_marc_vernacular(marc,field)
             temp_vern = "\"#{vernacular}\""
-            temp_text << "<br/>#{link_to h(vernacular), :q => temp_vern, :controller => 'catalog', :action => 'index', :search_field => 'search_author'}" unless vernacular.nil?
-            temp_text << "<br/>"
+            temp_text << "#{link_to h(vernacular), :q => temp_vern, :controller => 'catalog', :action => 'index', :search_field => 'search_author'}" unless vernacular.nil?
             contributors << temp_text
           end
         end
@@ -174,10 +173,10 @@ module MarcHelper
       end
     end
     return_text = ""
-    return_text << "<dt>Contributor</dt><dd>#{contributors.join}</dd>" unless contributors.blank?
+    return_text << "<dt>Contributor</dt><dd>#{contributors.join('</dd><dd>')}</dd>" unless contributors.blank?
     return_text << text unless text.blank?
-    return_text << "<dt>Related Work</dt><dd>#{related_works.join('<br/>')}</dd>" unless related_works.blank?
-    return_text << "<dt>Included Work</dt><dd>#{included_works.join('<br/>')}</dd>" unless included_works.blank?
+    return_text << "<dt>Related Work</dt><dd>#{related_works.join('</dd><dd>')}</dd>" unless related_works.blank?
+    return_text << "<dt>Included Work</dt><dd>#{included_works.join('</dd><dd>')}</dd>" unless included_works.blank?
     return_text.html_safe unless return_text.blank?
   end
 

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -4,15 +4,17 @@ module RecordHelper
     content_tag(:dt, label.gsub(":",""))
   end
 
-  def mods_display_content content
-    content_tag(:dd, link_urls_and_email(content).html_safe)
+  def mods_display_content values
+    Array[values].flatten.map do |value|
+      content_tag(:dd, link_urls_and_email(value).html_safe)
+    end.join.html_safe
   end
 
   def mods_record_field field
     if field.respond_to?(:label, :values) &&
        field.values.any?(&:present?)
       mods_display_label(field.label) +
-      mods_display_content(field.values.join)
+      mods_display_content(field.values)
     end
   end
 
@@ -25,11 +27,11 @@ module RecordHelper
   end
 
   def mods_display_name(names)
-    content_tag(:dd) do
-      names.map do |name|
-        "#{link_to(name.name, catalog_index_path(q: "\"#{name.name}\"", search_field: 'search_author'))}#{" (#{name.roles.join(', ')})" if name.roles.present?}"
-      end.join('<br/>').html_safe
-    end
+    names.map do |name|
+      content_tag(:dd) do
+        "#{link_to(name.name, catalog_index_path(q: "\"#{name.name}\"", search_field: 'search_author'))}#{" (#{name.roles.join(', ')})" if name.roles.present?}".html_safe
+      end
+    end.join.html_safe
   end
 
   def mods_subject_field(subjects)

--- a/app/views/catalog/_field_from_index.html.erb
+++ b/app/views/catalog/_field_from_index.html.erb
@@ -1,8 +1,7 @@
 <dt title="<%= fields[:label] %>"><%= fields[:label] %></dt>
-<dd>
-  <%= fields[:fields].join("<br/>").html_safe %>
-  <%- unless fields[:vernacular].nil? -%>
-    <br/>
-    <%= fields[:vernacular].join("<br/>").html_safe -%>
-  <%- end -%>
-</dd>
+<% fields[:fields].each do |field| %>
+  <dd><%= field %></dd>
+<% end if fields[:fields].present? %>
+<% fields[:vernacular].each do |field| %>
+  <dd><%= field %></dd>
+<% end if fields[:vernacular].present? %>

--- a/app/views/catalog/_field_from_marc.html.erb
+++ b/app/views/catalog/_field_from_marc.html.erb
@@ -1,13 +1,10 @@
 <dt title="<%= fields[:label] %>"><%= fields[:label] %></dt>
-<dd>
-  <%- unless fields[:fields].nil? -%>
-    <%- fields[:fields].each do |field| %>
-      <%= field[:field] %>
-      <%= "<br/>#{field[:vernacular]}".html_safe unless field[:vernacular].nil? %>
-      <%= options[:delimiter].html_safe if field != fields[:fields].last and options.has_key?(:delimiter) %>
-    <%- end -%>
-  <%- end -%>
-  <%- unless fields[:unmatched_vernacular].nil? -%>
-    <%= fields[:unmatched_vernacular].join("<br/>").html_safe -%>
-  <%- end -%>
-</dd>
+<% fields[:fields].each do |field| %>
+  <dd><%= field[:field] %></dd>
+  <% if field[:vernacular].present? %>
+    <dd><%= field[:vernacular] %></dd>
+  <% end %>
+<% end if fields[:fields].present? %>
+<% fields[:unmatched_vernacular].each do |field| %>
+  <dd><%= field %></dd>
+<% end if fields[:unmatched_vernacular].present? %>

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -161,6 +161,9 @@ describe MarcHelper do
     let(:contributor) { SolrDocument.new(marcxml: contributor_fixture) }
     let(:contributed_works) { SolrDocument.new(marcxml: contributed_works_fixture ) }
     let(:multi_role_contributor) { SolrDocument.new(marcxml: multi_role_contributor_fixture ) }
+    it "should return multiple dd elements when there are multiple values" do
+      expect(link_to_contributor_from_marc(contributor.to_marc)).to have_css('dd', count: 3)
+    end
     it "should display a fields with translated relator codes and raw RDA correctly" do
       data = link_to_contributor_from_marc(contributor.to_marc)
       data.should match(/>Contributor1<\/a> Performer</)
@@ -186,7 +189,7 @@ describe MarcHelper do
       works.should_not match(/act/)
     end
     it "should handle repeating subfield e" do
-       link_to_contributor_from_marc(multi_role_contributor.to_marc).should match(/\/a> actor\. director\.<br\/>/)
+       link_to_contributor_from_marc(multi_role_contributor.to_marc).should match(/\/a> actor\. director\.<\/dd>/)
     end
     it "should not display anything when no contributors are available" do
       link_to_contributor_from_marc(nil_document.to_marc).should be_nil

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -13,6 +13,9 @@ describe RecordHelper do
     it "should return correct content" do
       expect(helper.mods_display_content("hello, there")).to have_css("dd", text: "hello, there")
     end
+    it "should return multiple dd elements when a multi-element array is passed" do
+      expect(helper.mods_display_content(["hello", "there"])).to have_css("dd", count: 2)
+    end
   end
 
   describe "mods_record_field" do


### PR DESCRIPTION
...(instead of line-breaks).

This PR attempts to make this a global change for all repeating MARC/MODS fields that were perviously joined by line-breaks (although we may be missing some that'll crop-up over time).

Also, question for @jvine I have not added the `id` attribute to the `dt` and `dd` as in the desired output.  I wasn't sure if the ID was something you actually wanted (and I wasn't sure which identifier you were intending to place there if it needed to be explicit).

Closes #205 
### 571165

![815616-display](https://cloud.githubusercontent.com/assets/96776/3743305/5b296052-1776-11e4-8c4b-1dce17d91100.png)
![571165-markup](https://cloud.githubusercontent.com/assets/96776/3743304/5b290d28-1776-11e4-997f-07fca997970f.png)
### 815616

![571165-display](https://cloud.githubusercontent.com/assets/96776/3743307/5b2c5b68-1776-11e4-98f9-610f3af6b7bf.png)
![815616-markup](https://cloud.githubusercontent.com/assets/96776/3743306/5b2a0ad4-1776-11e4-9753-cbd116723b17.png)
### 485914

![485914-display](https://cloud.githubusercontent.com/assets/96776/3743309/5fdb76d0-1776-11e4-8954-e7f8e0bf2775.png)
![485914-markup](https://cloud.githubusercontent.com/assets/96776/3743308/5fda6c0e-1776-11e4-8895-e51a235eec9a.png)
### ps292jd8410

![ps292jd8410-display](https://cloud.githubusercontent.com/assets/96776/3743359/2dfc3d9c-1777-11e4-99f2-78ae0ed407d8.png)
![ps292jd8410-markup](https://cloud.githubusercontent.com/assets/96776/3743360/2dfcb600-1777-11e4-83f0-0dd8a41c6201.png)
