### PR TITLE
Improve backend lookup in additional results block and zero results page

### DIFF
--- a/app/assets/javascripts/backend_lookup.js
+++ b/app/assets/javascripts/backend_lookup.js
@@ -37,16 +37,38 @@ Blacklight.onLoad(function(){
     Plugin.prototype = {
 
         init: function() {
-          $url = $(this.element).data('lookup');
-          this.lookupResults();
+          var el = this;
+          $url = $(el.element).data('lookup');
+          if(el.onScreen()){
+            el.lookupResults();
+          } else {
+            $(document).on('scroll', function(){
+              if(el.onScreen()){
+                el.lookupResults();
+              }
+            });
+          }
+        },
+        onScreen: function(){
+          var el = $(this.element);
+          var viewport = {};
+          viewport.top = $(window).scrollTop();
+          viewport.bottom = viewport.top + $(window).height();
+          var bounds = {};
+          bounds.top = el.offset().top;
+          bounds.bottom = bounds.top + el.outerHeight();
+          return ((bounds.top <= viewport.bottom) && (bounds.bottom >= viewport.top));
         },
         lookupResults: function(){
           var el = this.element;
-          $.getJSON($url, function(data){
-            $response = data.response;
-            $total_count = $response.pages.total_count;
-            updateLink($total_count, el);
-          });
+          if(!$(el).data(pluginName + '_processed')) {
+            $(el).data(pluginName + '_processed', true);
+            $.getJSON($url, function(data){
+              $response = data.response;
+              $total_count = $response.pages.total_count;
+              updateLink($total_count, el);
+            });
+          }
         }
     };
 

--- a/app/views/catalog/_additional_results_block.html.erb
+++ b/app/views/catalog/_additional_results_block.html.erb
@@ -1,22 +1,26 @@
-<div class='panel panel-default additional-results'>
-  <div class="panel-body">
-    <h3>Looking for different results?</h3>
-    <p>
-      <span>Modify your search:</span>
-      <% if @search_modifier.has_filters? %>
-        <%= link_to("Remove limit(s)", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"}) %>
+<% if (@search_modifier.present? || @search_modifier.has_query?) && (params[:page].blank? || params[:page] == "1") %>
+  <div class='panel panel-default additional-results'>
+    <div class="panel-body">
+      <h3>Looking for different results?</h3>
+      <% if @search_modifier.present? %>
+        <p>
+          <span>Modify your search:</span>
+          <% if @search_modifier.has_filters? && @search_modifier.has_query? %>
+            <%= link_to("Remove limit(s)", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"}) %>
+          <% end %>
+          <% if @search_modifier.fielded_search? %>
+            <%= link_to("Search all fields", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"}) %>
+          <% end %>
+          <% if @search_modifier.query_has_stopwords? %>
+            <%= link_to("Search without #{SearchQueryModifier.stopwords.map{|w| "\"#{w}\""}.join(' ')}", catalog_index_path(@search_modifier.params_without_stopwords), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_stopwords)}"}) %>
+          <% end %>
+        </p>
       <% end %>
-      <% if @search_modifier.fielded_search? %>
-        <%= link_to("Search all fields", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"}) %>
+      <% if @search_modifier.has_query? %>
+        <p>
+          <span>Search elsewhere:</span> <%= link_to "Search WorldCat", "http://www.worldcat.org/search?q=#{params[:q]}" %> <%= link_to("Search library website", "http://library.stanford.edu/search/website?search=#{params[:q]}") %>
+        </p>
       <% end %>
-      <% if @search_modifier.query_has_stopwords? %>
-        <%= link_to("Search without #{SearchQueryModifier.stopwords.map{|w| "\"#{w}\""}.join(' ')}", catalog_index_path(@search_modifier.params_without_stopwords), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_stopwords)}"}) %>
-      <% end %>
-    </p>
-    <% if @search_modifier.has_query? %>
-      <p>
-        <span>Search elsewhere:</span> <%= link_to("Search articles", '#', class: 'disabled')%> <%= link_to("Search library website", "http://library.stanford.edu/search/website?search=#{params[:q]}") %>
-      </p>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -4,35 +4,34 @@
     <ul class="list-unstyled zero-results-list">
       <li>
         <%= t 'blacklight.search.zero_results.your_search' %>
-        <% if @search_modifier.query_search? %>
+        <% if @search_modifier.has_query? %>
           <%= "#{search_field_label(params)}: #{params[:q]}" %>
         <% end %>
         <%= @search_modifier.selected_filter_labels %>
       </li>
-      <% if @search_modifier.has_filters? %>
+      <% if @search_modifier.has_filters? && @search_modifier.has_query? %>
         <li><%= t 'blacklight.search.zero_results.limit_fields' %>
