### PR TITLE
Add SETS location.

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -535,6 +535,7 @@ module Constants
    "SEE-LOAN" => "See circulation desk for access",
    "SEE-OTHER" => "See related record(s) to request item",
    "SERIALS" => "Serials",
+   "SETS" => "Big Sets",
    "SHELBYSER" => "Serials",
    #"SHELBYSER" => "Serials - Shelved by series title",
    #"SHELBYTITL" => "Serials - Shelved by title",


### PR DESCRIPTION
From Metadata:

```
A new location has just been created in Symphony.
The location code is SETS. The public description / label should be "Big Sets".
This location will be used by the EAST-ASIA library.
Could you please add it to SearchWorks.
```
