### PR TITLE
Layout changes for non-image collection previews

### DIFF
--- a/app/assets/stylesheets/modules/accordion-sections.css.scss
+++ b/app/assets/stylesheets/modules/accordion-sections.css.scss
@@ -1,143 +1,148 @@
-.accordion-section {
-  font-size: small;
-  margin: 0 0 7px 0;
-  padding-left: 0;
+.accordion-sections {
+  margin-bottom: 15px;
+  overflow: auto;
 
-  .header {
-    float: left;
-    border-radius: 2px;
-    color: $white;
-    display: inline-block;
-    margin-right: 1em;
-    cursor: pointer;
-    padding: 2px 10px;
-    border-bottom: none;
-    font-weight: 300;
-    font-size: 0.9em;
-    padding: 0 8px 1px 10px;
-    white-space: nowrap;
-    width: 10.5em;
-    text-align: right;
+  .accordion-section {
+    font-size: small;
+    margin: 0 0 7px 0;
+    padding-left: 0;
 
-    i.fa {
-      padding-left: 4px;
+    .header {
+      float: left;
+      border-radius: 2px;
+      color: $white;
+      display: inline-block;
+      margin-right: 1em;
+      cursor: pointer;
+      padding: 2px 10px;
+      border-bottom: none;
+      font-weight: 300;
+      font-size: 0.9em;
+      padding: 0 8px 1px 10px;
+      white-space: nowrap;
+      width: 10.5em;
+      text-align: right;
+
+      i.fa {
+        padding-left: 4px;
+      }
     }
-  }
 
-  .remove-list-styles {
-    ul, ol {
-      margin-bottom: 0;
+    .remove-list-styles {
+      ul, ol {
+        margin-bottom: 0;
+      }
     }
-  }
 
-  &.summary {
+    &.summary {
+      .snippet {
+        margin-left: 86px;
+        ul {
+          list-style-type: none;
+        }
+      }
+    }
+
     .snippet {
-      margin-left: 86px;
-      ul {
-        list-style-type: none;
-      }
-    }
-  }
-
-  .snippet {
-    color: $sul-mini-accordion-text-color;
-    @extend .remove-list-styles;
-  }
-
-  .details {
-    border-top: 1px solid $sul-document-border-color;
-    border-right: 1px solid $sul-document-border-color;
-    border-bottom: 1px solid $sul-document-border-bottom-color;
-    border-left: 1px solid $sul-document-border-color;
-    display: none;
-    padding: 10px;
-    clear: left;
-    @extend .remove-list-styles;
-  }
-
-  .details:target {
-    display: block;
-  }
-
-}
-
-.accordion-section.summary {
-  .header {
-    background-color: $sul-summary-bg;
-  }
-}
-
-.accordion-section.online {
-  .header {
-    background-color: $sul-access-online-bg;
-    &.selected-database {
-      width: 10.7em;
-    }
-  }
-
-  .details {
-    .links {
-      list-style-type: none;
-      padding-left: 10px;
+      color: $sul-mini-accordion-text-color;
+      @extend .remove-list-styles;
     }
 
-    .google-books {
+    .details {
+      border-top: 1px solid $sul-document-border-color;
+      border-right: 1px solid $sul-document-border-color;
+      border-bottom: 1px solid $sul-document-border-bottom-color;
+      border-left: 1px solid $sul-document-border-color;
       display: none;
-      margin-top: 10px;
+      padding: 10px;
+      clear: left;
+      @extend .remove-list-styles;
+    }
 
-      ul {
+    .details:target {
+      display: block;
+    }
+
+  }
+
+  .accordion-section.summary {
+    .header {
+      background-color: $sul-summary-bg;
+    }
+  }
+
+  .accordion-section.online {
+    .header {
+      background-color: $sul-access-online-bg;
+      &.selected-database {
+        width: 10.7em;
+      }
+    }
+
+    .details {
+      .links {
         list-style-type: none;
-        padding-left: 0px;
-
-        li a {
-          display: none;
-        }
+        padding-left: 10px;
       }
 
-      .btn-preview {
+      .google-books {
         display: none;
+        margin-top: 10px;
 
-        .preview-link {
+        ul {
+          list-style-type: none;
+          padding-left: 0px;
+
+          li a {
+            display: none;
+          }
+        }
+
+        .btn-preview {
           display: none;
+
+          .preview-link {
+            display: none;
+          }
         }
       }
     }
   }
-}
 
-.accordion-section.course-reserves {
-  .header {
-    background-color: $sul-access-course-reserve-bg;
-  }
-
-  .details {
-    dd {
-      margin: 0 0 10px 15px;
-    }
-  }
-}
-
-.accordion-section.location {
-  .header {
-    background-color: $sul-access-location-bg;
-  }
-
-  .location-header {
-    background-color: #eee;
-    padding: 5px;
-    margin: 0;
-  }
-
-  .details {
-    padding: 0;
-
-    .location-column {
-      padding: 10px 25px;
+  .accordion-section.course-reserves {
+    .header {
+      background-color: $sul-access-course-reserve-bg;
     }
 
-    .stackmap-find-it {
-      font-weight: normal;
-      margin-left: 10px;
+    .details {
+      dd {
+        margin: 0 0 10px 15px;
+      }
+    }
+  }
+
+  .accordion-section.location {
+    .header {
+      background-color: $sul-access-location-bg;
+    }
+
+    .location-header {
+      background-color: #eee;
+      padding: 5px;
+      margin: 0;
+    }
+
+    .details {
+      padding: 0;
+
+      .location-column {
+        padding: 10px 25px;
+      }
+
+      .stackmap-find-it {
+        font-weight: normal;
+        margin-left: 10px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/file-collection-members.css.scss
+++ b/app/assets/stylesheets/modules/file-collection-members.css.scss
@@ -1,22 +1,31 @@
 .file-collection-members {
-  clear: both;
-  position: relative;
   border: 1px solid $panel-inner-border;
-  padding: 5px;
+  clear: both;
+  padding: 20px 5px 10px 5px;
+  position: relative;
 
   .members-number {
     position: absolute;
-    padding: 3px 5px;
     top: -10px;
     left: 45%;
-    a {
-      color: white;
-    }
   }
+
   .file-item {
-    margin-bottom: 5px;
+    margin: 0 0 8px 0;
+
     .file-icon {
-      text-align: right;
+      font-size: 20px;
+      padding: 2px 6px 0 5px;
+      text-align: center;
+      width: 20px;
+    }
+
+    .file-title {
     }
   }
+
+  .label-items-online {
+    @include label-items-online;
+  }
+
 }

--- a/app/assets/stylesheets/modules/image-collection-filmstrip.css.scss
+++ b/app/assets/stylesheets/modules/image-collection-filmstrip.css.scss
@@ -84,7 +84,10 @@
         margin-right: 0;
       }
     }
-
-
   }
+
+  .label-items-online {
+    @include label-items-online;
+  }
+
 }

--- a/app/assets/stylesheets/modules/results-documents.css.scss
+++ b/app/assets/stylesheets/modules/results-documents.css.scss
@@ -3,6 +3,7 @@
   .document {
     @include document;
 
+
     h3.index_title {
       @include h3-index-title-indent;
     }
@@ -33,6 +34,11 @@
   .cursor-pointer {
     cursor: pointer;
   }
+
+  .label-items-online {
+    @include label-items-online;
+  }
+
 }
 
 .document-metadata {

--- a/app/assets/stylesheets/searchworks-mixins.css.scss
+++ b/app/assets/stylesheets/searchworks-mixins.css.scss
@@ -33,3 +33,16 @@
   background-color: $sul-toolbar-bg;
   border-bottom: 3px solid $sul-toolbar-border !important;
 }
+
+@mixin label-items-online {
+  background-color: $sul-access-online-bg;
+  color: $white;
+  font-size: 12px;
+  font-weight: 300;
+  padding: 4px 8px;
+
+  a {
+    border-bottom: none;
+    color: white;
+  }
+}

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -5,7 +5,7 @@ module CollectionHelper
 
   def collection_members_enumeration(document)
     if document.collection_members.present?
-      "1 - #{document.collection_members.length} of #{pluralize(document.collection_members.total, 'item')} online"
+      "#{pluralize(document.collection_members.total, 'item')} online"
     end
   end
 

--- a/app/views/catalog/_file_collection_members.html.erb
+++ b/app/views/catalog/_file_collection_members.html.erb
@@ -1,23 +1,22 @@
 <% document ||= @document %>
 <% if document.collection_members(rows: 3).present? %>
   <div class="file-collection-members">
-    <span class="members-number label label-success">
+    <span class="members-number label label-items-online">
       <%= link_to_collection_members(collection_members_enumeration(document), document) %>
     </span>
     <% document.collection_members.each do |collection_member| %>
       <div class="row file-item">
-        <div class="col-xs-1 file-icon">
-          <%= link_to(image_tag("http://placehold.it/50x50"), catalog_path(collection_member)) %>
+        <div class="col-xs-2 file-icon">
+          <%= render_resource_icon collection_member[collection_member.format_key] %>
         </div>
-        <div class="col-xs-8 file-title">
+        <div class="col-xs-10 file-title">
           <%= link_to(presenter(collection_member).document_heading, catalog_path(collection_member)) %>
           <% if collection_member[:pub_date] %>
             <span class="main-title-date">[<%= collection_member[:pub_date] %>]</span>
           <% end %>
-        </div>
-        <div class="col-xs-3 file-author">
+          <br/>
           <% if collection_member.authors_from_index.present? %>
-            <%= collection_member.authors_from_index.first %>
+            <span class="file-author"><%= collection_member.authors_from_index.first %></span>
           <% end %>
         </div>
       </div>

--- a/app/views/catalog/_image_collection_filmstrip.html.erb
+++ b/app/views/catalog/_image_collection_filmstrip.html.erb
@@ -9,7 +9,7 @@
     <span class="glyphicon glyphicon-chevron-left"></span>
   </button>
 
-  <span class="members-number label label-success">
+  <span class="members-number label label-items-online">
     <%= link_to_collection_members(collection_members_enumeration(collection_document), collection_document) %>
   </span>
 

--- a/app/views/catalog/_search_results_accordion_sections.html.erb
+++ b/app/views/catalog/_search_results_accordion_sections.html.erb
@@ -1,4 +1,6 @@
-<%= render :partial => "catalog/accordion_section_summary", :locals => { :document => document } %>
-<%= render :partial => "catalog/accordion_section_online", :locals => { :document => document } %>
-<%= render :partial => "catalog/accordion_section_library", :locals => { :document => document } %>
-<%= render :partial => "catalog/accordion_section_course_reserves", :locals => { :document => document } %>
+<div class="accordion-sections">
+  <%= render :partial => "catalog/accordion_section_summary", :locals => { :document => document } %>
+  <%= render :partial => "catalog/accordion_section_online", :locals => { :document => document } %>
+  <%= render :partial => "catalog/accordion_section_library", :locals => { :document => document } %>
+  <%= render :partial => "catalog/accordion_section_course_reserves", :locals => { :document => document } %>
+</div>

--- a/spec/features/blacklight_customizations/breadcrumb_spec.rb
+++ b/spec/features/blacklight_customizations/breadcrumb_spec.rb
@@ -7,7 +7,7 @@ describe "Breadcrumb Customizations", type: :feature do
       fill_in 'q', with: '29'
       click_button 'search'
 
-      click_link '1 - 1 of 1 item online'
+      click_link '1 item online'
 
       within('.breadcrumb') do
         expect(page).to have_css('.filterValue', text: 'Image Collection1')

--- a/spec/helpers/collection_helper_spec.rb
+++ b/spec/helpers/collection_helper_spec.rb
@@ -27,7 +27,7 @@ describe CollectionHelper do
       no_collection_doc.stub(:collection_members).and_return([])
     end
     it "should return the correct number of document including the #total" do
-      expect(collection_members_enumeration(document)).to eq "1 - 2 of 5 items online"
+      expect(collection_members_enumeration(document)).to eq "5 items online"
     end
     it "should not return anything if an document does not have collection members" do
       expect(collection_members_enumeration(no_collection_doc)).to be_nil

--- a/spec/views/catalog/_file_collection_members.html.erb_spec.rb
+++ b/spec/views/catalog/_file_collection_members.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe "catalog/_file_collection_members.html.erb" do
     render
   end
   it "should have an icon" do
-    expect(rendered).to have_css('.file-icon img')
+    expect(rendered).to have_css('.file-icon')
   end
   it "should link the title" do
     expect(rendered).to have_css(".file-title a", text: "File Item")


### PR DESCRIPTION
Closes #613 
Closes #340 

> Layout changes to:
> - [x] get rid of the table layout, 
> - [x] use icon font instead of image, 
> - [x] drop the "1-3 of" text from the label,
> - [x] use the standard "online" bg color (#009b76) for the label,
> - [x] make the label the same size and font as the At the library etc. labels
> - [x] add margin below the other expand-o sections.
## 
## ![image](https://cloud.githubusercontent.com/assets/302258/3900974/80bd462e-229a-11e4-8fe3-c390d11e359d.png)

![image](https://cloud.githubusercontent.com/assets/302258/3900975/89243d0e-229a-11e4-80a4-506359c68f59.png)
