### PR TITLE
Add 'X' back into databases prefix option...

### DIFF
--- a/app/helpers/masthead_helper.rb
+++ b/app/helpers/masthead_helper.rb
@@ -8,7 +8,7 @@ module MastheadHelper
     end
   end
   def facets_prefix_options
-    ["0-9", ("A".."Z").to_a.delete_if{|letter| letter == "X"}].flatten
+    ["0-9", ("A".."Z").to_a].flatten
   end
   def digital_collections_params_for(format=nil)
     facet_params = {f: {building_facet: ["Stanford Digital Repository"]}}

--- a/spec/helpers/masthead_helper_spec.rb
+++ b/spec/helpers/masthead_helper_spec.rb
@@ -16,15 +16,13 @@ describe MastheadHelper do
   end
   describe "#facets_prefix_options" do
     it "should have the correct number of elements" do
-      expect(facets_prefix_options.length).to eq 26
+      expect(facets_prefix_options.length).to eq 27
     end
     it "should include the necessary options" do
       expect(facets_prefix_options).to include "0-9"
       expect(facets_prefix_options).to include "A"
+      expect(facets_prefix_options).to include "X"
       expect(facets_prefix_options).to include "Z"
-    end
-    it "should not contain 'X'" do
-      expect(facets_prefix_options).not_to include "X"
     end
   end
   describe '#digital_collections_params_for' do


### PR DESCRIPTION
...(since xSearch is now cataloged as a db).
### Before

![before](https://cloud.githubusercontent.com/assets/96776/4366225/5414f856-42bb-11e4-9f62-3f616e9acd91.png)
### After

![after](https://cloud.githubusercontent.com/assets/96776/4366226/5427206c-42bb-11e4-8f80-f52f12d38369.png)
