### PR TITLE
Sort the resource type and building facets by index.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -84,13 +84,13 @@ class CatalogController < ApplicationController
     config.add_facet_field "access_facet", :label => "Access", limit: 10
     config.add_facet_field "collection", label: "Collection", show: false, helper_method: :collection_breadcrumb_value
     config.add_facet_field "collection_type", :label => "Collection type", :show => false
-    config.add_facet_field "format_main_ssim", :label => "Resource type", partial: "resource_type_facet", limit: 100
+    config.add_facet_field "format_main_ssim", :label => "Resource type", partial: "resource_type_facet", limit: 100, sort: :index
     config.add_facet_field "format_physical_ssim", :label => "Media type", limit: 20
     config.add_facet_field "pub_year_tisim", :label => "Date", :range => {
       :input_label_range_begin => "from year",
       :input_label_range_end => "to year"
     }
-    config.add_facet_field "building_facet", :label => "Library", limit: 100
+    config.add_facet_field "building_facet", :label => "Library", limit: 100, sort: :index
     config.add_facet_field "language", :label => "Language", limit: 20
     config.add_facet_field "author_person_facet", :label => "Author", limit: 20
     config.add_facet_field 'callnum_facet_hsim',

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -112,6 +112,14 @@ describe CatalogController do
       expect(keys.index("era_facet")).to be < keys.index("author_other_facet")
       expect(keys.index("author_other_facet")).to be < keys.index("format")
     end
+    describe 'facet sort' do
+      it 'should set an index sort for the resource type facet' do
+        expect(config.facet_fields['format_main_ssim'].sort).to eq :index
+      end
+      it 'should set an index sort for the building type facet' do
+        expect(config.facet_fields['building_facet'].sort).to eq :index
+      end
+    end
     describe "facet limits" do
       it "should set a very high facet limit on building and format" do
         ['building_facet', 'format_main_ssim'].each do |facet|

--- a/spec/features/blacklight_customizations/facets_spec.rb
+++ b/spec/features/blacklight_customizations/facets_spec.rb
@@ -24,6 +24,26 @@ feature "Facets Customizations" do
       expect(page).to have_css("li span.sul-icon")
     end
   end
+  scenario 'resource type should be index sorted (not count)' do
+    visit root_path
+
+    book_index  = facet_index(facet_name: 'facet-format_main_ssim', value: 'Book')
+    db_index    = facet_index(facet_name: 'facet-format_main_ssim', value: 'Database')
+    image_index = facet_index(facet_name: 'facet-format_main_ssim', value: 'Image')
+
+    expect(book_index).to be < db_index
+    expect(db_index).to be < image_index
+  end
+  scenario 'library facet should be index sorted (not count)' do
+    visit root_path
+
+    green_index = facet_index(facet_name: 'facet-building_facet', value: 'Green')
+    music_index = facet_index(facet_name: 'facet-building_facet', value: 'Music')
+    sdr_index   = facet_index(facet_name: 'facet-building_facet', value: 'Stanford Digital Repository')
+
+    expect(green_index).to be < music_index
+    expect(music_index).to be < sdr_index
+  end
   scenario "while not in an access point facet title should not change", js: true do
     visit root_path
     fill_in "q", with: ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,6 +88,14 @@ def all_docs_on_page
   page.all(:xpath, "//form[@data-doc-id]").map{|e| e["data-doc-id"]}
 end
 
+def facet_index(options)
+  all_facets_by_name(options[:facet_name]).index(options[:value])
+end
+
+def all_facets_by_name(facet_name)
+  page.all("##{facet_name} a.facet_select").map(&:text)
+end
+
 def number_pattern
   /[1-9](?:\d{0,2})(?:,\d{3})*(?:\.\d*[1-9])?|0?\.\d*[1-9]|0/
 end


### PR DESCRIPTION
Fixes #878 
### Before

![facet-sort-before](https://cloud.githubusercontent.com/assets/96776/4197309/82c7862a-37e7-11e4-8ad1-1b2be30edfe1.png)
### After

![facet-sort-after](https://cloud.githubusercontent.com/assets/96776/4197310/82c859d8-37e7-11e4-9897-2d80d7d590fd.png)
