### PR TITLE
change the way the 856 titles appear in stanford only links

### DIFF
--- a/app/models/concerns/marc_links.rb
+++ b/app/models/concerns/marc_links.rb
@@ -14,7 +14,7 @@ module MarcLinks
         link = process_link(link_field)
         if link.present?
           SearchWorks::Links::Link.new(
-            text: ["<a title='#{link[:title]}' href='#{link[:href]}'>#{link[:text]}</a>", "#{'(source: Casalini)' if link[:casalini_toc]}"].compact.join(' '),
+            text: ["<a title='#{link[:title]}' href='#{link[:href]}'>#{link[:text]}</a>", "#{'(source: Casalini)' if link[:casalini_toc]}", " #{link[:additional_text] if link[:additional_text]}"].compact.join(' '),
             fulltext: link_is_fulltext?(link_field),
             stanford_only: stanford_only?(link),
             finding_aid: link_is_finding_aid?(link_field)
@@ -63,10 +63,17 @@ module MarcLinks
           }
         else
           link_text = (!suby.present? && !sub3.present?) ? url_host : [sub3, suby].compact.join(' ')
+          title = subz.join(" ")
+          additional_text = nil
+          if title =~ stanford_affiliated_regex
+            additional_text = "<span class='additional-link-text'>#{title.gsub(stanford_affiliated_regex, '')}</span>"
+            title = "Available to Stanford-affiliated users only"
+          end
           {:text=>link_text,
-           :title=>subz.join(" "),
+           :title=> title,
            :href=>field["u"],
-           :casalini_toc => false
+           :casalini_toc => false,
+           :additional_text => additional_text
           }
         end
       end

--- a/spec/fixtures/marc_records/marc_856_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_856_fixtures.rb
@@ -41,7 +41,7 @@ module Marc856Fixtures
         <datafield tag='856' ind1='0' ind2='0'>
           <subfield code='u'>http://library.stanford.edu</subfield>
           <subfield code='y'>Link text</subfield>
-          <subfield code='z'>Available to stanford affiliated users at:</subfield>
+          <subfield code='z'>Available to stanford affiliated users at:4 at one time</subfield>
         </datafield>
         <datafield tag='856' ind1='0' ind2='0'>
           <subfield code='u'>http://library.stanford.edu</subfield>

--- a/spec/views/catalog/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_online.html.erb_spec.rb
@@ -24,6 +24,8 @@ describe "catalog/access_panels/_online.html.erb" do
       render
       expect(rendered).to have_css(".panel-online")
       expect(rendered).to have_css("ul.links li span.stanford-only")
+      expect(rendered).to have_css("span.additional-link-text", text: "4 at one time")
+      expect(rendered).to have_css("a[title='Available to Stanford-affiliated users only']", text: "Link text", count: 3)
     end
     it "should only render SFX links when present" do
       assign(:document, SolrDocument.new(url_sfx: ['http://example.com/sfx-link'], marcxml: simple_856))


### PR DESCRIPTION
Fixes #194 
![screen shot 2014-08-01 at 5 15 09 pm](https://cloud.githubusercontent.com/assets/1656824/3786697/c0128d24-19e0-11e4-809a-4be35af056f6.png)
![screen shot 2014-08-01 at 5 15 20 pm](https://cloud.githubusercontent.com/assets/1656824/3786698/c0137cac-19e0-11e4-9204-13df70404766.png)
