### PR TITLE
Use URI#escape for parsing the host of the index links (MARC links uses ...

### DIFF
--- a/app/models/concerns/index_links.rb
+++ b/app/models/concerns/index_links.rb
@@ -52,7 +52,7 @@ module IndexLinks
       @document[:url_sfx].include?(link)
     end
     def link_host(link_field)
-      uri = URI.parse(link_field.gsub('^',''))
+      uri = URI.parse(URI.escape(link_field))
       host = uri.host
       if host =~ /ezproxy\.stanford\.edu/
         query = CGI.parse(uri.query)

--- a/spec/models/concerns/index_links_spec.rb
+++ b/spec/models/concerns/index_links_spec.rb
@@ -24,7 +24,7 @@ describe IndexLinks do
   }
   let(:bad_url_document) {
     SolrDocument.new(
-      url_fulltext: ["http://www.example.com/lookup?^The+Query+Is+No+Good"]
+      url_fulltext: ["http://www.example.com/lookup?^The+Query+Is+No+Good", "http://www.example.com/{1234-1431324-431313}Img100.jpg"]
     )
   }
   describe "mixin" do
@@ -62,8 +62,9 @@ describe IndexLinks do
       expect(finding_aid_links.finding_aid.first.text).to match /<a href='.*oac\.cdlib\.org\/findaid\/something-else'>Online Archive of California<\/a>/
     end
     it "should parse bad links properly" do
-      expect(bad_links.all.length).to eq 1
+      expect(bad_links.all.length).to eq 2
       expect(bad_links.all.first.text).to match /<a href=.*example\.com\/lookup\?\^The\+Query.*>www\.example\.com<\/a>/
+      expect(bad_links.all.last.text).to match /<a href=.*example\.com.*>www\.example\.com<\/a>/
     end
     it "should identify sfx URLs and link them appropriately" do
       expect(sfx_links.all.length).to eq 1


### PR DESCRIPTION
...rescue).
