### PR TITLE
Pin RefWorks export of selections to the non-lb node-name.

### DIFF
--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -10,7 +10,7 @@
 
     <% if @response.documents.any? {|d| d.exports_as? :refworks_marc_txt } %>
       <li>
-        <%= link_to t('blacklight.tools.refworks_html'), refworks_export_url(url: bookmarks_export_url(:refworks_marc_txt, params_for_search)), :id => "refworksLink" %>
+        <%= link_to t('blacklight.tools.refworks_html'), refworks_export_url(url: bookmarks_export_url(:refworks_marc_txt, params_for_search.merge(host: "#{Settings.HOSTNAME}.stanford.edu"))), :id => "refworksLink" %>
       </li>
     <% end %>
 


### PR DESCRIPTION
We need to do this until we have a single DB setup, and then we can go back to letting the request go through the load balancer.
