### PR TITLE
Hide overflow text of constraints on small screens.

### DIFF
--- a/app/assets/stylesheets/modules/constraints.css.scss
+++ b/app/assets/stylesheets/modules/constraints.css.scss
@@ -1,5 +1,8 @@
 span.constraints-label {
   font-size: 1.2em;
+  @media (max-width: $screen-xs-max) {
+    display: none;
+  }
 }
 
 span.constraint.btn-group {
@@ -20,4 +23,21 @@ span.constraint.btn-group {
     padding-bottom: 5px;
   }
 
+}
+@media (max-width: $screen-xs-max) {
+  .constraint {
+    &.query .filterValue {
+      max-width: 227px;
+    }
+    &.filter .filterValue {
+      max-width: 150px;
+    }
+    .filterValue {
+      display: inline-block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: -6px;
+    }
+  }
 }


### PR DESCRIPTION
Closes #850 
#### Before

![breadcrumb-before](https://cloud.githubusercontent.com/assets/96776/4329396/4242b9ae-3f98-11e4-9236-c6a1944117b6.png)
#### After

![breadcrumb-after](https://cloud.githubusercontent.com/assets/96776/4329397/425af6cc-3f98-11e4-96d2-33e6fc4015a3.png)
