### PR TITLE
Fallback on sorting by location/library code if there is no configured name

### DIFF
--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -16,7 +16,7 @@ class Holdings
           Holdings::Location.new(location_code, items)
         end
         append_mhld(:location, @locations, Holdings::Location)
-        @locations.sort_by!(&:name)
+        @locations.sort_by!(&:sort)
       end
       @locations
     end
@@ -37,7 +37,7 @@ class Holdings
       if @code == "GREEN"
         '0'
       else
-        name
+        name || @code
       end
     end
   end

--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -21,6 +21,9 @@ class Holdings
     def present_on_index?
       any_items? || any_index_mhlds?
     end
+    def sort
+      name || @code
+    end
     private
     def any_items?
       items.any?(&:present?)

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -26,6 +26,8 @@ describe Holdings::Library do
     it "should group by home location" do
       expect(callnumbers.length).to eq 3
       expect(locations.length).to eq 2
+    end
+    it "should sort by location code when there is no translation" do
       expect(locations.map(&:code)).to eq ["home-loc", "home-loc2"]
     end
     it "should sort locations alpha by name" do

--- a/spec/lib/holdings_spec.rb
+++ b/spec/lib/holdings_spec.rb
@@ -79,6 +79,8 @@ describe Holdings do
     }
     it "should group by library" do
       expect(libraries.libraries.length).to eq 2
+    end
+    it "should sort by library code when there is no translation" do
       expect(libraries.libraries.map(&:code)).to eq ['library', 'library2']
     end
     it "should sort Green first then the rest alpha" do


### PR DESCRIPTION
From time to time we'll get locations that aren't in our translation table.  This will sort on the code if there is no configured name for library or location.
