### PR TITLE
adds SearchWorksMarc and Instrumentation support

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,5 +1,24 @@
 # encoding: UTF-8
 module RecordHelper
+
+  def display_content_field field
+    if field.respond_to?(:label, :values) &&
+        field.values.any?(&:present?)
+      display_content_label(field.label) +
+      display_content_values(field.values)
+    end
+  end
+
+  def display_content_label label
+    content_tag :dt, label
+  end
+
+  def display_content_values values
+    values.map do |value|
+      content_tag :dd, value.join(', ')
+    end.join('').html_safe
+  end
+
   def mods_display_label label
     content_tag(:dt, label.gsub(":",""))
   end

--- a/app/models/concerns/marc_instrumentation.rb
+++ b/app/models/concerns/marc_instrumentation.rb
@@ -1,0 +1,7 @@
+module MarcInstrumentation
+  def marc_instrumentation
+    if self.respond_to?(:to_marc)
+      @marc_instrumentation ||= SearchWorksMarc::Instrumentation.new(self.to_marc)
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -17,6 +17,7 @@ class SolrDocument
   include DigitalImage
   include OpenSeadragon
   include SolrHoldings
+  include MarcInstrumentation
 
   include Blacklight::Solr::Document
 

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -72,6 +72,12 @@
       <%= render "field_from_index", :fields => physical_desc %>
     <%- end -%>
 
+    <% if (instrumentation = document.marc_instrumentation).present? %>
+      <% instrumentation.parse_marc_record.each do |field| %>
+        <%= display_content_field field %>
+      <% end %>
+    <% end %>
+
     <% series = link_to_series_from_marc(document.to_marc) %>
     <% if series.present? %>
       <dt>Series</dt>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,8 +25,13 @@ module SearchWorks
     require 'live_lookup'
     require 'search_query_modifier'
     require 'blacklight_advanced_search/parsing_nesting_parser'
