### PR TITLE
Make items that only exist at Hopkins and are not online request-able.

### DIFF
--- a/app/helpers/request_link_helper.rb
+++ b/app/helpers/request_link_helper.rb
@@ -1,7 +1,7 @@
 module RequestLinkHelper
   def request_link(document, callnumber)
     request_query = request_options(document, callnumber)
-    request_query.delete(:item_id) if Holdings::Library.new(callnumber.library).location_level_request?
+    request_query.delete(:item_id) if Holdings::Library.new(callnumber.library, document).location_level_request?
     if callnumber.on_order?
       request_query.delete(:item_id)
       request_query.delete(:home_lib)

--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -39,7 +39,7 @@ class Holdings
   def libraries
     unless @libraries
       @libraries = callnumbers.group_by(&:library).map do |library, items|
-        Holdings::Library.new(library, items)
+        Holdings::Library.new(library, @document, items)
       end
       append_mhld(:library, @libraries, Holdings::Library)
       @libraries.sort_by!(&:sort)

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -3,8 +3,9 @@ class Holdings
     include AppendMHLD
     attr_reader :code, :items
     attr_accessor :mhld
-    def initialize(code, items=[])
+    def initialize(code, document=nil, items=[])
       @code = code
+      @document = document
       @items = items
     end
     def name
@@ -31,7 +32,7 @@ class Holdings
       (mhld.present? && mhld.any?(&:present?))
     end
     def location_level_request?
-      Constants::REQUEST_LIBS.include?(@code)
+      Constants::REQUEST_LIBS.include?(@code) || hopkins_only_and_not_online?
     end
     def library_instructions
       Constants::LIBRARY_INSTRUCTIONS[@code]
@@ -42,6 +43,22 @@ class Holdings
       else
         name || @code
       end
+    end
+    private
+    def hopkins_only_and_not_online?
+      hopkins_only? && !document_online?
+    end
+    def hopkins_only?
+      @code == "HOPKINS" &&
+      @document.present? &&
+      @document.holdings.libraries.present? &&
+      @document.holdings.libraries.length == 1
+    end
+    def hopkins_and_not_online?
+      @code == "HOPKINS" && !document_online?
+    end
+    def document_online?
+      @document.present? && @document.access_panels.online?
     end
   end
 end

--- a/spec/integration/external-data/request_links_spec.rb
+++ b/spec/integration/external-data/request_links_spec.rb
@@ -10,5 +10,24 @@ describe 'Request Links', type: :feature, :"data-integration" => true do
         expect(page).to have_css('li a', text: "Request")
       end
     end
+    describe 'Hopkins' do
+      it 'should not render request links for items that exist at other libraries' do
+        visit catalog_path("10180544")
+
+        within(first("ul.location")) do
+          expect(page).to_not have_css('li a', text: "Request")
+        end
+      end
+      it 'should not render request links for items that are available online' do
+        visit catalog_path("10402123")
+
+        expect(page).to_not have_css('li a', text: "Request")
+      end
+      it 'should render request links for items that are not available online or at other libraries' do
+        visit catalog_path("3010807")
+
+        expect(page).to have_css('li a', text: "Request")
+      end
+    end
   end
 end


### PR DESCRIPTION
This changes the method signature of Holdings::Library
to include the SolrDocument class.

Closes #953 
### Examples
### Available online (10402123)
## ![10402123](https://cloud.githubusercontent.com/assets/96776/4395570/44ff971e-442c-11e4-8705-ad4ff91a3209.png)
### Available at another library (10180544)
## ![10180544](https://cloud.githubusercontent.com/assets/96776/4395569/44ff2edc-442c-11e4-99d4-da3268b1d2f6.png)
### Not online / Only @ Hopkins (3010807)

![3010807](https://cloud.githubusercontent.com/assets/96776/4395568/44fe983c-442c-11e4-8b16-128fac5f2393.png)
