### PR TITLE
removes access panel spacing

### DIFF
--- a/app/assets/stylesheets/modules/access-panel-library-locations.css.scss
+++ b/app/assets/stylesheets/modules/access-panel-library-locations.css.scss
@@ -20,7 +20,6 @@
     .items {
       li {
         padding-left: 20px;
-        margin-top: 10px;
 
         i {
           margin-left: -12px;


### PR DESCRIPTION
Closes #740 

Not adding the parent element `margin-bottom` as the current way the html is setup it shouldn't affect it. 
#### Before -8324859

![screen shot 2014-08-15 at 3 29 47 pm](https://cloud.githubusercontent.com/assets/1656824/3939679/b99ba250-24cb-11e4-9ffa-46268785b4ce.png)
#### After

![screen shot 2014-08-15 at 3 28 06 pm](https://cloud.githubusercontent.com/assets/1656824/3939673/95f2f696-24cb-11e4-8dc4-e13ae1650ba5.png)
