### PR TITLE
Commit squash initializer and switch to using rails_config settings.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :log_level, :info
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml config/solr.yml config/secrets.yml config/initializers/squash_exceptions.rb}
+set :linked_files, %w{config/database.yml config/solr.yml config/secrets.yml}
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{bin config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
@@ -57,3 +57,5 @@ namespace :deploy do
   end
 
 end
+
+before 'deploy:publishing', 'squash:write_revision'

--- a/config/initializers/squash_exceptions.rb
+++ b/config/initializers/squash_exceptions.rb
@@ -1,0 +1,5 @@
+Squash::Ruby.configure :api_host => Settings.SQUASH_API_HOST,
+                       :api_key => Settings.SQUSH_API_KEY,
+                       :environment => Settings.SQUASH_ENVIRONMENT || Rails.env,
+                       :disabled => (Rails.env.development? || Rails.env.test?),
+                       :revision_file => File.join(Rails.root, 'REVISION')

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,5 @@ STACKS_URL: "https://stacks.stanford.edu/image"
 REQUESTS_URL: "https://host.example.com/requests/new"
 SSRC_REQUESTS_URL: "http://host.example.com/link.ssds_request_form"
 LIVE_LOOKUP_URL: "http://host.example.com/lookup.pl"
+SQUASH_API_HOST: 'http://squash-host.example.com'
+SQUASH_API_KEY: 'squash-api-key'


### PR DESCRIPTION
Changing how we configure squash.  This was currently causing issues w/ errors thrown in development complaining about the squash api key not being configured.
