### PR TITLE
parse hours responses server side

### DIFF
--- a/app/assets/javascripts/location-hours.js
+++ b/app/assets/javascripts/location-hours.js
@@ -1,10 +1,9 @@
-$(function(){
-
+Blacklight.onLoad(function(){
   //Finds all of the location panels and instantiates jQuery plugin for each one
   $('[data-hours-route]').each(function(i,val){
-    $(val).locationHours(); 
+    $(val).locationHours();
   });
-})
+});
 
 
 ;(function ( $, window, document, undefined ) {
@@ -40,19 +39,16 @@ $(function(){
         init: function() {
           var element = this.element;
           var hoursElement = getHoursElement(this.element);
-          var libLocation = $(this.element).data('hours-route');          
+          var libLocation = $(this.element).data('hours-route');
           $.getJSON(libLocation, function(data){
+            if (data === null || !("hours" in data)){
+              return;
+            }
             if (data.error) {
               $(hoursElement).html(data.error);
               return;
             }
-            if (data === null){
-              return;
-            }
-            var open = getOpen(data[0]);
-            var close = getClose(data[0]);
-            var text = "Today's hours: " + open + " - " + close;
-            $(hoursElement).html(text);
+            $(hoursElement).html(data.hours);
           });
         }
     };

--- a/app/controllers/hours_controller.rb
+++ b/app/controllers/hours_controller.rb
@@ -1,6 +1,6 @@
 class HoursController < ApplicationController
   def show
-    response = HoursRequest.new(params[:id]).get
+    response = HoursRequest.new(params[:id]).parse_hours
     respond_to do |format|
       format.json { render json: response }
     end

--- a/lib/hours_request.rb
+++ b/lib/hours_request.rb
@@ -2,6 +2,23 @@ class HoursRequest
 
   def initialize(library)
     @library = library
+    @hours_response = parse_response
+  end
+
+  def parse_hours
+    if @hours_response.present? && !(@hours_response.has_key?('error'))
+      { hours: "Today's hours:#{opens_at} - #{closes_at}".gsub('m', '').gsub(':00', '') }
+    else
+      @hours_response
+    end
+  end
+
+  def parse_response
+    return begin
+      @hours_response = JSON.parse(get).first
+    rescue JSON::ParserError => e
+      @hours_response = nil
+    end
   end
 
   def full_url
@@ -20,7 +37,15 @@ class HoursRequest
         nil
       end
     else
-      {error: 'No public access'}.to_json
+      [{ error: 'No public access' }].to_json
     end
+  end
+
+  def opens_at
+    Time.parse(@hours_response['opens_at']).strftime('%l:%M%P').to_s
+  end
+
+  def closes_at
+    Time.parse(@hours_response['closes_at']).strftime('%l:%M%P').to_s
   end
 end

--- a/spec/lib/hours_request_spec.rb
+++ b/spec/lib/hours_request_spec.rb
@@ -3,7 +3,7 @@ require 'constants'
 describe HoursRequest do
   let(:library) { "GREEN" }
   let(:hours_request) { HoursRequest.new(library) }
-  let(:struct) { OpenStruct.new(get: OpenStruct.new(body: "test")) }
+  let(:struct) { OpenStruct.new(get: OpenStruct.new(body: '[{ "opens_at": "2014-08-26T08:30:00-07:00", "closes_at": "2014-08-26T17:00:00-07:00" }]')) }
 
   it "should initialize as HoursRequest object" do
     expect(hours_request).to be_an HoursRequest
@@ -18,13 +18,29 @@ describe HoursRequest do
     HoursRequest.new("SAL3").get
   end
   it "should return a JSON error if the library is not real" do
-    expect(JSON.parse(HoursRequest.new("NOT-A-REAL-LIBRARY").get)).to eq({'error' => 'No public access'})
+    expect(JSON.parse(HoursRequest.new("NOT-A-REAL-LIBRARY").get)).to eq([{'error' => 'No public access'}])
   end
 
-  it "should receive " do
-    # Fake URL that resolves for testing
-    expect(Faraday).to receive(:new).with({ url: "http://example.com/green/location/green_library/hours/for/today" }).and_return(struct)
-    expect(HoursRequest.new("GREEN").get).to eq("test")
+  describe '#get' do
+    it "should receive recieve a url and return the body response" do
+      # Fake URL that resolves for testing
+      expect(Faraday).to receive(:new).at_least(1).times.with({ url: "http://example.com/green/location/green_library/hours/for/today" }).and_return(struct)
+      expect(HoursRequest.new("GREEN").get).to eq "[{ \"opens_at\": \"2014-08-26T08:30:00-07:00\", \"closes_at\": \"2014-08-26T17:00:00-07:00\" }]"
+    end
+  end
+
+  describe '#opens_at' do
+    it 'should return correct opening hours' do
+      expect(Faraday).to receive(:new).at_least(1).times.with({ url: "http://example.com/green/location/green_library/hours/for/today" }).and_return(struct)
+      expect(hours_request.opens_at).to eq (' 8:30am')
+    end
+  end
+
+  describe '#closes_at' do
+    it 'should return correct xlosing hours' do
+      expect(Faraday).to receive(:new).at_least(1).times.with({ url: "http://example.com/green/location/green_library/hours/for/today" }).and_return(struct)
+      expect(hours_request.closes_at).to eq (' 5:00pm')
+    end
   end
 
 end


### PR DESCRIPTION
Closes #698 
Closes #775 // use BL.onLoad

Note: there are some issues with the hours api, so some of the libraries will fail gracefully by not showing anything.
#### 10250321

![screen shot 2014-08-26 at 4 19 56 pm](https://cloud.githubusercontent.com/assets/1656824/4053276/decfcb46-2d77-11e4-9f58-a232860dc50b.png)
