### PR TITLE
Only call #any? on mhlds when they are present.

### DIFF
--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -26,7 +26,7 @@ class Holdings
       mhld.present? && mhld.any?(&:present?)
     end
     def any_index_mhlds?
-      mhld.any? do |mhld_item|
+      mhld.present? && mhld.any? do |mhld_item|
         mhld_item.latest_received.present? ||
         mhld_item.public_note.present?
       end

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -21,6 +21,9 @@ describe Holdings::Location do
     describe "present_on_index?" do
       let(:mhld) { Holdings::MHLD.new('GREEN -|- STACKS -|- something') }
       let(:library_has_mhld) { Holdings::MHLD.new('GREEN -|- STACKS -|- -|- something -|-') }
+      it "should not throw an error on items w/o an mhld" do
+        expect(location_no_items_or_mhld).to_not be_present_on_index
+      end
       it "should return false unless the public note or latest received are present" do
         location_no_items_or_mhld.mhld = [library_has_mhld]
         expect(location_no_items_or_mhld).to_not be_present_on_index


### PR DESCRIPTION
A search for "nature" throws an error previous to this PR.
