### PR TITLE
Add status text to availability display.

### DIFF
--- a/app/assets/javascripts/jquery.live-lookup.js
+++ b/app/assets/javascripts/jquery.live-lookup.js
@@ -20,6 +20,7 @@
             var dom_item = $("[data-barcode='" + live_data.barcode + "']");
             var target = $(dom_item.data('status-target'), dom_item);
             var current_location = $('.current-location', dom_item)
+            var status_text = target.next('.status-text');
             if ( live_data.current_location ) {
               current_location.html(live_data.current_location);
             }
@@ -29,6 +30,10 @@
             if ( live_data.due_date && target.hasClass('unknown') ) {
               target.removeClass('unknown');
               target.addClass('unavailable');
+              status_text.text(''); // The due date/current location acts as the status text at this point
+              if (target.attr('title')) {
+                target.attr('title', status_text.data('unavailable-text'));
+              }
               if ( dom_item.data('request-url') ) {
                 $('.request-link', dom_item).html("<a class='btn btn-info btn-xs' href='" + dom_item.data('request-url') + "'>Request</a>")
               }
@@ -36,6 +41,10 @@
             if ( !live_data.due_date && dom_item.length > 0  && target.hasClass('unknown')) {
               target.removeClass('unknown');
               target.addClass('available');
+              status_text.text(status_text.data('available-text'));
+              if (target.attr('title')) {
+                target.attr('title', status_text.data('available-text'));
+              }
             }
           }
       });

--- a/app/assets/stylesheets/modules/availability-icons.css.scss
+++ b/app/assets/stylesheets/modules/availability-icons.css.scss
@@ -16,6 +16,10 @@ $available-color: green;
     @extend .fa-truck;
     color: $available-color;
   }
+  .noncirc_page {
+    @extend .fa-truck;
+    color: darkorange;
+  }
   .unavailable {
     @extend .fa-times;
     color: #990000;

--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -43,6 +43,9 @@
               </td>
               <td data-live-lookup-id="<%= document[:id] %>" data-status-target=".availability-icon" data-barcode="<%= item.barcode %>" <%= "data-request-url='#{request_link(document, item)}'".html_safe if item.requestable? && !item.must_request? %>>
                 <i class="availability-icon <%= item.status.availability_class %>"></i>
+                <span data-available-text="<%= Constants::TRANSLATE_STATUS['available'] %>" data-unavailable-text="<%= Constants::TRANSLATE_STATUS['unavailable'] %>" class='status-text'>
+                  <%= item.status.status_text %>
+                </span>
                 <span class="current-location">
                   <% unless item.treat_current_location_as_home_location? %>
                     <%= item.current_location.name %>

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -40,7 +40,10 @@
                   <% end %>
                   <% location.items.each do |item| %>
                     <li data-status-target=".availability-icon" data-barcode="<%= item.barcode %>" <%= "data-request-url='#{request_link(document, item)}'".html_safe if item.requestable? && !item.must_request? %>>
-                      <i class="availability-icon <%= item.status.availability_class %>"></i>
+                      <i title="<%= item.status.status_text %>" class="availability-icon <%= item.status.availability_class %>"></i>
+                      <span data-available-text="<%= Constants::TRANSLATE_STATUS['available'] %>" data-unavailable-text="<%= Constants::TRANSLATE_STATUS['unavailable'] %>" class='status-text sr-only'>
+                        <%= item.status.status_text %>
+                      </span>
                       <%= item.callnumber %>
                       <div class="request-link pull-right">
                         <% if item.must_request? %>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -945,12 +945,12 @@ module Constants
    #"SUL" => "Stanford University Libraries"
    }
    TRANSLATE_STATUS = {
-     "available" => "available",
-     "page" => "request",
-     "unavailable" => "unavailable",
-     "noncirc" => "in-library use",
-     "unknown" => "status unknown",
-     "noncirc_page" => "request for in-library use"
+     "available" => "Available",
+     "page" => "Available",
+     "unavailable" => "Unavailable",
+     "noncirc" => "In-library use",
+     "unknown" => "Unknown",
+     "noncirc_page" => "In-library use"
    }
    HIDE_1ST_IND = %W(760 762 765 767 770 772 773 774 775 776 777 780 785 786 787)
    HIDE_1ST_IND0 = %W(541 542 561 583 590)

--- a/spec/lib/holdings/status_spec.rb
+++ b/spec/lib/holdings/status_spec.rb
@@ -10,7 +10,7 @@ describe Holdings::Status do
       expect(status.availability_class).to eq 'available'
     end
     it "should have the available status text" do
-      expect(status.status_text).to eq 'available'
+      expect(status.status_text).to eq 'Available'
     end
     it "should be available" do
       expect(status).to be_available
