### PR TITLE
Fixes issues with multiple previews in a page

### DIFF
--- a/app/assets/javascripts/jquery.preview-embed-browse.js
+++ b/app/assets/javascripts/jquery.preview-embed-browse.js
@@ -32,9 +32,9 @@
             arrowLeft;
         $previewTarget.addClass('preview').empty();
         PreviewContent.append(previewUrl, $previewTarget);
-        appendPointer($previewTarget);
         $previewTarget.css('display', 'inline-block');
         $previewTarget.append($closeBtn).show();
+        appendPointer($previewTarget);
         $triggerBtn.html('Close');
         attachPreviewEvents();
         $triggerBtn.addClass('preview-open');
@@ -44,7 +44,7 @@
         $target.append($arrow);
 
         var maxLeft = $target.width() - $arrow.width() - 1,
-        arrowLeft = parseInt($item.offset().left + ($item.width()/2) - 120);
+        arrowLeft = parseInt($item.offset().left + ($item.width()/2) - $target.offset().left);
 
         if (arrowLeft < 0) arrowLeft = 0;
         if (arrowLeft > maxLeft) arrowLeft = maxLeft;

--- a/app/assets/stylesheets/modules/image-collection-filmstrip.css.scss
+++ b/app/assets/stylesheets/modules/image-collection-filmstrip.css.scss
@@ -4,6 +4,7 @@
   background-color: #fafafa;
   bottom: 0;
   box-sizing: border-box;
+  margin-bottom: 10px;
   padding: 0 20px 20px 20px;
   position: relative;
   width: 100%;

--- a/app/views/catalog/_image_collection_filmstrip.html.erb
+++ b/app/views/catalog/_image_collection_filmstrip.html.erb
@@ -1,6 +1,6 @@
 <%
   show_preview ||= true
-  preview_container = 'preview-container-' + collection_document[:id]
+  preview_container = 'preview-filmstrip-container-' + collection_document[:id]
 %>
 
 <div class="col-md-12 image-filmstrip" data-thumb-width="100" data=thumb-height="100">

--- a/spec/features/image_collection_spec.rb
+++ b/spec/features/image_collection_spec.rb
@@ -64,7 +64,7 @@ feature "Image Collection" do
     expect(page).to have_css(".image-filmstrip")
 
     within "div.image-filmstrip" do
-      expect(page).to have_css("div.preview-container-29")
+      expect(page).to have_css("div.preview-filmstrip-container-29")
     end
 
   end


### PR DESCRIPTION
Closes #410, #585 
- Fixes bug where filmstrip preview interferes with embed-browse preview
- Fixes arrow positioning in embed-browse preview

---

![image](https://cloud.githubusercontent.com/assets/302258/3774599/025ba4fc-192f-11e4-9a49-f7a64e6eb565.png)
