### PR TITLE
Swap dates_from_solr and MARC 264 on record view...

### DIFF
--- a/app/views/catalog/_dates_from_solr.html.erb
+++ b/app/views/catalog/_dates_from_solr.html.erb
@@ -13,8 +13,7 @@
 "latest_poss_year_isi"   => "Latest possible date",
 "production_year_isi"    => "Production date",
 "original_year_isi"      => "Original date",
-"copyright_year_isi"     => "Copyright date",
-"imprint_display"        => "Imprint"} %>
+"copyright_year_isi"     => "Copyright date"} %>
 <% doc_dates = dates.keys.map{|key| true if document[key] } %>
 <% unless doc_dates.blank? %>
   <% dates.each do |field, label| %>

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -1,12 +1,6 @@
 <% document ||= @document %>
 
-<%- new_publish = marc_264(document.to_marc) -%>
-<%- unless new_publish.blank? -%>
-  <%- new_publish.each do |label,values| -%>
-    <dt><%= label %></dt>
-    <dd><%= values.join("<br/>").html_safe %></dd>
-  <%- end -%>
-<%- end -%>
+<%= render 'catalog/dates_from_solr' %>
 
 <% title_translation = get_data_with_label_from_marc(document.to_marc, "Title Translation", '242') %>
 <% unless title_translation.nil? %>

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -54,7 +54,18 @@
       <% end %>
     <% end %>
 
-    <%= render 'catalog/dates_from_solr' %>
+    <% if (new_publish = marc_264(document.to_marc)).present? %>
+      <% new_publish.each do |label,values| %>
+        <dt><%= label %></dt>
+        <% values.each do |value| %>
+          <dd><%= value %></dd>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if (imprint = get_data_with_label(document, "Imprint", 'imprint_display')).present? %>
+      <%= render "catalog/field_from_index", :fields => imprint %>
+    <% end %>
 
     <%- physical_desc = get_data_with_label(document, "Physical description", 'physical')%>
     <%- unless physical_desc.nil? -%>

--- a/spec/views/catalog/record/_marc_bibliographic.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_bibliographic.html.erb_spec.rb
@@ -33,4 +33,20 @@ describe "catalog/record/_marc_bibliographic.html.erb" do
       expect(rendered).to have_css("dd", text: "Most responsible person ever")
     end
   end
+  describe "dates from solr" do
+    before do
+      assign(:document, SolrDocument.new(marcxml: metadata1, publication_year_isi: '1234', other_year_isi: '4321', copyright_year_isi: '5678'))
+      render
+    end
+    it "should include dates from solr" do
+      expect(rendered).to have_css('dt', text: 'Publication date')
+      expect(rendered).to have_css('dd', text: '1234')
+
+      expect(rendered).to have_css('dt', text: 'Date')
+      expect(rendered).to have_css('dd', text: '4321')
+
+      expect(rendered).to have_css('dt', text: 'Copyright date')
+      expect(rendered).to have_css('dd', text: '5678')
+    end
+  end
 end

--- a/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
@@ -27,4 +27,24 @@ describe "catalog/record/_marc_upper_metadata_items.html.erb" do
       expect(rendered).to have_css('dd a', text: "Name SubZ")
     end
   end
+  describe "Imprint" do
+    before do
+      assign(:document, SolrDocument.new(marcxml: marc_multi_series_fixture, imprint_display: ['Imprint Statement']))
+      render
+    end
+    it "should include the imprint statement" do
+      expect(rendered).to have_css('dt', text: "Imprint")
+      expect(rendered).to have_css('dd', text: "Imprint Statement")
+    end
+  end
+  describe "MARC 264" do
+    before do
+      assign(:document, SolrDocument.new(marcxml: single_marc_264_fixture))
+      render
+    end
+    it "should be rendered" do
+      expect(rendered).to have_css('dt', text: 'Production')
+      expect(rendered).to have_css('dd', text: 'SubfieldA SubfieldB')
+    end
+  end
 end


### PR DESCRIPTION
...(swapping between upper metadata and bibliographic sections).

Also removing imprint from dates_from_solr partial and keeping it in the upper metadata section.

Closes #573 
### 10446739
#### Before
## ![10446739-before](https://cloud.githubusercontent.com/assets/96776/3770625/bb91b576-18ec-11e4-963e-c01c78b3f611.png)
#### After

![10446739-after](https://cloud.githubusercontent.com/assets/96776/3770626/bb91e762-18ec-11e4-893d-9cc162b55a15.png)
