### PR TITLE
fixes bug where route referer was not being interpreted

### DIFF
--- a/app/helpers/feedback_form_helper.rb
+++ b/app/helpers/feedback_form_helper.rb
@@ -5,13 +5,22 @@ module FeedbackFormHelper
   end
 
   def show_quick_report?
-    refer = Rails.application.routes.recognize_path(request.referer)
     if (params[:controller] == 'catalog' && params[:action] == 'show') or
-      (refer[:controller] == 'catalog' && refer[:action] == 'show' &&
+      (refered_from_catalog_show? &&
         params[:controller] == 'feedback_forms' && params[:action] == 'new')
       true
     else
       false
+    end
+  end
+
+  def refered_from_catalog_show?
+    if request.referer.present?
+      if request.referer =~ /(\/catalog\/|\/view\/)/
+        true
+      else
+        false
+      end
     end
   end
 end

--- a/spec/helpers/feedback_form_helper_spec.rb
+++ b/spec/helpers/feedback_form_helper_spec.rb
@@ -25,9 +25,27 @@ describe FeedbackFormHelper do
     end
     it 'should return true when the referrer is a show page and current controller is feedback' do
       params = { controller: 'feedback_forms', action: 'new' }
-      controller.request.should_receive(:referer).and_return('http://127.0.0.1:3000/view/12')
+      controller.request.should_receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/view/12')
       helper.stub(:params).and_return(params)
       expect(helper.show_quick_report?).to be_true
+    end
+  end
+  describe 'refered_from_catalog_show?' do
+    it 'should be true if referer is from view show' do
+      controller.request.should_receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/view/12')
+      expect(helper.refered_from_catalog_show?).to be_true
+    end
+    it 'should be true if referer is from catalog show' do
+      controller.request.should_receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/catalog/12')
+      expect(helper.refered_from_catalog_show?).to be_true
+    end
+    it 'should be false if not a show page' do
+      controller.request.should_receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/catalog?f%5Baccess_facet%5D%5B%5D=At+the+Library&f%5Baccess_facet%5D%5B%5D=Online')
+      expect(helper.refered_from_catalog_show?).to be_false
+    end
+    it 'should be false if referer is nil' do
+      controller.request.should_receive(:referer).at_least(:once).and_return(nil)
+      expect(helper.refered_from_catalog_show?).to be_false
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where `route.referer` was not being recognized correctly on test or when an app hijacked the request referer. Squash bug 28
