### PR TITLE
Define logger for nearby on shelf so errors don't get thrown from Blackl...

### DIFF
--- a/lib/nearby_on_shelf.rb
+++ b/lib/nearby_on_shelf.rb
@@ -11,6 +11,11 @@ class NearbyOnShelf
   end
 
   protected
+
+  def logger
+    ::Rails.logger
+  end
+
   def blacklight_config
     @blacklight_config
   end
@@ -73,7 +78,6 @@ class NearbyOnShelf
     }
     result
   end
-  
   # create an array of sorted html list items containing the appropriate display text
   #  (analogous to what would be visible if you were looking at the spine of 
   #  a book on a shelf) from relevant solr docs, given a particular solr


### PR DESCRIPTION
...igh's solr helper.

Fixes all browse nearby being broken right now.  There is a test for this but it's an external integration test, which is why this wasn't caught sooner.
