### PR TITLE
changes list label to normal

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -26,6 +26,7 @@ en:
       view:
         label: 'View'
         brief: 'Brief'
+        list: 'Normal'
       per_page:
         button_label_html: '%{count}<span class="hidden-xs hidden-sm"> per page</span>'
       pagination_info:
@@ -35,7 +36,7 @@ en:
         single_item_found: ''
         no_items_found: "<h2>No results found in catalog</h2>"
       entry_pagination_info:
-        other: '%{current} of %{total}'        
+        other: '%{current} of %{total}'
     bookmarks:
       add:
         all_html: '<i class="fa fa-check-square-o"></i> <span class="hidden-sm hidden-xs">Select </span>all'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,1 @@
 HOSTNAME: "TEST-HOST"
-STACKS_URL: https://stacks-test.stanford.edu/image

--- a/spec/features/blacklight_customizations/view_options_spec.rb
+++ b/spec/features/blacklight_customizations/view_options_spec.rb
@@ -7,7 +7,7 @@ feature "View options" do
     click_button 'search'
 
     within('#view-type-dropdown') do
-      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'List')
+      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'Normal')
       expect(page).to have_css("li a.view-type-list i.fa.fa-th-list")
 
       expect(page).to have_css("li a.view-type-gallery span.view-type-label", text: 'Gallery')


### PR DESCRIPTION
Fixes #665 

List view changed to Normal view in UI

Note: The parameter for normal view is still `list`.

![screen shot 2014-08-07 at 11 56 07 am](https://cloud.githubusercontent.com/assets/1656824/3847350/b52aa5c6-1e64-11e4-9d84-fefba75d93dc.png)
