### PR TITLE
adds print stylesheets

### DIFF
--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -1,0 +1,10 @@
+
+@import 'print/bootstrap-variables';
+@import 'sul-variables';
+@import 'searchworks-mixins';
+@import 'blacklight';
+@import 'searchworks';
+@import 'font-awesome';
+@import '_sul-icons-rails';
+@import 'print/layout';
+@import 'print/styles';

--- a/app/assets/stylesheets/print/bootstrap-variables.css.scss
+++ b/app/assets/stylesheets/print/bootstrap-variables.css.scss
@@ -1,0 +1,3 @@
+// Bootstrap variables for print sheets
+
+$font-size-base: 12px;

--- a/app/assets/stylesheets/print/layout.css.scss
+++ b/app/assets/stylesheets/print/layout.css.scss
@@ -1,0 +1,9 @@
+.record-panels.col-md-4{
+  @extend .col-xs-4;
+}
+.record-sections.col-md-8{
+  @extend .col-xs-8;
+}
+#content.col-sm-7.col-md-8 {
+  @extend .col-xs-12;
+}

--- a/app/assets/stylesheets/print/styles.css.scss
+++ b/app/assets/stylesheets/print/styles.css.scss
@@ -1,0 +1,91 @@
+.print-header {
+  padding-left: 10px;
+  padding-right: 10px;
+  text-align: right;
+  h1 {
+    font-size: floor(($font-size-base * 1.6))
+  }
+  h2 {
+    border: none;
+    font-size: floor(($font-size-base * 1.4))
+  }
+}
+
+.breadcrumb.row {
+  float: left;
+}
+
+#appliedParams {
+  float:left;
+}
+
+.search_num_of_results {
+  margin-top: -45px;
+}
+
+// Do not display these elements
+.navbar, #topnav, #search-navbar-container, #facets, #sortAndPerPage, .record-toolbar, a.remove, .index-document-functions, footer, #sul-footer-container, #global-footer, .additional-results, .pagination, .record-side-nav, .library-location-heading img, .record-browse-nearby, .tech-details a, a.btn, .gallery-buttons, .preview-button-container, .google-preview {
+  display: none !important;
+}
+a[href]:after {
+  content: "";
+}
+
+h3.index_title {
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+}
+
+a,  a:visited {
+  text-decoration: none; border-bottom: none;
+}
+#documents .document, #documents .brief-document, #documents .gallery-document {
+  border: 0;
+  border-bottom: 1px solid #ddd; margin: 0;
+}
+.gallery .gallery-document {
+  height: 350px;
+}
+.callnumber-bar {
+  font-weight: normal; font-size: 1.1em;
+}
+#appliedParams {
+  padding: 0;
+}
+.constraint-value {
+  border: 0;
+}
+.accordion-section .snippet {
+  display: none;
+}
+.accordion-section .details {
+  display: block !important; border: 0;
+}
+.details dl {
+  margin-bottom: 0;
+}
+.accordion-section a.header {
+  text-align: left; padding-left: 0; font-weight: bold;
+}
+.accordion-section a.header i {
+  display: none;
+}
+.panel-library-location .library-location-heading-text {
+  padding-left: 0;
+}
+.document h1 {
+  margin-top: 0; padding-top: 0;
+}
+.record-sections .section {
+  padding-bottom: 0;
+}
+.panel-heading {
+  padding-left: 0;
+}
+#masthead {
+  border: none;
+}
+#su-content {
+  padding-bottom: 0!important;
+}

--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -17,6 +17,7 @@
     <%= opensearch_description_tag application_name, opensearch_catalog_path(:format => 'xml', :only_path => false) %>
     <%= favicon_link_tag asset_path('favicon.ico') %>
     <%= stylesheet_link_tag "application", media: "all" %>
+    <%= stylesheet_link_tag 'print', media: 'print' %>
     <link href="https://www.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
     <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" %>
     <%= javascript_include_tag "application" %>
@@ -45,7 +46,7 @@
           <%= render_masthead_partial %>
 
           <%= render partial: 'shared/ajax_modal' %>
-
+          <%= render 'shared/print_header' %>
           <section id="main-container" role="main" data-analytics-id="<%= Settings.GOOGLE_ANALYTICS_ID %>">
             <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 

--- a/app/views/shared/_print_header.html.erb
+++ b/app/views/shared/_print_header.html.erb
@@ -1,0 +1,4 @@
+<div class='visible-print print-header pull-right'>
+  <h1>SearchWorks Catalog</h1>
+  <h2>Stanford University Libraries</h2>
+</div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( print.css )


### PR DESCRIPTION
Closes #651 

So one thing about this is, we are essentially loading the styles twice. I haven't been able to figure out a better way to do this. I think this should be fine when minified and concat'd in prod.
### Record page - 493515

![screen shot 2014-08-14 at 1 13 19 pm](https://cloud.githubusercontent.com/assets/1656824/3926213/7e2c39e6-23ef-11e4-9ad8-f2ba67f54a03.png)
### Results page - ?utf8=✓&search_field=search&q=cats

![screen shot 2014-08-14 at 1 11 52 pm](https://cloud.githubusercontent.com/assets/1656824/3926199/6071d9e2-23ef-11e4-9a12-3e3ac020192a.png)
### Gallery results - ?utf8=✓&search_field=search&q=cats&view=gallery

![screen shot 2014-08-14 at 1 14 17 pm](https://cloud.githubusercontent.com/assets/1656824/3926233/abfb1144-23ef-11e4-9a15-53f32190bd3b.png)
### Brief results - ?utf8=✓&search_field=search&q=cats&view=brief

![screen shot 2014-08-14 at 1 15 28 pm](https://cloud.githubusercontent.com/assets/1656824/3926243/c4746748-23ef-11e4-893e-ebc51a101ff3.png)
