### PR TITLE
Add finding aid to search results for all MARC based objects.

### DIFF
--- a/app/views/catalog/_index_marc.html.erb
+++ b/app/views/catalog/_index_marc.html.erb
@@ -15,6 +15,11 @@
     <dt><%= document.extent_label %></dt>
     <dd><%= document.extent %></dd>
   <% end %>
+
+  <% if document.index_links.finding_aid.present? %>
+    <dt>Finding aid</dt>
+    <dd><%= document.index_links.finding_aid.first.html.html_safe %></dd>
+  <% end %>
 </dl>
 
 <%= render :partial => "search_results_accordion_sections", :locals => { :document => document } %>

--- a/app/views/catalog/_index_merged_image.html.erb
+++ b/app/views/catalog/_index_merged_image.html.erb
@@ -14,6 +14,11 @@
       <% end %>
     </dd>
   <% end %>
+
+  <% if document.index_links.finding_aid.present? %>
+    <dt>Finding aid</dt>
+    <dd><%= document.index_links.finding_aid.first.html.html_safe %></dd>
+  <% end %>
 </dl>
 
 <%= render :partial => "search_results_accordion_sections", :locals => { :document => document } %>

--- a/spec/views/catalog/_index_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_index_marc.html.erb_spec.rb
@@ -45,4 +45,19 @@ describe "catalog/_index_marc.html.erb" do
       expect(rendered).to have_css('dd a', text: "Subject2")
     end
   end
+  describe 'finding aid' do
+    before do
+      view.stub(:document).and_return(
+        SolrDocument.new(
+          marcxml: metadata1,
+          url_fulltext: ['http://oac.cdlib.org/findaid/12345']
+        )
+      )
+      render
+    end
+    it 'should display the finding aid' do
+      expect(rendered).to have_css('dt', text: 'Finding aid')
+      expect(rendered).to have_css('dd a', text: 'Online Archive of California')
+    end
+  end
 end

--- a/spec/views/catalog/_index_merged_image.html.erb_spec.rb
+++ b/spec/views/catalog/_index_merged_image.html.erb_spec.rb
@@ -10,7 +10,8 @@ describe "catalog/_index_merged_image.html.erb" do
         collection_with_title: ['12345 -|- Collection Title'],
         marcbib_xml: metadata1,
         physical: ["The Physical Extent"],
-        imprint_display: ['Imprint Statement']
+        imprint_display: ['Imprint Statement'],
+        url_fulltext: ['http://oac.cdlib.org/findaid/12345']
       )
     )
     expect(view).to receive(:presenter).and_return(presenter)
@@ -29,5 +30,9 @@ describe "catalog/_index_merged_image.html.erb" do
   end
   it "should include the collection" do
     expect(rendered).to have_css('dt', text: 'Collection')
+  end
+  it 'should include the finding aid' do
+    expect(rendered).to have_css('dt', text: 'Finding aid')
+    expect(rendered).to have_css('dd a', text: 'Online Archive of California')
   end
 end


### PR DESCRIPTION
Closes #767 

![4688803-results](https://cloud.githubusercontent.com/assets/96776/4139228/8af593bc-3398-11e4-86d2-a666a24ffeca.png)
