### PR TITLE
wait for first checkbox to be done before continuing

### DIFF
--- a/app/assets/javascripts/select-all.js
+++ b/app/assets/javascripts/select-all.js
@@ -21,15 +21,31 @@
       function init() {
         $element.on('click', function() {
           var state = $selectAll.is(':visible');
-
-          $(selectorSelectBookmarks).each(function(i, checkbox) {
-            var $checkbox = $(checkbox);
-
-            if ($checkbox.is(':checked') !== state) {
-              $checkbox.prop('checked', !state).click();
+          bookmarkSelectors = $(selectorSelectBookmarks);
+          var first = false;
+          var firstCheckboxIsDone = new $.Deferred();
+          bookmarkSelectors.each(function(i, checkbox) {
+            if (!first){
+              var $checkbox = $(checkbox);
+              if ($checkbox.is(':checked') !== state) {
+                var span = $checkbox.next('span');              
+                first = true;
+                $checkbox.prop('checked', !state).click();
+                span.on('DOMSubtreeModified', function(){
+                  firstCheckboxIsDone.resolve();
+                });
+              }
             }
           });
-
+          $.when(firstCheckboxIsDone).done(function(){
+            bookmarkSelectors.each(function(i, checkbox) {
+              var $checkbox = $(checkbox);
+              if ($checkbox.is(':checked') !== state) {
+                $checkbox.prop('checked', !state).click();
+              }
+            });
+          });
+          
           toggleActions();
         });
       }
@@ -47,7 +63,7 @@
 
     });
 
-  }
+  };
 
 })(jQuery);
 


### PR DESCRIPTION
I believe the best way to fix the problem we are having with select all

Closes #875

I also have another solution that doesn't quite work here: https://github.com/sul-dlss/SearchWorks/tree/select-all-fix

The problem with doing this server side, is that BL plugin that creates the interactivity keeps track of state separately and only looks for it once (on instantiation). https://github.com/projectblacklight/blacklight/blob/master/app/assets/javascripts/blacklight/checkbox_submit.js#L108

I believe this is the best way to do this, but am open to other ideas.
