### PR TITLE
Adds preferred callnumber, library and location to SMS

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -62,6 +62,11 @@ en:
         zoom_in: '<i class="fa fa-plus-circle"></i><span class="hidden-xs"> Zoom in</span>'
         zoom_out: '<i class="fa fa-minus-circle"></i><span class="hidden-xs">  Zoom out</span>'
         reset_size: '<i class="fa fa-compress"></i><span class="hidden-xs">  Reset size</span>'
+    sms:
+      text:
+        library_location: '%{library} - %{location}'
+        callnumber: '%{value}'
+        url: '%{url}'
   views:
     pagination_compact:
       next: '<span class="hidden-xs">Next </span><i class="fa fa-arrow-right"></i>'

--- a/lib/blacklight/solr/document/sms.rb
+++ b/lib/blacklight/solr/document/sms.rb
@@ -1,0 +1,24 @@
+# -*- encoding : utf-8 -*-
+# This module provides the body of an email export based on the document's semantic values
+module Blacklight::Solr::Document::Sms
+
+  # Return a text string that will be the body of the email
+  def to_sms_text
+    semantics = self.to_semantic_values
+    body = []
+    body << I18n.t('blacklight.sms.text.title', :value => semantics[:title].first) unless semantics[:title].blank?
+    body << I18n.t('blacklight.sms.text.author', :value => semantics[:author].first) unless semantics[:author].blank?
+
+    if self.holdings.present?
+      callnumber = holdings.preferred_callnumber
+      library = Holdings::Library.new(callnumber.library).name
+      location = Holdings::Location.new(callnumber.home_location).name
+
+      body << I18n.t('blacklight.sms.text.library_location', :library => library, :location => location)
+      body << I18n.t('blacklight.sms.text.callnumber', :value => callnumber.callnumber)
+    end
+
+    return body.join("\n") unless body.empty?
+  end
+
+end

--- a/spec/lib/sms_spec.rb
+++ b/spec/lib/sms_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe "Blacklight::Solr::Document::Sms" do
+  let(:doc) {
+    SolrDocument.new(
+      preferred_barcode: '12345',
+      item_display: [
+        '54321 -|- BIOLOGY -|- STACKS -|-  -|- -|- -|- -|- -|- callnumber1 -|- 1',
+        '12345 -|- GREEN -|- STACKS -|-  -|- -|- -|- -|- -|- callnumber2 -|- 2'
+      ]
+    )
+  }
+
+  before(:all) do
+    SolrDocument.use_extension(Blacklight::Solr::Document::Sms)
+  end
+
+  it "should return preferred call number with its library and location" do
+    sms_text = doc.to_sms_text
+    expect(sms_text).to match(/callnumber2/)
+    expect(sms_text).to match(/Green Library - Stacks/)
+    expect(sms_text).to_not match(/Biology Library (Falconer) - Stacks/)
+  end
+
+end


### PR DESCRIPTION
Closes #901 

```
Sent mail to 1112223333@txt.att.net (12.5ms)
Date: Tue, 16 Sep 2014 12:12:50 -0700
From: no-reply@xxx.xxx.xxx
To: 1112223333@txt.att.net
Message-ID: <xxx@xxx.xxx.mail>
Subject:
Mime-Version: 1.0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

Campbell Biology
BIOLOGY - STACKS
QH308.2 .C34 2011
http://localhost:3000/view/9052324
```
