### PR TITLE
set stylesheet media to all (for print work), removes extraneous fonttag

### DIFF
--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -16,10 +16,9 @@
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_path(:format => 'xml', :only_path => false) %>
     <%= favicon_link_tag asset_path('favicon.ico') %>
-    <%= stylesheet_link_tag    "application" %>
+    <%= stylesheet_link_tag "application", media: "all" %>
     <link href="https://www.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
     <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" %>
-    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700' rel='stylesheet' type='text/css'>
     <%= javascript_include_tag "application" %>
     <!--[if lte IE 8]><%= javascript_include_tag 'flot/excanvas.min' %><![endif]-->
     <%= csrf_meta_tags %>


### PR DESCRIPTION
We need this so that @jvine can finish the vis design for #651 
