### PR TITLE
Adds margin to record sections and panels for sidenav

### DIFF
--- a/app/assets/stylesheets/modules/browse-toolbar.css.scss
+++ b/app/assets/stylesheets/modules/browse-toolbar.css.scss
@@ -14,3 +14,12 @@
     line-height: 3em;
   }
 }
+
+@media only screen and (max-width : $screen-sm) {
+  .record-browse-nearby {
+    .callnumber {
+      display: block;
+      margin: 10px 10px 0 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/record-metadata-section.css.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.css.scss
@@ -2,14 +2,18 @@
   .section {
     padding-bottom: 15px;
 
-    .section-heading h2 i.fa {
-      font-size: 15px;
-      margin-right: 5px;
+    .section-heading h2 {
+      i.fa {
+        font-size: 15px;
+        margin-right: 5px;
+      }
     }
   }
 }
 
 .record-metadata {
+  margin-right: 25px;
+
   dt {
     width: auto;
   }


### PR DESCRIPTION
Closes #647 
- Adds margin to `record-metadata` div that contains metadata panels and sections
- Wraps browse nearby callnumber in smaller screens to accommodate side-nav
## 
## ![image](https://cloud.githubusercontent.com/assets/302258/3804575/813f551a-1c28-11e4-85f7-d67aab4b3698.png)

![image](https://cloud.githubusercontent.com/assets/302258/3804578/90b91abc-1c28-11e4-90eb-108d0a822c35.png)
