### PR TITLE
Add bound with note to bound with items and don't show request link.

### DIFF
--- a/app/assets/stylesheets/modules/availability.css.scss
+++ b/app/assets/stylesheets/modules/availability.css.scss
@@ -1,0 +1,9 @@
+.availability {
+  .note-highlight {
+    padding: 2px 5px;
+    background-color: $public-note-yellow;
+    &.bound-with-note {
+      margin-left: 10px;
+    }
+  }
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -12,6 +12,7 @@
 @import 'modules/availability-table';
 @import 'modules/advanced-search';
 @import 'modules/alert';
+@import 'modules/availability';
 @import 'modules/bookmarks';
 @import 'modules/breadcrumb';
 @import 'modules/brief-view';

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -23,6 +23,7 @@ $pantone-405: #5F574F;
 $pantone-334: #009B76;
 $pantone-5665: #C7D1C5;
 $white: #ffffff;
+$public-note-yellow: #faf8d2;
 
 $sul-footer-bg-color: $beige-10-percent;
 $sul-topnav-bg-color: $cardinal-red;
@@ -36,6 +37,7 @@ $sul-access-online-bg: $pantone-334;
 $sul-access-course-reserve-bg: $cardinal-red;
 $sul-availability-table-head-background: $beige-10-percent;
 $sul-availability-table-cell-border: $beige-30-percent;
+$sul-availability-public-note-color: $public-note-yellow;
 $sul-summary-bg: $cool-gray;
 $sul-pagination-active-bg: $gray-41-percent;
 $sul-body-bg: $beige-5-percent;

--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -16,7 +16,7 @@
               <% if location.mhld.present? %>
                 <% location.mhld.each do |mhld| %>
                   <% if mhld.public_note.present? %>
-                    <span class='public-note'><%= mhld.public_note %></span>
+                    <%= mhld.public_note %>
                   <% end %>
                 <% end %>
               <% end %>
@@ -25,11 +25,11 @@
               <% if location.mhld.present? %>
                 <% location.mhld.each do |mhld| %>
                   <% if mhld.latest_received.present? %>
-                    Latest: <%= mhld.latest_received%>
+                    <span class='note-highlight'>Latest: <%= mhld.latest_received%></span>
                   <% end %>
                 <% end %>
               <% end %>
-              <% if location.items.present? %>
+              <% if location.items.present? && !location.bound_with? %>
                 <% if library.location_level_request? || location.location_level_request? %>
                   <%= link_to('Request', request_link(document, location.items.first), class: 'btn btn-info btn-xs') %>
                 <% end %>

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -20,18 +20,28 @@
               <li>
                 <strong class="location-name"><%= location.name %></strong>
                 <% if location.items.present? %>
-                  <% if library.location_level_request? || location.location_level_request? %>
-                    <%= link_to('Request', request_link(document, location.items.first), class: 'btn btn-info btn-xs pull-right') %>
+                  <% if location.bound_with? && document.respond_to?(:to_marc) %>
+                    <p class="bound-with-note note-highlight">
+                      <% if (bound_with_note = get_data_with_label_from_marc(document.to_marc,"Note", '590')).present? %>
+                        <%= bound_with_note[:fields].map do |note|
+                              note[:field]
+                            end.join.html_safe %>
+                      <% end %>
+                    </p>
+                  <% else %>
+                    <% if library.location_level_request? || location.location_level_request? %>
+                      <%= link_to('Request', request_link(document, location.items.first), class: 'btn btn-info btn-xs pull-right') %>
+                    <% end %>
                   <% end %>
                 <% end %>
                 <ul class="list-unstyled items">
                   <% if location.mhld.present? %>
                     <% location.mhld.each do |mhld| %>
                       <% if mhld.public_note.present? %>
-                        <li class='mhld public-note'><%= mhld.public_note.html_safe %></li>
+                        <li class='mhld'><%= mhld.public_note.html_safe %></li>
                       <% end %>
                       <% if mhld.latest_received.present? %>
-                        <li class='mhld'>Latest: <%= mhld.latest_received.html_safe %></li>
+                        <li class='mhld note-highlight'>Latest: <%= mhld.latest_received.html_safe %></li>
                       <% end %>
                       <% if mhld.library_has.present? %>
                         <li class='mhld'>Library has: <%= mhld.library_has.html_safe %></li>

--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -9,6 +9,9 @@ class Holdings
     def name
       Constants::LOCS[@code]
     end
+    def bound_with?
+      @code && @code == "SEE-OTHER"
+    end
     def location_level_request?
       Constants::LOCATION_LEVEL_REQUEST_LOCS.include?(@code)
     end

--- a/spec/features/mhld_spec.rb
+++ b/spec/features/mhld_spec.rb
@@ -7,14 +7,14 @@ describe "MHLD", feature: true do
 
       within('[data-hours-route="/hours/CHEMCHMENG"]') do
         expect(page).to have_css('.location-name', text: 'Current Periodicals')
-        expect(page).to have_css('li.mhld.public-note', text: 'public note2')
-        expect(page).to have_css('li.mhld', text: 'Latest: latest received2')
+        expect(page).to have_css('li.mhld', text: 'public note2')
+        expect(page).to have_css('li.mhld.note-highlight', text: 'Latest: latest received2')
         expect(page).to have_css('li.mhld', text: 'Library has: library has2')
       end
       within('[data-hours-route="/hours/GREEN"]') do
         expect(page).to have_css('.location-name', text: 'Stacks')
-        expect(page).to have_css('li.mhld.public-note', text: 'public note3')
-        expect(page).to have_css('li.mhld', text: 'Latest: latest received3')
+        expect(page).to have_css('li.mhld', text: 'public note3')
+        expect(page).to have_css('li.mhld.note-highlight', text: 'Latest: latest received3')
         expect(page).to have_css('li.mhld', text: 'Library has: library has3')
       end
     end
@@ -28,12 +28,12 @@ describe "MHLD", feature: true do
         within('.accordion-section.location') do
           find('a.header').click
           expect(page).to have_css('tr th strong', text: 'Current Periodicals')
-          expect(page).to have_css('tr th .public-note', text: 'public note1')
-          expect(page).to have_css('tr th .public-note', text: 'public note2')
-          expect(page).to have_css('tr th .public-note', text: 'public note3')
-          expect(page).to have_css('tr td', text: 'Latest: latest received1')
-          expect(page).to have_css('tr td', text: 'Latest: latest received2')
-          expect(page).to have_css('tr td', text: 'Latest: latest received3')
+          expect(page).to have_css('tr th', text: 'public note1')
+          expect(page).to have_css('tr th', text: 'public note2')
+          expect(page).to have_css('tr th', text: 'public note3')
+          expect(page).to have_css('tr td .note-highlight', text: 'Latest: latest received1')
+          expect(page).to have_css('tr td .note-highlight', text: 'Latest: latest received2')
+          expect(page).to have_css('tr td .note-highlight', text: 'Latest: latest received3')
         end
       end
     end

--- a/spec/integration/external-data/location_spec.rb
+++ b/spec/integration/external-data/location_spec.rb
@@ -43,4 +43,22 @@ describe "Location", feature: true, :"data-integration" => true do
       end
     end
   end
+  describe "bound with items" do
+    before do
+      visit catalog_path('796463')
+    end
+    it "should not show request links for requstable libraries" do
+      within('.availability') do
+        expect(page).to_not have_content('Request')
+      end
+    end
+    it "should show the MARC 590 note in the availability display" do
+      within('.availability') do
+        expect(page).to have_css('.bound-with-note.note-highlight', text: "Copy 1 bound with 1967, pt. 1. 796443(parent record's ckey)")
+        expect(page).to have_css('.bound-with-note.note-highlight a', text:"796443")
+        click_link '796443'
+      end
+      expect(page).to have_css('h1', text: /Der Urheberschutz wissenschaftlicher/)
+    end
+  end
 end

--- a/spec/integration/external-data/mhld_spec.rb
+++ b/spec/integration/external-data/mhld_spec.rb
@@ -7,8 +7,8 @@ describe "MHLD", feature: true, :"data-integration" => true do
 
       within('.access-panel.panel-library-location') do
         expect(page).to have_css('li.mhld', text: 'Library has: v.1(1985)-v.20(2012)')
-        expect(page).to have_css('li.mhld.public-note', text: 'Latest issues in CURRENT PERIODICALS; earlier issues in STACKS.')
-        expect(page).to have_css('li.mhld', text: 'Latest: v.21:no.4 (2013)')
+        expect(page).to have_css('li.mhld', text: 'Latest issues in CURRENT PERIODICALS; earlier issues in STACKS.')
+        expect(page).to have_css('li.mhld.note-highlight', text: 'Latest: v.21:no.4 (2013)')
         expect(page).to have_css('li.mhld', text: 'Library has: v.21(2013)-')
       end
     end
@@ -22,8 +22,8 @@ describe "MHLD", feature: true, :"data-integration" => true do
         within('.accordion-section.location') do
           find('a.header').click
           expect(page).to have_css('tr th strong', text: 'Current Periodicals')
-          expect(page).to have_css('tr th .public-note', text: 'Latest issues in CURRENT PERIODICALS; earlier issues in STACKS.')
-          expect(page).to have_css('tr td', text: 'Latest: v.21:no.4 (2013)')
+          expect(page).to have_css('tr th', text: 'Latest issues in CURRENT PERIODICALS; earlier issues in STACKS.')
+          expect(page).to have_css('tr td .note-highlight', text: 'Latest: v.21:no.4 (2013)')
         end
 
       end

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -34,6 +34,16 @@ describe Holdings::Location do
       end
     end
   end
+  describe "#bound_with?" do
+    let(:location) { Holdings::Location.new("STACKS") }
+    let(:bound_with_location) { Holdings::Location.new("SEE-OTHER") }
+    it "should return true for locations that are SEE-OTHER" do
+      expect(bound_with_location).to be_bound_with
+    end
+    it "should return false for locations that are not SEE-OTHER" do
+      expect(location).to_not be_bound_with
+    end
+  end
   describe "#mhld" do
     let(:location) {Holdings::Location.new("STACKS")}
     it "should be an accessible attribute" do

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -87,6 +87,20 @@ describe "catalog/_index_location.html.erb" do
       expect(rendered).to have_css('tbody tr td.indent-callnumber', count: 2)
     end
   end
+  describe "bound with" do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          id: '123',
+          item_display: ['1234 -|- SAL3 -|- SEE-OTHER -|- -|- -|- -|- -|- -|- ABC 123']
+        )
+      )
+      render
+    end
+    it "should not display request links for requestable libraries" do
+      expect(rendered).to_not have_content("Request")
+    end
+  end
   describe "mhld" do
     describe "with matching library/location" do
       before do

