### PR TITLE
Modify footer styling so links don't move on smaller viewports

### DIFF
--- a/app/assets/stylesheets/modules/sul-footer.css.scss
+++ b/app/assets/stylesheets/modules/sul-footer.css.scss
@@ -44,3 +44,4 @@
 
 #global-footer {max-width: 100%;}
 #global-footer p {max-width: 100%;}
+#global-footer #bottom-text {margin-right: 6px;}


### PR DESCRIPTION
The Stanford footer currently has a minor display problem. At viewports narrower than 1200px, the row of links that should be above the copyright and address line gets bumped below that line:

![sw-footer-current](https://cloud.githubusercontent.com/assets/101482/4226506/24bcefbe-3938-11e4-88d3-22fd72112322.png)

This pull request adds a very simple override (reduces by 6px the right margin allocated to the row of links) to the Stanford footer styling to ensure that the row of links remains in the proper place at any viewport width:

![sw-footer-fixed](https://cloud.githubusercontent.com/assets/101482/4226525/514d7e2c-3938-11e4-881c-fb039007ea3a.png)