-        <%= link_to "#{search_field_label(params)}: #{params[:q]}", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"} %>
+          <%= link_to "#{search_field_label(params)}: #{params[:q]}", catalog_index_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"} %>
         </li>
       <% end %>
       <% if @search_modifier.fielded_search? %>
         <li><%= t 'blacklight.search.zero_results.search_fields' %>
-        <%= link_to "All fields: #{params[:q]}", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"} %>
+          <%= link_to "All fields: #{params[:q]}", catalog_index_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"} %>
         </li>
       <% end %>
   </div>
 </div>
-<div class="panel panel-default">
-  <div class="panel-body">
-    <h3>Check other sources</h3>
-    <ul class="list-unstyled zero-results-list">
-      <li>
-        <%= link_to "Check WorldCat", "http://www.worldcat.org/search?q=#{params[:q]}" %>
-      </li>
-      <li>
-        <%= link_to "Check articles", "#", class:"disabled" %>
-      </li>
-      <li>
-        <%= link_to "Check library website", "http://library.stanford.edu/search/website?search=#{params[:q]}" %>
-      </li>
+<% if @search_modifier.has_query? %>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <h3>Check other sources</h3>
+      <ul class="list-unstyled zero-results-list">
+        <li>
+          <%= link_to "Check WorldCat", "http://www.worldcat.org/search?q=#{params[:q]}" %>
+        </li>
+        <li>
+          <%= link_to "Check library website", "http://library.stanford.edu/search/website?search=#{params[:q]}" %>
+        </li>
+    </div>
   </div>
-</div>
+<% end %>

--- a/lib/search_query_modifier.rb
+++ b/lib/search_query_modifier.rb
@@ -4,6 +4,10 @@ class SearchQueryModifier
     @config = config
   end
 
+  def present?
+    has_filters_and_query? || fielded_search? || query_has_stopwords?
+  end
+
   def params_without_stopwords
     @params.merge(q: query_without_stopwords)
   end
@@ -15,15 +19,11 @@ class SearchQueryModifier
   end
 
   def params_without_fielded_search_and_filters
-    @params.merge(search_field: nil, f: nil)
+    @params.merge(search_field: nil, f: nil, range: nil)
   end
 
   def params_without_fielded_search
     @params.merge(search_field: nil)
-  end
-
-  def query_search?
-    @params[:q].present?
   end
 
   def fielded_search?
@@ -33,19 +33,19 @@ class SearchQueryModifier
   end
 
   def params_without_filters
-    @params.merge(f: nil)
+    @params.merge(f: nil, range: nil)
   end
 
   def selected_filter_labels
     if has_filters?
       @config.facet_fields.values.map do |facet|
-        "#{facet.label}: #{@params[:f][facet.field].join(', ')}" if @params[:f][facet.field].present?
+        "#{facet.label}: #{@params[:f][facet.field].join(', ')}" if @params[:f].present? && @params[:f][facet.field].present?
       end.compact.join(', ')
     end
   end
 
   def has_filters?
-    @params[:f].present?
+    @params[:f].present? || @params[:range].present?
   end
 
   def has_query?
@@ -57,6 +57,10 @@ class SearchQueryModifier
   end
 
   private
+
+  def has_filters_and_query?
+    has_filters? && has_query?
+  end
 
   def query_without_stopwords
     if has_query?

--- a/spec/features/backend_lookup_spec.rb
+++ b/spec/features/backend_lookup_spec.rb
@@ -3,13 +3,23 @@ require 'spec_helper'
 feature "Backend lookup", js: true do
   before do
     visit root_path
+  end
+  scenario "lookup should return additional results on the zero results page" do
     fill_in "q", with: "sdfsda"
     select 'Author', from: 'search_field'
     click_button 'search'
-  end
-  scenario "lookup should return additional results" do
+
     within "#content" do
       expect(page).to have_css("a", text: "All fields: sdfsda ... found 0 results")
+    end
+  end
+  scenario "lookup should return additional results on the results page" do
+    click_link "Online"
+    fill_in "q", with: '2'
+    click_button 'search'
+
+    within "#content" do
+      expect(page).to have_css("a", text: "Remove limit(s) ... found 1 results")
     end
   end
 end

--- a/spec/integration/external-data/backend_lookup_spec.rb
+++ b/spec/integration/external-data/backend_lookup_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "Backend lookup", type: :feature, js: true, :"data-integration" => true do
+  before do
+    visit root_path
+  end
+
+  describe "on search results" do
+    before do
+      click_on "Online"
+      fill_in 'q', with: 'Search'
+      click_button 'search'
+    end
+    it "should not execute until scrolled to" do
+      expect(page).to     have_css('a', text: /^Remove limit\(s\)$/)
+      expect(page).to_not have_css('a', text: /^Remove limit\(s\) \.{3} found \d{4,} results$/)
+      page.driver.scroll_to(0, 10000)
+      expect(page).to     have_css('a', text: /^Remove limit\(s\) \.{3} found \d{4,} results$/)
+    end
+  end
+end

