### PR TITLE
Add left border-radius to input-group-addon that holds the search field ...

### DIFF
--- a/app/assets/stylesheets/modules/search-bar.css.scss
+++ b/app/assets/stylesheets/modules/search-bar.css.scss
@@ -23,6 +23,14 @@
     }
   }
 
+  .search-form {
+    .input-group-addon {
+      &.for-search-field {
+        border-radius: 4px 0 0 4px;
+      }
+    }
+  }
+
   .navbar-nav.navbar-right.searchbar-right:last-child {
     margin-right: -15px;
   }

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
 
   <div class="input-group">
   <% unless search_fields.empty? %>
-    <span class="input-group-addon">
+    <span class="input-group-addon for-search-field">
       <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
       <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :id=>"search_field", :class=>"search_field") %>
     </span>


### PR DESCRIPTION
...select.

Closes #859 
![search-bar-border-radius](https://cloud.githubusercontent.com/assets/96776/4377911/6b3a7e96-4353-11e4-8ae0-129a27078bec.png)
