### PR TITLE
Add thumbnails for Image and File collections.

### DIFF
--- a/app/models/concerns/digital_collection.rb
+++ b/app/models/concerns/digital_collection.rb
@@ -11,7 +11,7 @@ module DigitalCollection
   private
 
   class CollectionMembers
-    delegate :present?, :each, :map, :length, to: :documents
+    delegate :present?, :each, :first, :last, :map, :length, to: :documents
     def initialize(document, options={})
       @options = options
       @document = document

--- a/app/views/catalog/thumbnails/_file_collection_thumbnail.html.erb
+++ b/app/views/catalog/thumbnails/_file_collection_thumbnail.html.erb
@@ -1,0 +1,8 @@
+<%= link_to document, tabindex: '-1' do %>
+  <%= content_tag(:span, class:"fake-cover") do %>
+    <%# Wrapper needed for the way that Firefox handles display: table-cell %>
+    <%= content_tag(:div, class: "fake-cover-text-wrapper") do %>
+      <%= content_tag(:div, get_main_title(document), class: "fake-cover-text") %>
+    <% end %>
+  <% end %>
+<% end if document_index_view_type == :gallery %>

--- a/app/views/catalog/thumbnails/_file_thumbnail.html.erb
+++ b/app/views/catalog/thumbnails/_file_thumbnail.html.erb
@@ -1,0 +1,8 @@
+<%= link_to document, tabindex: '-1' do %>
+  <%= content_tag(:span, class:"fake-cover") do %>
+    <%# Wrapper needed for the way that Firefox handles display: table-cell %>
+    <%= content_tag(:div, class: "fake-cover-text-wrapper") do %>
+      <%= content_tag(:div, get_main_title(document), class: "fake-cover-text") %>
+    <% end %>
+  <% end %>
+<% end if document_index_view_type == :gallery %>

--- a/app/views/catalog/thumbnails/_image_collection_thumbnail.html.erb
+++ b/app/views/catalog/thumbnails/_image_collection_thumbnail.html.erb
@@ -1,0 +1,3 @@
+<% if document_index_view_type == :gallery && document.collection_members.present?  %>
+  <%= image_tag(document.collection_members.first.image_urls(:large).first, class: 'stacks-image', alt: '') if document.collection_members.first.image_urls.present? %>
+<% end %>

--- a/app/views/catalog/thumbnails/_merged_file_collection_thumbnail.html.erb
+++ b/app/views/catalog/thumbnails/_merged_file_collection_thumbnail.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'catalog/thumbnails/file_collection_thumbnail', locals: {document: document} %>

--- a/app/views/catalog/thumbnails/_merged_image_collection_thumbnail.html.erb
+++ b/app/views/catalog/thumbnails/_merged_image_collection_thumbnail.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'catalog/thumbnails/image_collection_thumbnail', locals: {document: document} %>

--- a/spec/views/catalog/thumbnails/_file_collection_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/thumbnails/_file_collection_thumbnail.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "catalog/thumbnails/_file_collection_thumbnail.html.erb" do
+  describe "fake covers" do
+    before do
+      view.stub(:document).and_return(SolrDocument.new(id: '1234', title_display: "Title"))
+    end
+    it "should be included on the gallery view" do
+      view.stub(:document_index_view_type).and_return(:gallery)
+      render
+      expect(rendered).to have_css('.fake-cover', text: "Title")
+    end
+    it "should not be included on other views" do
+      view.stub(:document_index_view_type).and_return(:list)
+      render
+      expect(rendered).to_not have_css('.fake-cover')
+    end
+  end
+end

--- a/spec/views/catalog/thumbnails/_image_collection_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/thumbnails/_image_collection_thumbnail.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "catalog/thumbnails/_image_collection_thumbnail.html.erb" do
+  describe "fake covers" do
+    let(:document) { SolrDocument.new(id: '1234', title_display: "Title") }
+    before do
+      view.stub(:document).and_return(document)
+    end
+    it "should be included on the gallery view" do
+      expect(document).to receive(:collection_members).at_least(:once).and_return([
+        SolrDocument.new(display_type: ['image'], file_id: ['123', '321'])
+      ])
+      view.stub(:document_index_view_type).and_return(:gallery)
+      render
+      expect(rendered).to have_css('img.stacks-image')
+    end
+    it "should not be included on other views" do
+      view.stub(:document_index_view_type).and_return(:list)
+      render
+      expect(rendered).to_not have_css('img.stacks-image')
+    end
+  end
+end

--- a/spec/views/catalog/thumbnails/_merged_file_collection_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/thumbnails/_merged_file_collection_thumbnail.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "catalog/thumbnails/_merged_file_collection_thumbnail.html.erb" do
+  describe "fake covers" do
+    before do
+      view.stub(:document).and_return(SolrDocument.new(id: '1234', title_display: "Title"))
+    end
+    it "should be included on the gallery view" do
+      view.stub(:document_index_view_type).and_return(:gallery)
+      render
+      expect(rendered).to have_css('.fake-cover', text: "Title")
+    end
+    it "should not be included on other views" do
+      view.stub(:document_index_view_type).and_return(:list)
+      render
+      expect(rendered).to_not have_css('.fake-cover')
+    end
+  end
+end

--- a/spec/views/catalog/thumbnails/_merged_image_collection_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/thumbnails/_merged_image_collection_thumbnail.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "catalog/thumbnails/_merged_image_collection_thumbnail.html.erb" do
+  describe "collection member images" do
+    let(:document) { SolrDocument.new(id: '1234', title_display: "Title") }
+    before do
+      view.stub(:document).and_return(document)
+    end
+    it "should be included on the gallery view" do
+      expect(document).to receive(:collection_members).at_least(:once).and_return([
+        SolrDocument.new(display_type: ['image'], file_id: ['123', '321'])
+      ])
+      view.stub(:document_index_view_type).and_return(:gallery)
+      render
+      expect(rendered).to have_css('img.stacks-image')
+    end
+    it "should not be included on other views" do
+      view.stub(:document_index_view_type).and_return(:list)
+      render
+      expect(rendered).to_not have_css('img.stacks-image')
+    end
+  end
+end


### PR DESCRIPTION
Image collections get first collection member's thumb and file collections (as well as file objects) get fake cover.

Closes #716 
#### Collection objects

![file-image-colls](https://cloud.githubusercontent.com/assets/96776/4158433/95cbdbbc-348c-11e4-8884-704860651edc.png)
#### File objects

![file-objects](https://cloud.githubusercontent.com/assets/96776/4158431/92b9849c-348c-11e4-8ceb-c17e861777f4.png)
