### PR TITLE
remove top level class references

### DIFF
--- a/app/models/concerns/marc_instrumentation.rb
+++ b/app/models/concerns/marc_instrumentation.rb
@@ -1,7 +1,7 @@
 module MarcInstrumentation
   def marc_instrumentation
     if self.respond_to?(:to_marc)
-      @marc_instrumentation ||= SearchWorksMarc::Instrumentation.new(self.to_marc)
+      @marc_instrumentation ||= Instrumentation.new(self.to_marc)
     end
   end
 end

--- a/spec/lib/search_works_marc/instrumentation_spec.rb
+++ b/spec/lib/search_works_marc/instrumentation_spec.rb
@@ -5,7 +5,7 @@ describe Instrumentation do
 
   describe 'initialize' do
     let(:document) { SolrDocument.new(marcxml: marc_382_instrumentation).to_marc }
-    let(:instrumentation) { SearchWorksMarc::Instrumentation.new(document) }
+    let(:instrumentation) { Instrumentation.new(document) }
     it 'should be type Instrumentation' do
       expect(instrumentation.class).to eq Instrumentation
     end
@@ -17,7 +17,7 @@ describe Instrumentation do
   end
   describe 'parse_marc_record' do
     let(:document) { SolrDocument.new(marcxml: marc_382_instrumentation).to_marc }
-    let(:instrumentation) { SearchWorksMarc::Instrumentation.new(document) }
+    let(:instrumentation) { Instrumentation.new(document) }
     it 'should return an array' do
       expect(instrumentation.parse_marc_record.class).to eq Array
     end

--- a/spec/models/concerns/marc_instrumentation_spec.rb
+++ b/spec/models/concerns/marc_instrumentation_spec.rb
@@ -12,6 +12,6 @@ describe MarcInstrumentation do
   end
   it 'should return SearchWorksMarc::Instrumentation for document with 382 field' do
     document = SolrDocument.new(marcxml: marc_382_instrumentation)
-    expect(document.marc_instrumentation.class).to eq SearchWorksMarc::Instrumentation
+    expect(document.marc_instrumentation.class).to eq Instrumentation
   end
 end


### PR DESCRIPTION
So warnings are not in tests anymore
