### PR TITLE
[WIP] Add public_note and callnumber_type methods to the callnumber class.

### DIFF
--- a/lib/holdings/callnumber.rb
+++ b/lib/holdings/callnumber.rb
@@ -57,14 +57,20 @@ class Holdings
     def full_shelfkey
       item_display[9]
     end
-    def course_id
-      item_display[10]
+    def public_note
+      item_display[10].gsub('.PUBLIC.', '').strip if item_display[10]
     end
-    def reserve_desk
+    def callnumber_type
       item_display[11]
     end
-    def loan_period
+    def course_id
       item_display[12]
+    end
+    def reserve_desk
+      item_display[13]
+    end
+    def loan_period
+      item_display[14]
     end
 
     def status

--- a/spec/lib/holdings/callnumber_spec.rb
+++ b/spec/lib/holdings/callnumber_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 describe Holdings::Callnumber do
   let(:complex_item_display) {
-    'barcode -|- library -|- home_location -|- current_location -|- type -|- truncated_callnumber -|- shelfkey -|- reverse_shelfkey -|- callnumber -|- full_shelfkey -|- course_id -|- reserve_desk -|- loan_period'
+    'barcode -|- library -|- home_location -|- current_location -|- type -|- truncated_callnumber -|- shelfkey -|- reverse_shelfkey -|- callnumber -|- full_shelfkey -|- public_note -|- callnumber_type -|- course_id -|- reserve_desk -|- loan_period'
   }
   let(:callnumber) { Holdings::Callnumber.new(complex_item_display) }
-  let(:methods) { [:barcode, :library, :home_location, :current_location, :type, :truncated_callnumber, :shelfkey, :reverse_shelfkey, :callnumber, :full_shelfkey, :course_id, :reserve_desk, :loan_period] }
+  let(:methods) { [:barcode, :library, :home_location, :current_location, :type, :truncated_callnumber, :shelfkey, :reverse_shelfkey, :callnumber, :full_shelfkey, :public_note, :callnumber_type, :course_id, :reserve_desk, :loan_period] }
   it "should have an attribute for each piece of the item display field" do
     methods.each do |method|
       expect(callnumber).to respond_to(method)
@@ -63,6 +63,13 @@ describe Holdings::Callnumber do
     end
     it "should replace the home location with the current location" do
       expect(Holdings::Callnumber.new("barcode -|- library -|- home_location -|- IC-DISPLAY -|-").home_location).to eq "IC-DISPLAY"
+    end
+  end
+  describe "public_note" do
+    let(:public_note) { Holdings::Callnumber.new('barcode -|- library -|- home_location -|- current_location -|- type -|- truncated_callnumber -|- shelfkey -|- reverse_shelfkey -|- callnumber -|- full_shelfkey -|- .PUBLIC. The Public Note -|- callnumber_type -|- course_id -|- reserve_desk -|- loan_period') }
+    it "should remove the .PUBLIC. string from the public note field" do
+      expect(public_note.public_note).to eq 'The Public Note'
+      expect(public_note.public_note).to_not include 'PUBLIC'
     end
   end
   describe "reserves" do


### PR DESCRIPTION
Prerequisite for #469 and #566.

This is ready to merge but we don't want to deploy it until the indexing team has updated the redesign index w/ the new `item_display` fields to match.
