### PR TITLE
Add SPEC specific location translation for the MANUSCRIPT location.

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -616,6 +616,10 @@ module Constants
    "LOCKED-STK" => "Locked Stacks: ask at Media & Microtext Center"
  }
 
+ SPEC_SPECIFIC_LOCS = {
+   "MANUSCRIPT" => "Manuscript Collection: request at Special Collections service desk"
+ }
+
  NONCIRC_LOCS = ["2NDFLR-REF",
    "3RDFLR-REF",
    "ARTLCKL-R",

--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -62,6 +62,10 @@ class Holdings
       Constants::LOCS.merge(Constants::GREEN_SPECIFIC_LOCS)[@code]
     end
 
+    def spec_coll_specific_location_name
+      Constants::LOCS.merge(Constants::SPEC_SPECIFIC_LOCS)[@code]
+    end
+
     def method_missing(method_name, *args, &block)
       case method_name
       when /#{sanitized_library}_specific_location_name/

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -10,8 +10,14 @@ describe Holdings::Location do
     it "should translate the location code" do
       expect(Holdings::Location.new(location_code).name).to eq "Locked Stacks: ask at circulation desk"
     end
-    it 'should get location specific names' do
-      expect(Holdings::Location.new(location_code, [callnumber]).name).to eq "Locked Stacks: ask at Media & Microtext Center"
+    describe 'location specific translations' do
+      it 'should be present for Green' do
+        expect(Holdings::Location.new(location_code, [callnumber]).name).to eq "Locked Stacks: ask at Media & Microtext Center"
+      end
+      it 'should be present for SPEC' do
+        expect(Holdings::Location.new("MANUSCRIPT", [Holdings::Callnumber.new("barcode -|- HOOVER -|- MANUSCRIPT -|- -|- -|-")]).name).to eq "Manuscript Collection"
+        expect(Holdings::Location.new("MANUSCRIPT", [Holdings::Callnumber.new("barcode -|- SPEC-COLL -|- MANUSCRIPT -|- -|- -|-")]).name).to eq "Manuscript Collection: request at Special Collections service desk"
+      end
     end
   end
   describe "#present?" do


### PR DESCRIPTION
Closes #937 

**Example ckey:** 5628594

**Note:** Change in location sort is known, and okayed by @jvine.
### Before

![5628594-before](https://cloud.githubusercontent.com/assets/96776/4361765/1ab4f374-4287-11e4-8209-ed660354e0ff.png)
### After

![5628594-after](https://cloud.githubusercontent.com/assets/96776/4361764/1aad4160-4287-11e4-9779-d530e1429ff3.png)
