### PR TITLE
Use a branch of osd-rails that adds the optional 3 param to addEventList...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ end
 
 gem "coderay"
 
-gem 'openseadragon', github: 'sul-dlss/openseadragon-rails'
+gem 'openseadragon', github: 'sul-dlss/openseadragon-rails', branch: 'ff36-fix'
 
 gem 'deprecation'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,8 @@ GIT
 
 GIT
   remote: git://github.com/sul-dlss/openseadragon-rails.git
-  revision: afe09fa081b0a4f854cbeb0c4f9cba7edda17ea9
+  revision: 9baa6dce49555c9b6c3cc1d650f14499b7cdd23c
+  branch: ff36-fix
   specs:
     openseadragon (0.0.5)
       rails (> 3.2.0)


### PR DESCRIPTION
...ener.

I believe this addresses the errors that people are getting in FF 3.6 (i.e. what most of the library kiosks are running).
