### PR TITLE
Don't add the solr start parameter to the counter when linking to docs.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -35,6 +35,8 @@ class CatalogController < ApplicationController
 
     # items to show per page, each number in the array represent another option to choose from.
     #config.per_page = [10,20,50,100]
+    config.default_per_page = 20
+
 
     ## Default parameters to send on single-document requests to Solr. These settings are the Blackligt defaults (see SolrHelper#solr_doc_params) or
     ## parameters included in the Blacklight-jetty document requestHandler.

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -8,7 +8,7 @@
     <span class="document-counter">
       <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
     </span>
-    <%= link_to_document document, :label => get_main_title(document), :counter => (counter + @response.params[:start].to_i) %>
+    <%= link_to_document document, :label => get_main_title(document), :counter => counter %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
   </h3>
 

--- a/app/views/catalog/_index_header_gallery.html.erb
+++ b/app/views/catalog/_index_header_gallery.html.erb
@@ -8,7 +8,7 @@
   <h3 class="index_title">
     <% counter = document_counter_with_offset(document_counter) %>
     <%= render_resource_icon document[document.format_key] %>
-    <%= link_to_document document, label: get_main_title(document), counter: (counter + @response.params[:start].to_i) %>
+    <%= link_to_document document, label: get_main_title(document), counter: counter %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
   </h3>
 </div>

--- a/spec/features/blacklight_customizations/record_pagination_spec.rb
+++ b/spec/features/blacklight_customizations/record_pagination_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "Record view pagination", js: true do
+  before do
+    visit root_path
+  end
+
+  it "should pass the appropriate counter" do
+    fill_in 'q', with: ''
+    click_button 'search'
+
+    within('.page_links') do
+      click_link 'Next'
+    end
+
+    document_title = all('.document .index_title a').first.text
+
+    within(first('.document')) do
+      expect(page).to have_css('.document-counter', text: '21')
+      click_link document_title
+    end
+
+    within('.record-toolbar') do
+      expect(page).to have_content('21 of')
+      click_link 'Back to results'
+    end
+
+    within(first('.document')) do
+      expect(page).to have_css('.document-counter', text: '21')
+      expect(page).to have_css('.index_title a', text: document_title)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #603 
#### Before

![per-page-before](https://cloud.githubusercontent.com/assets/96776/3837015/11e527a6-1de2-11e4-923e-6bcdf083b478.gif)
#### After

![per-page-after](https://cloud.githubusercontent.com/assets/96776/3837014/11e39f9e-1de2-11e4-9e5d-d81f8a4edfe1.gif)
