### PR TITLE
Removes obsolete technical details placeholder block

### DIFF
--- a/app/views/catalog/record/_record_metadata_file.html.erb
+++ b/app/views/catalog/record/_record_metadata_file.html.erb
@@ -16,7 +16,3 @@
     <% end %>
   </div>
 </div>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>

--- a/app/views/catalog/record/_record_metadata_file_collection.html.erb
+++ b/app/views/catalog/record/_record_metadata_file_collection.html.erb
@@ -16,7 +16,3 @@
     <% end %>
   </div>
 </div>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>

--- a/app/views/catalog/record/_record_metadata_image.html.erb
+++ b/app/views/catalog/record/_record_metadata_image.html.erb
@@ -16,7 +16,3 @@
     <% end %>
   </div>
 </div>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details col-md-12 row">
-</div>

--- a/app/views/catalog/record/_record_metadata_image_collection.html.erb
+++ b/app/views/catalog/record/_record_metadata_image_collection.html.erb
@@ -16,7 +16,3 @@
     <% end %>
   </div>
 </div>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>

--- a/app/views/catalog/record/_record_metadata_marc.html.erb
+++ b/app/views/catalog/record/_record_metadata_marc.html.erb
@@ -9,10 +9,6 @@
   </div>
 </div>
 
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>
-
 <% if @document.holdings.browsable_callnumbers.present? %>
   <%= render 'catalog/record/callnumber_browse' %>
 <% end %>

--- a/app/views/catalog/record/_record_metadata_merged_file_collection.html.erb
+++ b/app/views/catalog/record/_record_metadata_merged_file_collection.html.erb
@@ -13,7 +13,3 @@
 <% if @document.holdings.browsable_callnumbers.present? %>
   <%= render 'catalog/record/callnumber_browse' %>
 <% end %>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>

--- a/app/views/catalog/record/_record_metadata_merged_image.html.erb
+++ b/app/views/catalog/record/_record_metadata_merged_image.html.erb
@@ -12,7 +12,3 @@
 <% if @document.holdings.browsable_callnumbers.present? %>
   <%= render 'catalog/record/callnumber_browse' %>
 <% end %>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>

--- a/app/views/catalog/record/_record_metadata_merged_image_collection.html.erb
+++ b/app/views/catalog/record/_record_metadata_merged_image_collection.html.erb
@@ -12,7 +12,3 @@
 <% if @document.holdings.browsable_callnumbers.present? %>
   <%= render 'catalog/record/callnumber_browse' %>
 <% end %>
-
-<%# technical details placeholder - librarian view, catkey etc %>
-<div class="record-technical-details row">
-</div>


### PR DESCRIPTION
Removes unused placeholder `div` block created early in the project. Technical details are rendered in a different `tech-details` block.

![image](https://cloud.githubusercontent.com/assets/302258/4365969/7c941000-42b6-11e4-9d16-4063702a95f3.png)
