### PR TITLE
Use preferred barcode to get the preferred callnumber (fallback on first)

### DIFF
--- a/app/views/catalog/_index_header_gallery.html.erb
+++ b/app/views/catalog/_index_header_gallery.html.erb
@@ -2,7 +2,7 @@
 <div class="documentHeader">
   <div class="callnumber-bar">
     <% if document.holdings.callnumbers.present? %>
-      <%= document.holdings.callnumbers.first.callnumber %>
+      <%= document.holdings.preferred_callnumber.callnumber %>
     <% end %>
   </div>
   <h3 class="index_title">

--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -9,12 +9,20 @@ require 'holdings/status'
 class Holdings
   include AppendMHLD
   def initialize(document)
-    @item_display = document[:item_display]
-    @mhld_display = document[:mhld_display]
+    @document = document
+    @item_display = @document[:item_display]
+    @mhld_display = @document[:mhld_display]
   end
   def find_by_barcode(barcode)
     callnumbers.find do |callnumber|
       callnumber.barcode == barcode
+    end
+  end
+  def preferred_callnumber
+    @preferred_callnumber ||= if @document[:preferred_barcode]
+      find_by_barcode(@document[:preferred_barcode])
+    else
+      callnumbers.first
     end
   end
   def present?

--- a/spec/lib/holdings_spec.rb
+++ b/spec/lib/holdings_spec.rb
@@ -94,6 +94,35 @@ describe Holdings do
       expect(complex_holdings.browsable_callnumbers.length).to eq 1
     end
   end
+  describe '#preferred_barcode' do
+    let(:preferred) {
+      Holdings.new(
+        SolrDocument.new(
+          preferred_barcode: '12345',
+          item_display: [
+            '54321 -|- GREEN -|- STACKS -|-  -|- -|- -|- -|- -|- callnumber1 -|- 1',
+            '12345 -|- GREEN -|- STACKS -|-  -|- -|- -|- -|- -|- callnumber2 -|- 2'
+          ]
+        )
+      )
+    }
+    let(:no_preferred) {
+      Holdings.new(
+        SolrDocument.new(
+          item_display: [
+            '54321 -|- GREEN -|- STACKS -|-  -|- -|- -|- -|- -|- callnumber1 -|- 1',
+            '12345 -|- GREEN -|- STACKS -|-  -|- -|- -|- -|- -|- callnumber2 -|- 2'
+          ]
+        )
+      )
+    }
+    it 'should return the callnumber based on preferred barcode' do
+      expect(preferred.preferred_callnumber.barcode).to eq '12345'
+    end
+    it 'should return the first callnumber if there is no preferred barcode available' do
+      expect(no_preferred.preferred_callnumber.barcode).to eq '54321'
+    end
+  end
   describe "#find_by_barcode" do
     let(:found) { complex_holdings.find_by_barcode('barcode2') }
     it "should return a single Holdings::Callnumber" do


### PR DESCRIPTION
The only place where we use this in the UI is on the gallery view.

The indexing team will be working on an algorithm to determine the preferred item and they'll return the barcode in the `preferred_barcode` field.  Once it is returned in search results we'll start seeing it as the callnumber in the gallery view.
