### PR TITLE
Do not show INTERNET callnumbers.

### DIFF
--- a/lib/holdings/callnumber.rb
+++ b/lib/holdings/callnumber.rb
@@ -4,7 +4,8 @@ class Holdings
       @holding_info = holding_info
     end
     def present?
-      @holding_info.present?
+      @holding_info.present? &&
+      !(item_display[1] == "SUL" && item_display[2] == "INTERNET")
     end
     def browsable?
       item_display[8].present?

--- a/spec/lib/holdings/callnumber_spec.rb
+++ b/spec/lib/holdings/callnumber_spec.rb
@@ -13,11 +13,15 @@ describe Holdings::Callnumber do
   end
   describe "#present?" do
     let(:no_item_display) { Holdings::Callnumber.new('') }
+    let(:internet_callnumber) { Holdings::Callnumber.new(' -|- SUL -|- INTERNET -|- -|- -|-') }
     it "should be false when the item_display doesn't exist" do
       expect(no_item_display).to_not be_present
     end
     it "should return true when the item_display exists" do
       expect(callnumber).to be_present
+    end
+    it "should return false for INTERNET callnumbers" do
+      expect(internet_callnumber).to_not be_present
     end
   end
   describe "#on_order?" do


### PR DESCRIPTION
With the inclusion of SUL items we were getting a bunch of unnecessary location access panels for online-only materials as you can see in 8919378

![8919378-before](https://cloud.githubusercontent.com/assets/96776/3783197/3e493508-19aa-11e4-8998-5deaaab3fb73.png)

These have an item display field that looks like this

![8919378-item-display](https://cloud.githubusercontent.com/assets/96776/3783198/3e49dbfc-19aa-11e4-9864-39564dc42f91.png)

We can safely ignore this in the display.
