### PR TITLE
Adds find articles guide to home and databases pages

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -50,14 +50,20 @@
   <ul class="media-list">
     <li class="media">
       <div class="media-body">
+        <%= link_to "Citation finder", "http://sul-sfx.stanford.edu/sfxlcl41/az", class: "media-heading" %>
+        <p>Find an article in one of Stanford's ejournal subscriptions.</p>
+      </div>
+    </li>
+    <li class="media">
+      <div class="media-body">
         <%= link_to "xSearch", "http://xsearch.stanford.edu", class: "media-heading" %>
         <p>Search for articles in multiple databases simultaneously.</p>
       </div>
     </li>
     <li class="media">
       <div class="media-body">
-        <%= link_to "Citation finder", "http://sul-sfx.stanford.edu/sfxlcl41/az", class: "media-heading" %>
-        <p>Find an article in one of Stanford's ejournal subscriptions.</p>
+        <%= link_to "Find articles", "http://library.stanford.edu/guides/find-articles", class: "media-heading" %>
+        <p>Guide to searching for articles at Stanford.</p>
       </div>
     </li>
   </ul>

--- a/app/views/catalog/mastheads/_databases.html.erb
+++ b/app/views/catalog/mastheads/_databases.html.erb
@@ -2,7 +2,12 @@
   <div id="masthead" class="databases-masthead">
     <h1>Databases</h1>
     <p>Licensed resources are for the non-profit educational use of Stanford University. Use of these resources is governed by copyright law and individual license agreements. Systematic downloading, distributing, or retaining substantial portions of information is prohibited.</p>
-    <p><%= link_to "Selected article databases", selected_databases_path %> | <%= link_to "Connect from off campus", "http://library.stanford.edu/using/connect-campus" %> | <%= link_to "Report a connection problem", "http://library.stanford.edu/ask/email/connection-problems" %></p>
+    <p>
+      <%= link_to "Selected article databases", selected_databases_path %> |
+      <%= link_to "Find articles", "http://library.stanford.edu/guides/find-articles" %> | 
+      <%= link_to "Connect from off campus", "http://library.stanford.edu/using/connect-campus" %> |
+      <%= link_to "Report a connection problem", "http://library.stanford.edu/ask/email/connection-problems" %>
+    </p>
     <%= render "catalog/database_prefix" %>
   </div>
 </div>

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -4,8 +4,16 @@ feature "Databases Access Point" do
   before do
     visit databases_path
   end
-  scenario "Database Topic facet should be present and uncollapsed" do
+  scenario "should have a custom masthead" do
     expect(page).to have_title("Databases in SearchWorks")
+    within("#masthead") do
+      expect(page).to have_css("h1", text: "Databases")
+      expect(page).to have_css("a", text: "Find articles")
+      expect(page).to have_css("a", text: "Connect from off campus")
+      expect(page).to have_css("a", text: "Report a connection problem")
+    end
+  end
+  scenario "Database Topic facet should be present and uncollapsed" do
     within("#facets") do
       within(".blacklight-db_az_subject") do
         expect(page).to_not have_css(".collapsed")

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -26,8 +26,9 @@ feature "Home Page" do
   end
   scenario "'Articles' section should display" do
     expect(page).to have_css('h2', text: 'Looking for articles?')
-    expect(page).to have_css(".media a", text: "xSearch")
     expect(page).to have_css(".media a", text: "Citation finder")
+    expect(page).to have_css(".media a", text: "Find articles")
+    expect(page).to have_css(".media a", text: "xSearch")
   end
   scenario "'Help with SearchWorks' section should display" do
     expect(page).to have_css('h2', text: 'Help with SearchWorks')


### PR DESCRIPTION
Closes #663 
- Based on JIRA ticket SW-1130 spec, moved xSearch to bottom of the list

@jvine Please let me know if there are changes to 'Find articles' placement and text 
## 
## ![image](https://cloud.githubusercontent.com/assets/302258/4164069/c4131e5a-34ef-11e4-9133-b3e81f8490a2.png)

![image](https://cloud.githubusercontent.com/assets/302258/4164077/e5817dde-34ef-11e4-82b0-2233ba4179c4.png)
