### PR TITLE
Remove column declarations from individual accordion sections.

### DIFF
--- a/app/assets/stylesheets/modules/accordion-sections.css.scss
+++ b/app/assets/stylesheets/modules/accordion-sections.css.scss
@@ -1,6 +1,7 @@
 .accordion-sections {
   margin-bottom: 15px;
   overflow: auto;
+  padding-left: 0;
 
   .accordion-section {
     font-size: small;

--- a/app/views/catalog/_accordion_section_course_reserves.html.erb
+++ b/app/views/catalog/_accordion_section_course_reserves.html.erb
@@ -8,7 +8,7 @@
     count = document.access_panels.course_reserve.courses.length
     snippet = document.access_panels.course_reserve.courses.map(&:id).join(', ')
   %>
-  <div class="accordion-section course-reserves col-xs-12 col-sm-12 col-md-8 col-lg-9">
+  <div class="accordion-section course-reserves">
     <a class="header" data-accordion-section-target=".<%= id %>-course-reserves">
       Course Reserves (<%= count %>) <i class="fa fa-caret-right"></i>
     </a>

--- a/app/views/catalog/_accordion_section_library.html.erb
+++ b/app/views/catalog/_accordion_section_library.html.erb
@@ -7,7 +7,7 @@
   <%
     snippet = document.access_panels.library_locations.libraries.map(&:name).join(', ')
   %>
-  <div class="accordion-section location col-xs-12 col-sm-12 col-md-8 col-lg-9">
+  <div class="accordion-section location">
     <a class="header" data-accordion-section-target=".<%= id %>-location">
       At the library <i class="fa fa-caret-right"></i>
     </a>

--- a/app/views/catalog/_accordion_section_online.html.erb
+++ b/app/views/catalog/_accordion_section_online.html.erb
@@ -7,7 +7,7 @@
   snippet_link = document.access_panels.online.links.try(:first)
 %>
 
-<div class="accordion-section online col-xs-12 col-sm-12 col-md-8 col-lg-9 <%= visible %>">
+<div class="accordion-section online <%= visible %>">
   <a class="header" data-accordion-section-target=".<%= id %>-online">
     Online <i class="fa fa-caret-right"></i>
   </a>

--- a/app/views/catalog/_accordion_section_summary.html.erb
+++ b/app/views/catalog/_accordion_section_summary.html.erb
@@ -2,7 +2,7 @@
 
 <% if summary_data.present? %>
   <% id = document[:id] %>
-  <div class="accordion-section summary col-xs-12 col-sm-12 col-md-8 col-lg-9">
+  <div class="accordion-section summary">
     <a class="header" data-accordion-section-target=".<%= id %>-summary">
       Summary <i class="fa fa-caret-right"></i>
     </a>

--- a/app/views/catalog/_search_results_accordion_sections.html.erb
+++ b/app/views/catalog/_search_results_accordion_sections.html.erb
@@ -1,4 +1,4 @@
-<div class="accordion-sections">
+<div class="accordion-sections col-lg-9">
   <%= render :partial => "catalog/accordion_section_summary", :locals => { :document => document } %>
   <%= render :partial => "catalog/accordion_section_online", :locals => { :document => document } %>
   <%= render :partial => "catalog/accordion_section_library", :locals => { :document => document } %>


### PR DESCRIPTION
This will help w/ some of the accordion truncation wrapping issues (but not all).  This helps give a lot more space for the accordion sections themselves so data isn't unnecessarily squished.
#### Before

![before](https://cloud.githubusercontent.com/assets/96776/4068810/981799e8-2e3c-11e4-8e67-2bcc3dad062b.png)
#### After

![after](https://cloud.githubusercontent.com/assets/96776/4068811/9818dace-2e3c-11e4-9d1b-f565ac831d3f.png)
