### PR TITLE
[WIP] Mods relateditems language

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -19,6 +19,22 @@ module RecordHelper
     end.join('').html_safe
   end
 
+  def mods_language_field field
+    if field.respond_to?(:label, :values) &&
+       field.values.any?(&:present?)
+      mods_display_label(field.label) +
+      mods_display_content_together(field.values)
+    end
+  end
+
+  def mods_display_content_together values
+    linked_values = []
+    Array[values].flatten.map do |value|
+      linked_values.push(link_urls_and_email(value).html_safe) if value.present?
+    end
+    content_tag(:dd, linked_values.join('; ').html_safe)
+  end
+
   def mods_display_label label
     content_tag(:dt, label.gsub(":",""))
   end

--- a/app/views/catalog/record/_mods_bibliographic.html.erb
+++ b/app/views/catalog/record/_mods_bibliographic.html.erb
@@ -1,3 +1,15 @@
+<% @document.mods.resourceType.each do |resource_type| %>
+  <%= mods_record_field(resource_type) %>
+<% end %>
+
+<% @document.mods.imprint.each do |imprint| %>
+  <%= mods_record_field(imprint) %>
+<% end %>
+
+<% @document.mods.language.each do |language| %>
+  <%= mods_record_field(language) %>
+<% end %>
+
 <% @document.mods.audience.each do |audience| %>
   <%= mods_record_field(audience) %>
 <% end %>

--- a/app/views/catalog/record/_mods_bibliographic.html.erb
+++ b/app/views/catalog/record/_mods_bibliographic.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% @document.mods.language.each do |language| %>
-  <%= mods_record_field(language) %>
+  <%= mods_language_field(language) %>
 <% end %>
 
 <% @document.mods.audience.each do |audience| %>

--- a/app/views/catalog/record/_mods_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_mods_upper_metadata_items.html.erb
@@ -2,18 +2,6 @@
   <%= mods_name_field(name) %>
 <% end %>
 
-<% @document.mods.resourceType.each do |resource_type| %>
-  <%= mods_record_field(resource_type) %>
-<% end %>
-
-<% @document.mods.imprint.each do |imprint| %>
-  <%= mods_record_field(imprint) %>
-<% end %>
-
-<% @document.mods.language.each do |language| %>
-  <%= mods_record_field(language) %>
-<% end %>
-
 <% @document.mods.description.each do |description| %>
   <%= mods_record_field(description) %>
 <% end %>

--- a/spec/fixtures/mods_records/mods_fixtures.rb
+++ b/spec/fixtures/mods_records/mods_fixtures.rb
@@ -87,6 +87,7 @@ module ModsFixtures
         </originInfo>
         <language displayLabel="Lang">
           <languageTerm type="code">eng</languageTerm>
+          <languageTerm type="code">per</languageTerm>
         </language>
         <physicalDescription>
           <note displayLabel="Condition">amazing</note>

--- a/spec/fixtures/mods_records/mods_fixtures.rb
+++ b/spec/fixtures/mods_records/mods_fixtures.rb
@@ -86,7 +86,7 @@ module ModsFixtures
           <dateIssued>copyright 2014</dateIssued>
         </originInfo>
         <language displayLabel="Lang">
-          <languageTerm type="text">Esperanza</languageTerm>
+          <languageTerm type="code">eng</languageTerm>
         </language>
         <physicalDescription>
           <note displayLabel="Condition">amazing</note>
@@ -102,10 +102,9 @@ module ModsFixtures
         <note displayLabel="Notez">Pick up milkz</note>
         <relatedItem>
           <titleInfo>
-            <title>The collection of everything</title>
+            The collection of everything
           </titleInfo>
           <identifier type="uri">http://fakeurl.stanford.edu/abc123</identifier>
-          <typeOfResource collection="yes" />
         </relatedItem>
         <identifier type="uri">http://www.myspace.com/myband</identifier>
         <location>

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -44,6 +44,27 @@ describe RecordHelper do
     end
   end
 
+  describe 'mods_display_content_together' do
+    it 'should return correct content delimited by a semi colon and space' do
+      expect(helper.mods_display_content_together(['hello', 'there'])).to have_css('dd', count: 1, text: 'hello; there')
+    end
+  end
+
+  describe 'mods_language_field' do
+    let(:mods_field)  { OpenStruct.new({label: "test", values: ["hello", "there"]}) }
+    let(:url_field)  { OpenStruct.new({label: "test", values: ["http://library.stanford.edu"]}) }
+    it 'should return correct content' do
+      expect(helper.mods_language_field(mods_field)).to have_css("dt", text: "test")
+      expect(helper.mods_language_field(mods_field)).to have_css("dd", text: "hello; there")
+    end
+    it "should link fields with URLs" do
+      expect(mods_language_field(url_field)).to have_css("a[href='http://library.stanford.edu']", text: "http://library.stanford.edu")
+    end
+    it "should not print empty labels" do
+      expect(helper.mods_language_field(empty_field)).to_not be_present
+    end
+  end
+
   describe "mods_record_field" do
     let(:mods_field)  { OpenStruct.new({label: "test", values: ["hello, there"]}) }
     let(:url_field)  { OpenStruct.new({label: "test", values: ["http://library.stanford.edu"]}) }