--- a/spec/views/catalog/_additional_results_block.html.erb_spec.rb
+++ b/spec/views/catalog/_additional_results_block.html.erb_spec.rb
@@ -11,6 +11,7 @@ describe "catalog/_additional_results_block.html.erb" do
   let(:no_modifier) { SearchQueryModifier.new({}, simple_config) }
   let(:query) { SearchQueryModifier.new({q: "Query of the stopwords"}, simple_config) }
   let(:filter) { SearchQueryModifier.new({f: {fieldA: ["ValueA"], fieldB: ['ValueB']}, q: 'a query'}, facet_config) }
+  let(:range) { SearchQueryModifier.new({range: {fieldA: {begin: '1234', end: '4321'}}, q: 'a query'}, facet_config) }
   let(:fielded) { SearchQueryModifier.new({search_field: 'search_title', q: 'a query'}, simple_config) }
   describe "stopwords search" do
     before do
@@ -19,6 +20,15 @@ describe "catalog/_additional_results_block.html.erb" do
     end
     it "should render a link removing stopwords if present" do
       expect(rendered).to have_css('a', text: 'Search without "and" "of" "the"')
+    end
+  end
+  describe "range search" do
+    before do
+      assign(:search_modifier, range)
+      render
+    end
+    it "should render a link removing filters" do
+      expect(rendered).to have_css('a', text: 'Remove limit(s)')
     end
   end
   describe "filtered search" do
@@ -45,6 +55,9 @@ describe "catalog/_additional_results_block.html.erb" do
       render
     end
     it "should not include any of the modifier links" do
+      expect(rendered).not_to have_content("Looking for different results?")
+      expect(rendered).not_to have_content("Modify your search")
+      expect(rendered).not_to have_content("Search elsewhere")
       expect(rendered).not_to have_css('a', text: 'Search without "and" "of" "the"')
       expect(rendered).not_to have_css('a', text: 'Remove limit(s)')
       expect(rendered).not_to have_css('a', text: 'Search all fields')
@@ -59,6 +72,16 @@ describe "catalog/_additional_results_block.html.erb" do
     it "should include a link to the library website" do
       expect(rendered).to have_css('a', text: 'Search library website')
       expect(rendered).to match /library\.stanford\.edu\/search\/website\?search=hello/
+    end
+  end
+  describe "pages past the first" do
+    before do
+      assign(:search_modifier, filter)
+      view.stub(:params).and_return(page: 2)
+      render
+    end
+    it "should not render" do
+      expect(rendered).to be_blank
     end
   end
 end

--- a/spec/views/catalog/_zero_results.html.erb_spec.rb
+++ b/spec/views/catalog/_zero_results.html.erb_spec.rb
@@ -32,7 +32,6 @@ describe "catalog/_zero_results.html.erb" do
     render
     expect(rendered).to have_css("h3", text: "Check other sources")
     expect(rendered).to have_css("a", text: "Check WorldCat")
-    expect(rendered).to have_css("a", text: "Check articles")
     expect(rendered).to have_css("a", text: "Check library website")
   end
 


### PR DESCRIPTION
Closes #674 
- Don't show "Remove limit(s)" link unless there is a query (so we don't lead to an all results page).
- Don't show the additional results block on any page but the first page.
- Don't execute backend lookup until the link is in the viewport to minimize solr queries.
- Removed disabled Article search link.
- Only link to WorldCat/Library search when there is a query to search.

![backend-lookup](https://cloud.githubusercontent.com/assets/96776/3900255/febe14b6-2288-11e4-9c33-f2e8777571fb.gif)

---
#### Search w/ filters
## ![search-w-filters](https://cloud.githubusercontent.com/assets/96776/3900257/10afcb24-2289-11e4-90ff-d8b3139ffa57.png)
#### Search w/o filters
## ![search-wo-filters](https://cloud.githubusercontent.com/assets/96776/3900256/109ecf5e-2289-11e4-9be2-ee1502b37bf7.png)
#### Search w/ stop-words
## ![search-w-stopwords](https://cloud.githubusercontent.com/assets/96776/3900258/10c261c6-2289-11e4-99f4-990c5faf76a4.png)
#### Zero results w/ filters
## ![zero-results-w-filters](https://cloud.githubusercontent.com/assets/96776/3900259/10d13660-2289-11e4-9961-35eb7964cdf6.png)
#### Zero results w/o filters

![zero-results-wo-filters](https://cloud.githubusercontent.com/assets/96776/3900260/10e705b2-2289-11e4-987c-56c650cd607c.png)