@@ -24,7 +24,7 @@ describe Holdings::Status do
       expect(status.availability_class).to eq 'noncirc'
     end
     it "should have the noncirc status text" do
-      expect(status.status_text).to eq 'in-library use'
+      expect(status.status_text).to eq 'In-library use'
     end
     it "should be noncirc" do
       expect(status).to be_noncirc
@@ -38,7 +38,7 @@ describe Holdings::Status do
       expect(status.availability_class).to eq 'noncirc_page'
     end
     it "should have the noncirc_page status text" do
-      expect(status.status_text).to eq 'request for in-library use'
+      expect(status.status_text).to eq 'In-library use'
     end
     it "should be noncirc_page" do
       expect(status).to be_noncirc_page
@@ -52,7 +52,7 @@ describe Holdings::Status do
       expect(status.availability_class).to eq 'page'
     end
     it "should have the page status text" do
-      expect(status.status_text).to eq 'request'
+      expect(status.status_text).to eq 'Available'
     end
     it "should be pageable" do
       expect(status).to be_pageable
@@ -66,7 +66,7 @@ describe Holdings::Status do
       expect(status.availability_class).to eq 'unavailable'
     end
     it "should have the unavailable status text" do
-      expect(status.status_text).to eq 'unavailable'
+      expect(status.status_text).to eq 'Unavailable'
     end
     it "should be unavailable" do
       expect(status).to be_unavailable
@@ -80,7 +80,7 @@ describe Holdings::Status do
       expect(status.availability_class).to eq 'unknown'
     end
     it "should have the unknown status text" do
-      expect(status.status_text).to eq 'status unknown'
+      expect(status.status_text).to eq 'Unknown'
     end
     it "should be unavailable" do
       expect(status).to be_unknown

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -44,6 +44,26 @@ describe "catalog/_index_location.html.erb" do
       expect(rendered).to have_css('tbody td i.page')
     end
   end
+  describe "status text" do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          id: '123',
+          item_display: [
+            '123 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123',
+            '321 -|- SPEC-COLL -|- STACKS -|- -|- -|- -|- -|- -|- ABC 321'
+          ]
+        )
+      )
+      render
+    end
+    it "should have unknown status text for items we'll be looking up" do
+      expect(rendered).to have_css('.status-text', text: 'Unknown')
+    end
+    it "should have explicit status text for items that we know the status" do
+      expect(rendered).to have_css('.status-text', text: 'In-library use')
+    end
+  end
   describe "multiple items in a location" do
     before do
       view.stub(:document).and_return(

--- a/spec/views/catalog/access_panels/_location.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_location.html.erb_spec.rb
@@ -21,6 +21,24 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       expect(rendered).to have_css(".panel-body")
     end
   end
+  describe "status text" do
+    before do
+      assign(:document, SolrDocument.new(
+        id: '123',
+        item_display: [
+          '123 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123',
+          '321 -|- SPEC-COLL -|- STACKS -|- -|- -|- -|- -|- -|- ABC 321'
+        ]
+      ))
+      render
+    end
+    it "should have screen-reader-only unknown status text for items we'll be looking up" do
+      expect(rendered).to have_css('.status-text.sr-only', text: 'Unknown')
+    end
+    it "should have explicit screen-reader-only status text for items that we know the status" do
+      expect(rendered).to have_css('.status-text.sr-only', text: 'In-library use')
+    end
+  end
   describe "current locations" do
     it "should be displayed" do
       assign(:document, SolrDocument.new(


### PR DESCRIPTION
Closes #567 
### Noncirc Page Icon
#### 10362045

![10362045-results](https://cloud.githubusercontent.com/assets/96776/3783909/0e91e01e-19b2-11e4-870a-ac040c142863.png)

![10362045-record-icon](https://cloud.githubusercontent.com/assets/96776/3783890/dbf14ed8-19b1-11e4-9b0e-a5f14e83e5e0.png)
### Status text
#### 3956413
##### Results

**Note:** Due date acts as status text
![3956413-results](https://cloud.githubusercontent.com/assets/96776/3783891/dbf162b0-19b1-11e4-95c0-a24ab0e16c31.gif)
##### Record

![3956413-record](https://cloud.githubusercontent.com/assets/96776/3783888/dbf0418c-19b1-11e4-891e-10e7da0f1969.gif)
#### 7861312
##### Results

![7861312-results](https://cloud.githubusercontent.com/assets/96776/3783892/dbf2c4c0-19b1-11e4-86a5-3d56b03c2d5e.gif)
##### Record

![7861312-record](https://cloud.githubusercontent.com/assets/96776/3783889/dbf06a90-19b1-11e4-8328-781a7b7edb5d.gif)