--- a/spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb
@@ -9,6 +9,21 @@ describe "catalog/record/_mods_bibliographic.html.erb" do
     before do
       assign(:document, document)
     end
+    it "should display type" do
+      render
+      expect(rendered).to have_css("dt", text: "Type of resource")
+      expect(rendered).to have_css("dd", text: "Still image")
+    end
+    it "should display imprint" do
+      render
+      expect(rendered).to have_css("dt", text: "Imprint")
+      expect(rendered).to have_css("dd", text: "copyright 2014")
+    end
+    it "should display language" do
+      render
+      expect(rendered).to have_css("dt", text: "Lang")
+      expect(rendered).to have_css("dd", text: "English")
+    end
     it "should display audience" do
       render
       expect(rendered).to have_css("dt", text: "Who?")
@@ -21,10 +36,10 @@ describe "catalog/record/_mods_bibliographic.html.erb" do
       expect(rendered).to have_css("dt", text: "Notez")
       expect(rendered).to have_css("dd", text: "Pick up milkz")
     end
-    pending "should display related item" do
-      # render
-      # expect(rendered).to have_css("dt", text: "Related")
-      # expect(rendered).to have_css("dd", text: "Cat loverz")
+    it "should display related item" do
+      render
+      expect(rendered).to have_css("dt", text: "Related")
+      expect(rendered).to have_css("dd", text: "Cat loverz")
     end
     it "should display identifier" do
       render

--- a/spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb
@@ -22,7 +22,7 @@ describe "catalog/record/_mods_bibliographic.html.erb" do
     it "should display language" do
       render
       expect(rendered).to have_css("dt", text: "Lang")
-      expect(rendered).to have_css("dd", text: "English")
+      expect(rendered).to have_css("dd", text: "English; Persian")
     end
     it "should display audience" do
       render

--- a/spec/views/catalog/record/_mods_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_upper_metadata_items.html.erb_spec.rb
@@ -13,21 +13,6 @@ describe "catalog/record/_mods_upper_metadata_items.html.erb" do
       expect(rendered).to have_css("dt", text: "Author/Creator")
       expect(rendered).to have_css("dd", text: "J. Smith")
     end
-    it "should display type" do
-      render
-      expect(rendered).to have_css("dt", text: "Type of resource")
-      expect(rendered).to have_css("dd", text: "Still image")
-    end
-    it "should display imprint" do
-      render
-      expect(rendered).to have_css("dt", text: "Imprint")
-      expect(rendered).to have_css("dd", text: "copyright 2014")
-    end
-    pending "should display language" do
-      # render
-      # expect(rendered).to have_css("div.section-uppermetadata dt", text: "Lang")
-      # expect(rendered).to have_css("div.section-uppermetadata dd", text: "Esperanza")
-    end
     it "should display description" do
       render
       expect(rendered).to have_css("dt", text: "Condition")

--- a/spec/views/catalog/record/_mods_upper_metadata_section.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_upper_metadata_section.html.erb_spec.rb
@@ -10,8 +10,8 @@ describe "catalog/record/_mods_upper_metadata_section.html.erb" do
     end
     it "should display correct sections" do
       render
-      expect(rendered).to have_css("dt", count: 4)
-      expect(rendered).to have_css("dd", count: 4)
+      expect(rendered).to have_css("dt", count: 2)
+      expect(rendered).to have_css("dd", count: 2)
     end
   end
 


### PR DESCRIPTION
Closes #163, related to #143

Restructures the way mods metadata are ordered per @jvine spec.

Also, changes languages in mods to be one dd delimited by semi-colons
### Before - ww121ss5000

![screen shot 2014-08-15 at 7 21 14 am](https://cloud.githubusercontent.com/assets/1656824/3934130/d27e7700-2487-11e4-99f2-1cac658a1152.png)
### After

![screen shot 2014-08-15 at 7 20 19 am](https://cloud.githubusercontent.com/assets/1656824/3934131/da9c0c2c-2487-11e4-9cfd-2837696c4628.png)
#### The only fields left in upper metadata section are primary names and description. ww779nm2965

![screen shot 2014-08-15 at 7 20 28 am](https://cloud.githubusercontent.com/assets/1656824/3934151/05a4f5f0-2488-11e4-84bd-9d710cb8a881.png)
