### PR TITLE
Add an optional delimiter parameter to #mods_record_field.

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -23,17 +23,23 @@ module RecordHelper
     content_tag(:dt, label.gsub(":",""))
   end
 
-  def mods_display_content values
-    Array[values].flatten.map do |value|
-      content_tag(:dd, link_urls_and_email(value).html_safe) if value.present?
-    end.join.html_safe
+  def mods_display_content(values, delimiter=nil)
+    if delimiter
+      content_tag(:dd, values.map{|value|
+        link_urls_and_email(value) if value.present?
+      }.compact.join(delimiter).html_safe)
+    else
+      Array[values].flatten.map do |value|
+        content_tag(:dd, link_urls_and_email(value).html_safe) if value.present?
+      end.join.html_safe
+    end
   end
 
-  def mods_record_field field
+  def mods_record_field(field, delimiter=nil)
     if field.respond_to?(:label, :values) &&
        field.values.any?(&:present?)
       mods_display_label(field.label) +
-      mods_display_content(field.values)
+      mods_display_content(field.values, delimiter)
     end
   end
 

--- a/app/views/catalog/record/_mods_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_mods_upper_metadata_items.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% document.mods.language.each do |language| %>
-  <%= mods_record_field(language) %>
+  <%= mods_record_field(language, ', ') %>
 <% end %>
 
 <% document.mods.description.each do |description| %>

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -47,6 +47,7 @@ describe RecordHelper do
   describe "mods_record_field" do
     let(:mods_field)  { OpenStruct.new({label: "test", values: ["hello, there"]}) }
     let(:url_field)  { OpenStruct.new({label: "test", values: ["http://library.stanford.edu"]}) }
+    let(:multi_values) { double(label: 'test', values: ['123', '321']) }
     it "should return correct content" do
       expect(helper.mods_record_field(mods_field)).to have_css("dt", text: "test")
       expect(helper.mods_record_field(mods_field)).to have_css("dd", text: "hello, there")
@@ -56,6 +57,13 @@ describe RecordHelper do
     end
     it "should not print empty labels" do
       expect(helper.mods_record_field(empty_field)).to_not be_present
+    end
+    it 'should join values with a <dd> by default' do
+      expect(helper.mods_record_field(multi_values)).to have_css("dd", count: 2)
+    end
+    it 'should join values with a supplied delimiter' do
+      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css("dd", count: 1)
+      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css("dd", text: '123DELIM321')
     end
   end
   describe "names" do


### PR DESCRIPTION
Only implemented for language at the moment.
### ww121ss5000
#### Before

![ww121ss5000-before](https://cloud.githubusercontent.com/assets/96776/4170929/f8b98480-3537-11e4-9a25-670a50136de3.png)
#### After

![ww121ss5000-after](https://cloud.githubusercontent.com/assets/96776/4170928/f8af8ff2-3537-11e4-987e-50c80b9baf34.png)
