### PR TITLE
Add support for full and brief email exports.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem "blacklight_range_limit", github: 'projectblacklight/blacklight_range_limit'
 gem 'blacklight-hierarchy', github: 'sul-dlss/blacklight-hierarchy', branch: 'blacklight5'
 gem "retina_tag"
 gem 'jquery-datatables-rails', '~> 2.2.1'
+gem 'roadie-rails', '~> 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
     blacklight (5.6.0)
@@ -122,6 +123,8 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    css_parser (1.3.5)
+      addressable
     deprecation (0.1.0)
       activesupport
     devise (3.2.4)
@@ -241,6 +244,12 @@ GEM
     retina_tag (1.3.1)
       jquery-rails
       rails (>= 3.1)
+    roadie (3.0.1)
+      css_parser (~> 1.3.4)
+      nokogiri (~> 1.6.0)
+    roadie-rails (1.0.3)
+      rails (>= 3.0, < 4.2)
+      roadie (~> 3.0)
     rsolr (1.0.10)
       builder (>= 2.1.2)
     rspec-core (2.14.8)
@@ -351,6 +360,7 @@ DEPENDENCIES
   rails (= 4.1.5)
   rails_config
   retina_tag
+  roadie-rails (~> 1.0.3)
   rspec-rails (< 2.99)
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)

--- a/app/mailers/search_works_record_mailer.rb
+++ b/app/mailers/search_works_record_mailer.rb
@@ -1,0 +1,42 @@
+class SearchWorksRecordMailer < ActionMailer::Base
+  default 'Content-Transfer-Encoding' => '7bit'
+  include Roadie::Rails::Automatic
+  include Blacklight::Configurable
+  helper :application, :marc, :record
+  def email_record(documents, details, url_gen_params)
+    subject = if details[:subject].present?
+      details[:subject]
+    else
+      I18n.t('blacklight.email.text.subject', :count => documents.length, :title => (documents.first.to_semantic_values[:title].first rescue 'N/A') )
+    end
+
+    @documents         = documents
+    @message           = details[:message]
+    @url_gen_params    = url_gen_params
+    @blacklight_config = blacklight_config
+
+    mail(:to => details[:to],  :subject => subject)
+  end
+  def full_email_record(documents, details, url_gen_params)
+    subject = if details[:subject].present?
+      details[:subject]
+    else
+      I18n.t('blacklight.email.text.subject', :count => documents.length, :title => (documents.first.to_semantic_values[:title].first rescue 'N/A') )
+    end
+
+    @documents         = documents
+    @message           = details[:message]
+    @url_gen_params    = url_gen_params
+    @blacklight_config = blacklight_config
+
+    mail(:to => details[:to],  :subject => subject)
+  end
+
+  helper_method :link_to
+
+  private
+
+  def link_to(*args)
+    args.first
+  end
+end

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -1,0 +1,55 @@
+<%= form_tag url_for(:controller => "catalog", :action => "email"), :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
+
+  <div class="modal-body">
+    <%= render :partial=>'/flash_msg' %>
+    <div class="form-group">
+      <div class="col-sm-10 col-sm-offset-2">
+        <%= radio_button_tag :type, 'brief', true %> <%= label_tag(:type_brief,  "<strong>Brief record</strong> (title & author, library & call number, links, bookmark)".html_safe) %><br/>
+        <%= radio_button_tag :type, 'full' %> <%= label_tag(:type_full, "<strong>Full record</strong>".html_safe) %>
+      </div>
+    </div>
+    <div style="display:none; visibility: hidden;">
+      <%= label_tag(:email_address, "Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.")%>
+      <%= text_field_tag :email_address, "" %>
+    </div>
+    <div class="form-group">
+      <label class="control-label col-sm-2" for="to">
+        <%= t('blacklight.email.form.to') %>
+      </label>
+      <div class="col-sm-10">
+        <%= text_field_tag :to, params[:to], class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label class="control-label col-sm-2" for="subject">
+        Subject:
+      </label>
+      <div class="col-sm-10">
+        <%= text_field_tag :subject, I18n.t('blacklight.email.text.subject', :count => @documents.length, :title => (@documents.first.to_semantic_values[:title].first rescue 'N/A') ), class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label class="control-label col-sm-2" for="message">
+        <%= t('blacklight.email.form.message') %>
+      </label>
+      <div class="col-sm-10">
+        <%= text_area_tag :message, params[:message], class: 'form-control' %>
+      </div>
+    </div>
+
+    <% @documents.each do |doc| %>
+      <%=hidden_field_tag "id[]", doc.get(:id)%>
+    <% end %>
+    <%- if params[:sort] -%>
+      <%= hidden_field_tag "sort", params[:sort] %>
+    <%- end -%>
+    <%- if params[:per_page] -%>
+      <%= hidden_field_tag "per_page", params[:per_page] %>
+    <%- end -%>
+  </div>
+  <div class="modal-footer">
+  <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
+  </div>
+<% end %>

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -1,6 +1,6 @@
 <% document ||= @document %>
 
