### PR TITLE
Allow gallery and embed browse previews to be clicked in.

### DIFF
--- a/app/assets/javascripts/jquery.preview-embed-browse.js
+++ b/app/assets/javascripts/jquery.preview-embed-browse.js
@@ -70,10 +70,15 @@
       }
 
       function currentPreview(e){
-        if (e.target === $triggerBtn[0]){
+        // Check if we're clicking in a preview
+        if ($(e.target).parents('.preview-container').length > 0){
           return true;
         }else{
-          return false;
+          if (e.target === $triggerBtn[0]) {
+            return true;
+          }else{
+            return false;
+          }
         }
       }
 

--- a/app/assets/javascripts/jquery.preview-gallery.js
+++ b/app/assets/javascripts/jquery.preview-gallery.js
@@ -77,8 +77,8 @@
       }
 
       function currentPreview(e){
-        // Check if it is an accordion button selection
-        if (typeof $(e.target).data('accordion-section-target') !== 'undefined'){
+        // Check if we're clicking in a preview
+        if ($(e.target).parents('.preview-container').length > 0){
           return true;
         }else{
           if (e.target === $triggerBtn[0]) {


### PR DESCRIPTION
Previously we were closing these previews when the surrounding page was clicked on,
however this also included clicks w/i the preview itself. This commit checks to see
if the click target is inside a preview container before it closes all the previews
on the page.

Closes #876 
### Before
## ![accordion-before](https://cloud.githubusercontent.com/assets/96776/4254626/2fa2acb8-3aad-11e4-9493-c77a32cfd3d1.gif)
### After

![accordion-after](https://cloud.githubusercontent.com/assets/96776/4254625/2f9d5d58-3aad-11e4-8b94-c5123361cb9d.gif)