--- a/spec/views/catalog/access_panels/_location.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_location.html.erb_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe "catalog/access_panels/_location.html.erb", js:true do
+  include MarcMetadataFixtures
   describe "non location record" do
     before do
       assign(:document, SolrDocument.new)
@@ -19,6 +20,23 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       expect(rendered).to have_css(".library-location-heading-text a", text: "Earth Sciences Library (Branner)")
       expect(rendered).to have_css("div.location-hours-today")
       expect(rendered).to have_css(".panel-body")
+    end
+  end
+  describe "bound with locations" do
+    before do
+      assign(:document, SolrDocument.new(
+        id: '1234',
+        item_display: ['1234 -|- SAL3 -|- SEE-OTHER -|- -|- -|- -|- -|- -|- ABC 123'],
+        marcxml: linked_ckey_fixture
+      ))
+      render
+    end
+    it "should display the MARC 590 as a bound with note" do
+      expect(rendered).to have_css('p.bound-with-note.note-highlight', text: 'Copy 1 bound with v. 140 55523 (parent record’s ckey)')
+      expect(rendered).to have_css('p.bound-with-note.note-highlight a', text: '55523')
+    end
+    it "should not display request links for requestable libraries" do
+      expect(rendered).to_not have_content("Request")
     end
   end
   describe "status text" do