-<%= render 'catalog/dates_from_solr' %>
+<%= render partial: 'catalog/dates_from_solr', locals: {document: document} %>
 
 <% title_translation = get_data_with_label_from_marc(document.to_marc, "Title Translation", '242') %>
 <% unless title_translation.nil? %>
@@ -432,12 +432,12 @@
 
 <%- isbn = get_data_with_label(document, "ISBN", 'isbn_display') -%>
 <%- unless isbn.nil? -%>
-  <%= render "field_from_index", :fields => isbn %>
+  <%= render "catalog/field_from_index", :fields => isbn %>
 <%- end -%>
 
 <%- issn = get_data_with_label(document, "ISSN", 'issn_display') -%>
 <%- unless issn.nil? -%>
-  <%= render "field_from_index", :fields => issn %>
+  <%= render "catalog/field_from_index", :fields => issn %>
 <%- end -%>
 
 <%- pub_num = get_data_with_label_from_marc(document.to_marc, "Publisher Number", '028') -%>

--- a/app/views/catalog/record/_marc_contents_summary.html.erb
+++ b/app/views/catalog/record/_marc_contents_summary.html.erb
@@ -1,14 +1,15 @@
-<% if @document.marc_links.finding_aid.present? %>
+<% document ||= @document %>
+<% if document.marc_links.finding_aid.present? %>
   <dt title="Finding aid">Finding aid</dt>
-  <dd><%= @document.marc_links.finding_aid.map(&:html).join("<br/>").html_safe %></dd>
+  <dd><%= document.marc_links.finding_aid.map(&:html).join("<br/>").html_safe %></dd>
 <% end %>
 
-<% biblio = get_data_with_label_from_marc(@document.to_marc, "Bibliography", '504') %>
+<% biblio = get_data_with_label_from_marc(document.to_marc, "Bibliography", '504') %>
 <% unless biblio.nil? %>
   <%= render_field_from_marc(biblio) %>
 <% end %>
 
-<% toc = get_toc(@document.to_marc) %>
+<% toc = get_toc(document.to_marc) %>
 <% unless toc.nil? %>
   <dt><%= toc[:label] %></dt>
   <dd>
@@ -43,14 +44,14 @@
 <% end %>
 
 
-<% summary = get_data_with_label_from_marc(@document.to_marc, "Summary", '520') %>
+<% summary = get_data_with_label_from_marc(document.to_marc, "Summary", '520') %>
 <% unless summary.nil? %>
   <%= render_field_from_marc(summary) %>
 <% end %>
 
-<% if @document.marc_links.supplemental.present? %>
+<% if document.marc_links.supplemental.present? %>
   <dt title="Supplemental links">Supplemental links</dt>
   <dd>
-    <%= @document.marc_links.supplemental.map(&:html).join("<br/>").html_safe %>
+    <%= document.marc_links.supplemental.map(&:html).join("<br/>").html_safe %>
   </dd>
 <% end %>

--- a/app/views/catalog/record/_marc_contributors.html.erb
+++ b/app/views/catalog/record/_marc_contributors.html.erb
@@ -1,1 +1,2 @@
-<%= link_to_contributor_from_marc(@document.to_marc) %>
+<% document ||= @document %>
+<%= link_to_contributor_from_marc(document.to_marc) %>