+    require 'search_works_marc'
+
     # load all access panels
     config.autoload_paths += %W(#{config.root}/lib/access_panels)
+
+     # load all SearchWorksMarc
+    config.autoload_paths += %W(#{config.root}/lib/search_works_marc)
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/lib/search_works_marc.rb
+++ b/lib/search_works_marc.rb
@@ -1,0 +1,60 @@
+require 'marc'
+
+class SearchWorksMarc
+  attr_reader :marc_record
+  def initialize(marc_record)
+    @marc_record = remove_fields marc_record.fields
+  end
+
+  def parse_marc_record
+    label_array = []
+    if defined?(grouping)
+      grouping.each do |key, value|
+        temp_hash = OpenStruct.new label: label_by_indicator(key)
+        fields = value
+                  .map { |f| f
+                    .map { |sf| reject_excluded_subfields sf
+                    }.compact
+                  }
+        temp_hash.values = format_subfields fields
+        label_array.push temp_hash
+      end
+    end
+    label_array
+  end
+
+  private
+  def remove_fields fields
+    remove_control_fields remove_custom_fields fields
+  end
+
+  def remove_control_fields fields
+    fields.map { |field| field.tag =~ /00./ ? nil : field }.compact
+  end
+
+  def remove_custom_fields fields
+    fields.map do |field|
+      unless (Constants::HIDE_1ST_IND.include?(field.tag) and field.indicator1 == "1") or (Constants::HIDE_1ST_IND0.include?(field.tag) and field.indicator1 == "0")
+        field
+      end
+    end.compact
+  end
+
+  def grouping
+    @marc_record.group_by(&:tag)
+  end
+
+  def label_by_indicator key
+    key
+  end
+
+  def format_subfields fields
+    fields.map { |f| f.map { |sf| sf.value } }
+  end
+
+  def reject_excluded_subfields field
+    unless Constants::EXCLUDE_FIELDS.include?(field.code)
+      field
+    end
+  end
+end

--- a/lib/search_works_marc/instrumentation.rb
+++ b/lib/search_works_marc/instrumentation.rb
@@ -1,0 +1,74 @@
+class Instrumentation < SearchWorksMarc
+  def initialize(marc_record)
+    @marc_record = remove_fields marc_record
+                    .fields
+                    .select { |f| f.tag == '382' }
+  end
+
+  private
+  def format_subfields fields
+    fields.map do |section|
+      temp_array = []
+      j = 0
+      section.each_with_index.map do |field, i|
+        if field.code == 'n'
+          append_to_previous code_to_string(field.code, field.value), temp_array, i - 1 - j
+          j += 1
+        else
+          temp_array.push code_to_string field.code, field.value
+        end
+      end
+      temp_array.compact
+    end
+  end
+  
+  def grouping
+    @marc_record.group_by { |f| f.indicator1 }
+  end
+
+  def append_to_previous field, array, index
+    array[index] = "#{array[index]} #{field}"
+  end
+
+  def label_by_indicator indicator
+    self.send("indicator_#{indicator}")
+  end
+
+  def code_to_string code, value
+    self.send("#{code}_subfield", value)
+  end
+
+  def indicator_0
+    'Instrumentation'
+  end
+
+  def indicator_1
+    'Partial instrumentation'
+  end
+  def a_subfield value
+    value
+  end
+
+  def b_subfield value
+    "solo #{value}"
+  end
+
+  def d_subfield value
+    "doubling #{value}"
+  end
+
+  def n_subfield value
+    "(#{value})"
+  end
+
+  def method_missing(method_name, *args, &block)
+    case method_name
+    when /._subfield$/
+      nil
+    when /^indicator_./
+      nil
+    else
+      super
+    end
+  end
+end

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -782,4 +782,48 @@ module MarcMetadataFixtures
   def no_fields_fixture
     "<record></record>"
   end
+  def marc_382_instrumentation
+    <<-xml
+      <record>
+        <datafield tag="432"></datafield>
+        <datafield tag="382" ind1="0" ind2="1">
+          <subfield code="a">singer</subfield>
+          <subfield code="n">1</subfield>
+          <subfield code="d">bass guitar</subfield>
+          <subfield code="n">2</subfield>
+          <subfield code="a">percussion</subfield>
+          <subfield code="n">1</subfield>
+          <subfield code="a">guitar</subfield>
+          <subfield code="n">1</subfield>
+          <subfield code="d">electronics</subfield>
+          <subfield code="n">1</subfield>
+        </datafield>
+        <datafield tag="382" ind1="0" ind2=" ">
+          <subfield code="a">singer</subfield>
+          <subfield code="n">3</subfield>
+        </datafield>
+        <datafield tag="382" ind1="1" ind2=" ">
+          <subfield code="a">cowbell</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+  def sw_marc_removed
+    <<-xml
+      <record>
+        <controlfield tag="001">control stuff</controlfield>
+        <datafield tag="760" ind1="1" ind2="1">should be removed</datafield>
+        <datafield tag="541" ind1="0" ind2="1">should be removed</datafield>
+      </record>
+    xml
+  end
+  def sw_marc_not_removed
+    <<-xml
+      <record>
+        <controlfield tag="001">control stuff</controlfield>
+        <datafield tag="760" ind1="0" ind2="1">should not be removed</datafield>
+        <datafield tag="541" ind1="1" ind2="1">should not be removed</datafield>
+      </record>
+    xml
+  end
 end

--- a/spec/fixtures/solr_documents/43.yml
+++ b/spec/fixtures/solr_documents/43.yml
@@ -1,0 +1,9 @@
+:id: 43
+:title_display: Best Album Every Written
+:author_person_full_display: McDonald, Ronald
+:display_type:
+  - sirsi
+:format: music
+:format_main_ssim: Music
+:marcxml: <%= marc_382_instrumentation %>
+:pub_date: 2008

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -2,6 +2,29 @@ require "spec_helper"
 
 describe RecordHelper do
   let(:empty_field) { OpenStruct.new({label: "test", values: [""] }) }
+  describe 'display_content_field' do
+    let(:values) {[['guitar (1)'], ['solo cowbell', 'trombone (2)']]}
+    let(:content) { OpenStruct.new(label: 'Instrumentation', values: values)}
+    it 'should return dt with label and dd with values' do
+      expect(helper.display_content_field(content)).to have_css('dt', text: 'Instrumentation')
+      expect(helper.display_content_field(content)).to have_css('dd', count: 2)
+    end
+  end
+  describe 'display_content_label' do
+    it 'should return correct dt' do
+      expect(helper.display_content_label('test')).to have_css('dt', text: 'test')
+    end
+  end
+
+  describe 'display_content_values' do
+    let(:values) {[['guitar (1)'], ['solo cowbell', 'trombone (2)']]}
+    it 'should return dds of values' do
+      expect(helper.display_content_values(values)).to have_css('dd', count: 2)
+      expect(helper.display_content_values(values)).to have_css('dd', text: 'guitar (1)')
+      expect(helper.display_content_values(values)).to have_css('dd', text: 'solo cowbell, trombone (2)')
+    end
+  end
+
   describe "mods_display_label" do
     it "should return correct label" do
       expect(helper.mods_display_label("test:")).to_not have_content ":"

--- a/spec/lib/search_works_marc/instrumentation_spec.rb
+++ b/spec/lib/search_works_marc/instrumentation_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Instrumentation do
+  include MarcMetadataFixtures
+
+  describe 'initialize' do
+    let(:document) { SolrDocument.new(marcxml: marc_382_instrumentation).to_marc }
+    let(:instrumentation) { SearchWorksMarc::Instrumentation.new(document) }
+    it 'should be type Instrumentation' do
+      expect(instrumentation.class).to eq Instrumentation
+    end
+    it "should contain only 382 fields" do
+      instrumentation.marc_record.each do |record|
+        expect(record.tag).to eq '382'
+      end
+    end
+  end
+  describe 'parse_marc_record' do
+    let(:document) { SolrDocument.new(marcxml: marc_382_instrumentation).to_marc }
+    let(:instrumentation) { SearchWorksMarc::Instrumentation.new(document) }
+    it 'should return an array' do
+      expect(instrumentation.parse_marc_record.class).to eq Array
+    end
+    it 'should have two values grouped by instrumentation/partial instrumentation' do
+      expect(instrumentation.parse_marc_record.length).to eq 2
+      instrumentation.parse_marc_record.each do |group|
+        expect(group.label).to match /(Instrumentation|Partial instrumentation)/
+      end
+    end
+    it "grouped values should be an array" do
+      instrumentation.parse_marc_record.each do |group|
+        expect(group.values.class).to eq Array
+      end
+    end
+    it 'items in array should be OpenStruct' do
+      instrumentation.parse_marc_record.each do |item|
+        expect(item.class).to eq OpenStruct
+      end
+    end
+    describe "subfields" do
+      it 'a subfield should equal the value' do
+        expect(instrumentation.parse_marc_record[1].values.first.first).to eq 'cowbell'
+      end
+      it 'n subfield should be appended to previous value' do
+        expect(instrumentation.parse_marc_record[0].values.first.first).to eq 'singer (1)'
+      end
+      it 'd subfield should should add doubling' do
+        expect(instrumentation.parse_marc_record[0].values.first[1]).to eq 'doubling bass guitar (2)'
+      end
+    end
+  end
+end

--- a/spec/lib/search_works_marc_spec.rb
+++ b/spec/lib/search_works_marc_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe SearchWorksMarc do
+  include MarcMetadataFixtures
+
+  describe 'initialize' do
+    let(:document) { SolrDocument.new(marcxml: sw_marc_removed).to_marc }
+    let(:sw_marc) { SearchWorksMarc.new(document) }
+    it 'should be type SearchWorksMarc' do
+      expect(sw_marc.class).to be SearchWorksMarc
+    end
+    it 'should not contain any control fields or removed custom fields' do
+      expect(sw_marc.marc_record).to match_array []
+    end
+    it 'should contain these fields as the indicator value does not match' do
+      document = SolrDocument.new(marcxml: sw_marc_not_removed).to_marc
+      sw_marc = SearchWorksMarc.new(document)
+      expect(sw_marc.marc_record.length).to eq 2
+    end
+  end
+
+  describe 'parse_marc_record' do
+    let(:document) { SolrDocument.new(marcxml: metadata1).to_marc }
+    let(:sw_marc) { SearchWorksMarc.new(document) }
+    it 'should return an array' do
+      expect(sw_marc.parse_marc_record.class).to eq Array
+    end
+    it 'should have 13 values grouped by tag' do
+      expect(sw_marc.parse_marc_record.count).to eq 13
+      expect(sw_marc.parse_marc_record.map{ |f| f.label }.uniq.length).to eq 13
+    end
+    it 'grouped values should be an array' do
+      sw_marc.parse_marc_record.each do |group|
+        expect(group.values.class).to eq Array
+      end
+    end
+    it 'items in array should be OpenStruct' do
+      sw_marc.parse_marc_record.each do |group|
+        expect(group.class).to eq OpenStruct
+      end
+    end
+    it 'values should not contain excluded subfields' do
+      expect(sw_marc.parse_marc_record.first.values.join('')).to_not match /\^A170662/
+    end
+    describe 'subfields' do
+      it 'should equal the value' do
+        expect(sw_marc.parse_marc_record[1].values.first.first).to eq 'Some intersting papers,'
+      end
+    end
+
+  end
+end

--- a/spec/models/concerns/marc_instrumentation_spec.rb
+++ b/spec/models/concerns/marc_instrumentation_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe MarcInstrumentation do
+  include MarcMetadataFixtures
+  it 'should return nil for non marc object' do
+    document = SolrDocument.new()
+    expect(document.marc_instrumentation).to be nil
+  end
+  it 'should return empty marc_record for marc doc without 382 field' do
+    document = SolrDocument.new(marcxml: metadata1)
+    expect(document.marc_instrumentation.marc_record.length).to eq 0
+  end
+  it 'should return SearchWorksMarc::Instrumentation for document with 382 field' do
+    document = SolrDocument.new(marcxml: marc_382_instrumentation)
+    expect(document.marc_instrumentation.class).to eq SearchWorksMarc::Instrumentation
+  end
+end

--- a/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
@@ -47,4 +47,17 @@ describe "catalog/record/_marc_upper_metadata_items.html.erb" do
       expect(rendered).to have_css('dd', text: 'SubfieldA SubfieldB')
     end
   end
+  describe "Instrumentation (Marc 382)" do
+    before do
+      assign(:document, SolrDocument.new(marcxml: marc_382_instrumentation))
+      render
+    end
+    it "should be rendered and include specific dts/dds" do
+      expect(rendered).to have_css('dt', text: 'Instrumentation')
+      expect(rendered).to have_css('dd', text: 'singer (1), doubling bass guitar (2), percussion (1), guitar (1), doubling electronics (1)')
+      expect(rendered).to have_css('dd', text: 'singer (3)')
+      expect(rendered).to have_css('dt', text: 'Partial instrumentation')
+      expect(rendered).to have_css('dd', text: 'cowbell')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #268 

Adds `SearchWorksMarc` class with subclass `Instrumentation`. For customization based off various marc fields, base private methods in `SearchWorksMarc` can be overridden by a subclass.
### Fixture 43

![screen shot 2014-08-11 at 11 43 53 am](https://cloud.githubusercontent.com/assets/1656824/3880793/8d5642a0-2187-11e4-9dd8-f1979dc4b2c9.png)
### 10246987

Note there are some issues with this record's metadata, which is why things like "doubling 1" appear. Has been reported to metadata team.
![screen shot 2014-08-11 at 11 45 57 am](https://cloud.githubusercontent.com/assets/1656824/3880809/c7e16d00-2187-11e4-9da6-a489513b47ab.png)