@@ -88,8 +106,8 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       it "should include the matched MHLD" do
         expect(rendered).to have_css('h3 a', text: "Green Library", count: 1)
         expect(rendered).to have_css('li .location-name', text: "Stacks", count: 1)
-        expect(rendered).to have_css('ul.items li.mhld.public-note', text: "public note")
-        expect(rendered).to have_css('ul.items li.mhld', text: "Latest: latest received")
+        expect(rendered).to have_css('ul.items li.mhld', text: "public note")
+        expect(rendered).to have_css('ul.items li.mhld.note-highlight', text: "Latest: latest received")
         expect(rendered).to have_css('ul.items li.mhld', text: "Library has: library has")
         expect(rendered).to have_css('ul.items li', text: "ABC 123")
       end
@@ -105,8 +123,8 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       it "should invoke a library block w/ the appropriate mhld data" do
         expect(rendered).to have_css('h3 a', text: "Green Library")
         expect(rendered).to have_css('li .location-name', text: "Stacks")
-        expect(rendered).to have_css('ul.items li.mhld.public-note', text: "public note")
-        expect(rendered).to have_css('ul.items li.mhld', text: "Latest: latest received")
+        expect(rendered).to have_css('ul.items li.mhld', text: "public note")
+        expect(rendered).to have_css('ul.items li.mhld.note-highlight', text: "Latest: latest received")
         expect(rendered).to have_css('ul.items li.mhld', text: "Library has: library has")
       end
     end


### PR DESCRIPTION
Fixes #560 

Also we noticed that the class that we were going to use to highlight certain parts of the MHLD display was on the wrong piece (was public note, is now latest received).
### Bound with item
#### 796463
##### Record view

![796463-record](https://cloud.githubusercontent.com/assets/96776/3835631/5a356008-1dc3-11e4-93df-707f191aa092.png)
##### Results view

![796463-results](https://cloud.githubusercontent.com/assets/96776/3835632/5a4b46b6-1dc3-11e4-8b63-965d7b76008d.png)
### MHLD Latest Received
#### 492502
##### Record view

![492502-record](https://cloud.githubusercontent.com/assets/96776/3835639/79a56adc-1dc3-11e4-87f1-37fa2fdc9ea3.png)
##### Results view

![492502-results](https://cloud.githubusercontent.com/assets/96776/3835638/799d557c-1dc3-11e4-9da0-3669730274ef.png)