--- a/app/views/catalog/record/_marc_metadata_sections.html.erb
+++ b/app/views/catalog/record/_marc_metadata_sections.html.erb
@@ -1,4 +1,5 @@
-<% if (contributors = render "catalog/record/marc_contributors").present? %>
+<% document ||= @document %>
+<% if (contributors = render(partial: "catalog/record/marc_contributors", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.contributors.id') %>" data-side-nav-class="<%= t('record_side_nav.contributors.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.contributors.icon').html_safe %> Contributors</h2>
@@ -11,7 +12,7 @@
   </div>
 <% end %>
 
-<% if (contents_summary = render "catalog/record/marc_contents_summary").present? %>
+<% if (contents_summary = render(partial: "catalog/record/marc_contents_summary", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.contents_summary.id') %>" data-side-nav-class="<%= t('record_side_nav.contents_summary.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.contents_summary.icon').html_safe %> Contents/Summary</h2>
@@ -24,7 +25,7 @@
   </div>
 <% end %>
 
-<% if (subjects = render "catalog/record/marc_subjects").present? %>
+<% if (subjects = render(partial: "catalog/record/marc_subjects", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.subjects.id') %>" data-side-nav-class="<%= t('record_side_nav.subjects.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.subjects.icon').html_safe %> Subjects</h2>
@@ -35,7 +36,7 @@
   </div>
 <% end %>
 
-<% if (bibliography = render "catalog/record/marc_bibliographic").present? %>
+<% if (bibliography = render(partial: "catalog/record/marc_bibliographic", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.bibliography_info.id') %>" data-side-nav-class="<%= t('record_side_nav.bibliography_info.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.bibliography_info.icon').html_safe %> Bibliographic information</h2>

--- a/app/views/catalog/record/_marc_subjects.html.erb
+++ b/app/views/catalog/record/_marc_subjects.html.erb
@@ -1,22 +1,23 @@
-<% subject_display = get_subjects(@document.to_marc) %>
+<% document ||= @document %>
+<% subject_display = get_subjects(document.to_marc) %>
 <% if subject_display %>
   <dl>
     <%= subject_display %>
   </dl>
 <% end %>
 
-<% genre_display = get_genre_subjects(@document.to_marc) %>
+<% genre_display = get_genre_subjects(document.to_marc) %>
 <% if genre_display %>
   <dl>
     <%= genre_display %>
   </dl>
 <% end %>
 
-<% if @document.is_a_database? && @document[:db_az_subject] %>
+<% if document.is_a_database? && document[:db_az_subject] %>
   <dl>
     <dt>Database topics</dt>
-    <% @document[:db_az_subject].each do |subject| %>
-      <dd><%= link_to(subject, catalog_index_path(f: { :db_az_subject => [subject], @document.format_key => ["Database"]})) %></dd>
+    <% document[:db_az_subject].each do |subject| %>
+      <dd><%= link_to(subject, catalog_index_path(f: { :db_az_subject => [subject], document.format_key => ["Database"]})) %></dd>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -13,12 +13,12 @@
 
     <%- author_corp = link_to_data_with_label(document, "Corporate Author", 'author_corp_display', {:action => 'index', :search_field => 'search_author'}) -%>
     <%- unless author_corp.nil? -%>
-      <%= render "field_from_index", :fields => author_corp %>
+      <%= render "catalog/field_from_index", :fields => author_corp %>
     <%- end -%>
 
     <%- author_meeting = link_to_data_with_label(document, "Meeting", 'author_meeting_display', {:action => 'index', :search_field => 'search_author'}) -%>
     <%- unless author_meeting.nil? -%>
-      <%= render "field_from_index", :fields => author_meeting %>
+      <%= render "catalog/field_from_index", :fields => author_meeting %>
     <%- end -%>
 
     <%- language = get_data_with_label(document, "Language", 'language') -%>
@@ -69,7 +69,7 @@
 
     <%- physical_desc = get_data_with_label(document, "Physical description", 'physical')%>
     <%- unless physical_desc.nil? -%>
-      <%= render "field_from_index", :fields => physical_desc %>
+      <%= render "catalog/field_from_index", :fields => physical_desc %>
     <%- end -%>
 
     <% if (instrumentation = document.marc_instrumentation).present? %>

--- a/app/views/catalog/record/_mods_abstract_contents.html.erb
+++ b/app/views/catalog/record/_mods_abstract_contents.html.erb
@@ -1,4 +1,5 @@
-<% @document.mods.abstract.each do |abstracts| %>
+<% document ||= @document %>
+<% document.mods.abstract.each do |abstracts| %>
   <% if abstracts.respond_to?(:values) %>
     <div class="section-abstract">
       <%= abstracts.values.join %>
@@ -6,7 +7,7 @@
   <% end %>
 <% end %>
 
-<% @document.mods.contents.each do |contents| %>
+<% document.mods.contents.each do |contents| %>
   <% if contents.respond_to?(:values) %>
     <div class="section-contents">
       <%= contents.values.join %>

--- a/app/views/catalog/record/_mods_access.html.erb
+++ b/app/views/catalog/record/_mods_access.html.erb
@@ -1,3 +1,4 @@
-<% @document.mods.accessCondition.each do |accessCondition| %>
+<% document ||= @document %>
+<% document.mods.accessCondition.each do |accessCondition| %>
   <%= mods_record_field(accessCondition) %>
 <% end %>

--- a/app/views/catalog/record/_mods_bibliographic.html.erb
+++ b/app/views/catalog/record/_mods_bibliographic.html.erb
@@ -1,19 +1,20 @@
-<% @document.mods.audience.each do |audience| %>
+<% document ||= @document %>
+<% document.mods.audience.each do |audience| %>
   <%= mods_record_field(audience) %>
 <% end %>
 
-<% @document.mods.note.each do |notes| %>
+<% document.mods.note.each do |notes| %>
   <%= mods_record_field(notes) %>
 <% end %>
 
-<% @document.mods.relatedItem.each do |related_item| %>
+<% document.mods.relatedItem.each do |related_item| %>
   <%= mods_record_field(related_item) %>
 <% end %>
 
-<% @document.mods.identifier.each do |identifier| %>
+<% document.mods.identifier.each do |identifier| %>
   <%= mods_record_field(identifier) %>
 <% end %>
 
-<% @document.mods.location.each do |location| %>
+<% document.mods.location.each do |location| %>
   <%= mods_record_field(location) %>
 <% end %>

--- a/app/views/catalog/record/_mods_contributors.html.erb
+++ b/app/views/catalog/record/_mods_contributors.html.erb
@@ -1,3 +1,4 @@
-<% mods_secondary_names(@document.mods.name).each do |name| %>
+<% document ||= @document %>
+<% mods_secondary_names(document.mods.name).each do |name| %>
   <%= mods_name_field(name) %>
 <% end %>

--- a/app/views/catalog/record/_mods_metadata_sections.html.erb
+++ b/app/views/catalog/record/_mods_metadata_sections.html.erb
@@ -1,4 +1,5 @@
-<% if (contributors = render "catalog/record/mods_contributors").present? %>
+<% document ||= @document %>
+<% if (contributors = render(partial: "catalog/record/mods_contributors", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.contributors.id') %>" data-side-nav-class="<%= t('record_side_nav.contributors.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.contributors.icon').html_safe %> Contributors</h2>
@@ -11,7 +12,7 @@
   </div>
 <% end %>
 
-<% if (abstract_contents = render "catalog/record/mods_abstract_contents").present? %>
+<% if (abstract_contents = render(partial: "catalog/record/mods_abstract_contents", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.abstract_contents.id') %>" data-side-nav-class="<%= t('record_side_nav.abstract_contents.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.abstract_contents.icon').html_safe %> Abstract/Contents</h2>
@@ -24,7 +25,7 @@
   </div>
 <% end %>
 
-<% if (subjects = render "catalog/record/mods_subjects").present? %>
+<% if (subjects = render(partial: "catalog/record/mods_subjects", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.subjects.id') %>" data-side-nav-class="<%= t('record_side_nav.subjects.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.subjects.icon').html_safe %> Subjects</h2>
@@ -37,7 +38,7 @@
   </div>
 <% end %>
 
-<% if (bibliography = render "catalog/record/mods_bibliographic").present? %>
+<% if (bibliography = render(partial: "catalog/record/mods_bibliographic", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.bibliography_info.id') %>" data-side-nav-class="<%= t('record_side_nav.bibliography_info.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.bibliography_info.icon').html_safe %> Bibliographic information</h2>
@@ -50,7 +51,7 @@
   </div>
 <% end %>
 
-<% if (access_conditions = render "catalog/record/mods_access").present? %>
+<% if (access_conditions = render(partial: "catalog/record/mods_access", locals: {document: document})).present? %>
   <div class="section" id="<%= t('record_side_nav.access_conditions.id') %>" data-side-nav-class="<%= t('record_side_nav.access_conditions.id') %>">
     <div class="section-heading">
       <h2><%= t('record_side_nav.access_conditions.icon').html_safe %> Access conditions </h2>

--- a/app/views/catalog/record/_mods_subjects.html.erb
+++ b/app/views/catalog/record/_mods_subjects.html.erb
@@ -1,8 +1,9 @@
-<% if @document.mods.subject.any?(&:values) %>
+<% document ||= @document %>
+<% if document.mods.subject.any?(&:values) %>
   <dt>Subject</dt>
-  <%= mods_subject_field(@document.mods.subject)%>
+  <%= mods_subject_field(document.mods.subject)%>
 <% end %>
-<% if @document.mods.genre.any?(&:values) %>
+<% if document.mods.genre.any?(&:values) %>
   <dt>Genre</dt>
-  <%= mods_genre_field(@document.mods.genre)%>
+  <%= mods_genre_field(document.mods.genre)%>
 <% end %>

--- a/app/views/catalog/record/_mods_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_mods_upper_metadata_items.html.erb
@@ -1,19 +1,20 @@
-<% mods_primary_names(@document.mods.name).each do |name| %>
+<% document ||= @document %>
+<% mods_primary_names(document.mods.name).each do |name| %>
   <%= mods_name_field(name) %>
 <% end %>
 
-<% @document.mods.resourceType.each do |resource_type| %>
+<% document.mods.resourceType.each do |resource_type| %>
   <%= mods_record_field(resource_type) %>
 <% end %>
 
-<% @document.mods.imprint.each do |imprint| %>
+<% document.mods.imprint.each do |imprint| %>
   <%= mods_record_field(imprint) %>
 <% end %>
 
-<% @document.mods.language.each do |language| %>
+<% document.mods.language.each do |language| %>
   <%= mods_record_field(language) %>
 <% end %>
 
-<% @document.mods.description.each do |description| %>
+<% document.mods.description.each do |description| %>
   <%= mods_record_field(description) %>
 <% end %>

--- a/app/views/catalog/record/_mods_upper_metadata_section.html.erb
+++ b/app/views/catalog/record/_mods_upper_metadata_section.html.erb
@@ -1,5 +1,5 @@
-<% items = render "catalog/record/mods_upper_metadata_items" %>
-<% if items.present? %>
+<% document ||= @document %>
+<% if (items = render(partial: "catalog/record/mods_upper_metadata_items", locals: {document: document})).present? %>
   <div class="section">
     <div class="section-body">
       <dl class="dl-horizontal dl-invert">

--- a/app/views/search_works_record_mailer/email_record.text.erb
+++ b/app/views/search_works_record_mailer/email_record.text.erb
@@ -1,0 +1,7 @@
+Message: <%= @message.html_safe unless @message.nil? %>
+______________________________________________________________
+<% @documents.each do |document| %>
+<%= document.to_email_text %>
+Bookmark: <%= polymorphic_path(document, {:only_path => false}.merge(@url_gen_params)) %>
+______________________________________________________________
+<% end %>

--- a/app/views/search_works_record_mailer/full_email_record.html.erb
+++ b/app/views/search_works_record_mailer/full_email_record.html.erb
@@ -1,0 +1,45 @@
+<html>
+  <head>
+    <style>
+      .record-side-nav {display: none;}
+    </style>
+  </head>
+  <body>
+    <% if @message.present? %>
+      <dl>
+        <dt>Message</dt>
+        <%= @message %>
+      </dl>
+    <% end %>
+    <% @documents.each do |document| %>
+      <h1><a href="<%= polymorphic_path(document, {:only_path => false}.merge(@url_gen_params)) %>"><%= document[:title_display] %></a></h1>
+      <% if document.respond_to?(:to_marc) %>      
+        <%= render(partial: 'catalog/record/marc_upper_metadata_items', locals: {document: document, blacklight_config: @blacklight_config}) %>
+        <%= render(partial: 'catalog/record/marc_metadata_sections', locals: {document: document, blacklight_config: @blacklight_config}) %>
+      <% elsif document.mods.present? %>
+        <%= render(partial: 'catalog/record/mods_upper_metadata_section', locals: {document: document, blacklight_config: @blacklight_config}) %>
+        <%= render(partial: 'catalog/record/mods_metadata_sections', locals: {document: document, blacklight_config: @blacklight_config}) %>
+      <% end %>
+      <% if document.access_panels.online? %>
+        <h2>Online</h2>
+        <% document.access_panels.online.links.each do |link| %>
+          <%= link.html.html_safe %><br/>
+        <% end %>
+      <% end %>
+      <% if document.holdings.present? %>
+        <h2>At the library</h2>
+        <dl>
+          <% document.holdings.libraries.each do |library| %>
+            <% library.locations.each do |location| %>
+              <dt><%= library.name %> - <%= location.name %></dt>
+              <% location.items.each do |item| %>
+                <dd><%= item.callnumber %></dd>
+              <% end %>
+            <% end %>
+          <% end %>
+        </dl>
+      <% end %>
+      <hr/>
+    <% end %>
+  </body>
+</html>

--- a/lib/blacklight/solr/document/email.rb
+++ b/lib/blacklight/solr/document/email.rb
@@ -1,0 +1,29 @@
+# -*- encoding : utf-8 -*-
+# Overridding Blacklight's module to provide our own breif email text
+module Blacklight::Solr::Document::Email
+
+  # Return a text string that will be the body of the email
+  def to_email_text
+    semantics = self.to_semantic_values
+    body = []
+    body << I18n.t('blacklight.email.text.title', :value => semantics[:title].join(" ")) if semantics[:title].present?
+    body << I18n.t('blacklight.email.text.author', :value => semantics[:author].join(" ")) if semantics[:author].present?
+    if self.holdings.present?
+      holdings.libraries.each do |library|
+        library.locations.each do |location|
+          body << "#{library.name} - #{location.name}"
+          location.items.each do |item|
+            body << "\t#{item.callnumber}"
+          end
+        end
+      end
+    end
+    if self.access_panels.online?
+      body << "Online:"
+      self.access_panels.online.links.each do |link|
+        body << "\t#{link.href}"
+      end
+    end
+    return body.join("\n") unless body.empty?
+  end
+end

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe SearchWorksRecordMailer do
+  include MarcMetadataFixtures
+  include ModsFixtures
+  let(:documents) {
+    [
+      SolrDocument.new(
+        id: '123',
+        title_display: "Title1",
+        item_display: ["12345 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123"],
+        url_sfx: ["http://library.stanford.edu"],
+        modsxml: mods_everything
+      ),
+      SolrDocument.new(
+        id: '321',
+        title_display: "Title2",
+        item_display: ["54321 -|- SAL3 -|- STACKS -|- -|- -|- -|- -|- -|- ABC 321"],
+        url_sfx: ["http://stacks.stanford.edu"],
+        marcxml: metadata1
+      )
+    ]
+  }
+  let(:params) { {to: 'email@example.com', message: 'The message', subject: 'The subject'} }
+  let(:url_params) { {host: 'example.com'} }
+  describe 'email_record' do
+    let(:mail) { SearchWorksRecordMailer.email_record(documents, params, url_params) }
+    it 'should send a plain-text email' do
+      expect(mail.content_type).to match /text\/plain/
+    end
+    it 'should include the provided message' do
+      expect(mail.body).to include "Message: The message"
+    end
+    it 'should include the titles of all documents' do
+      expect(mail.body).to include "Title: Title1"
+      expect(mail.body).to include "Title: Title2"
+    end
+    it 'should include the callnumbers' do
+      expect(mail.body).to include "Green Library - Stacks"
+      expect(mail.body).to include "ABC 123"
+
+      expect(mail.body).to include "SAL3 (off-campus storage) - Stacks"
+      expect(mail.body).to include "ABC 321"
+    end
+    it 'should include the URLs' do
+      expect(mail.body).to include "Online:"
+      expect(mail.body).to include "http://library.stanford.edu"
+      expect(mail.body).to include "http://stacks.stanford.edu"
+    end
+    it 'should include the URL to all the documents' do
+      expect(mail.body).to include "Bookmark: http://example.com/view/123"
+      expect(mail.body).to include "Bookmark: http://example.com/view/321"
+    end
+  end
+  describe 'full_email_record' do
+    let(:mail) { SearchWorksRecordMailer.full_email_record(documents, params, url_params) }
+    it 'should send a html email' do
+      expect(mail.content_type).to match /text\/html/
+    end
+    it 'should include full HTML markup' do
+      expect(mail.body).to have_css('html')
+      expect(mail.body).to have_css('body')
+    end
+    it 'should include the titles of all documents as links' do
+      expect(mail.body).to have_css('h1 a', text: 'Title1')
+      expect(mail.body).to have_css('h1 a', text: 'Title2')
+    end
+    it 'should include Subjects and Bibliographic information from both MARC and MODS records' do
+      expect(mail.body).to have_css('h2', text: 'Subjects', count: 2)
+      expect(mail.body).to have_css('h2', text: 'Bibliographic information', count: 2)
+    end
+    it 'should include the HTML markup for MARC records' do
+      expect(mail.body).to have_css('dt', text: 'Related Work')
+      expect(mail.body).to have_css('dd', text: 'A quartely publication.')
+    end
+    it 'should include the HTML markup for MODS records' do
+      expect(mail.body).to have_css('dt', text: 'Contributor')
+      expect(mail.body).to have_css('dd', text: 'B. Smith (Producer)')
+    end
+    it 'should include holdings of all documents' do
+      expect(mail.body).to have_css('h2', text: 'At the library', count: documents.length)
+      expect(mail.body).to have_css('dt', text: 'Green Library - Stacks')
+      expect(mail.body).to have_css('dd', text: 'ABC 123')
+
+      expect(mail.body).to have_css('dt', text: 'SAL3 (off-campus storage) - Stacks')
+      expect(mail.body).to have_css('dd', text: 'ABC 321')
+    end
+    it 'should include links of all the documents' do
+      expect(mail.body).to have_css('h2', text: 'Online')
+      expect(mail.body).to have_css('a', text: 'Find full text', count: documents.length)
+    end
+    it 'should separate records w/ a horizontal rule' do
+      expect(mail.body).to have_css('hr', count: documents.length)
+    end
+  end
+end


### PR DESCRIPTION
Closes #684 

Brief is plain-text which is parity with production. Full is an HTML email that renders the upper and lower metadata sections from the record view (removing any internal `link_to` links).  This is new behavior which will help the maintainability of this output much easier.
### New email form

![email-form](https://cloud.githubusercontent.com/assets/96776/4097432/f0766328-2fd4-11e4-8888-d84fe0a6cb33.png)
### Brief plain-text output

![9743424-brief](https://cloud.githubusercontent.com/assets/96776/4097427/dd95e5d0-2fd4-11e4-8443-ab42dcbde09b.png)
### Full HTML output (rendered in a browser)

![9743424-html](https://cloud.githubusercontent.com/assets/96776/4097430/e8d9fc10-2fd4-11e4-8bd4-5f06ee8f5a16.png)
