### PR TITLE
Make items on reserve not requestable.

### DIFF
--- a/lib/holdings/requestable.rb
+++ b/lib/holdings/requestable.rb
@@ -15,9 +15,14 @@ class Holdings
     private
 
     def item_is_requestable?
+      !on_reserve? &&
       requestable_item_type? &&
       requestable_home_location? &&
       requestable_current_location?
+    end
+
+    def on_reserve?
+      @callnumber.on_reserve?
     end
 
     def must_request_item?

--- a/spec/lib/holdings/requestable_spec.rb
+++ b/spec/lib/holdings/requestable_spec.rb
@@ -12,6 +12,17 @@ describe Holdings::Requestable do
         end
       end
     end
+    describe 'reserves' do
+      it 'should not be requestable if the item is on reserve' do
+        expect(
+          Holdings::Requestable.new(
+            Holdings::Callnumber.new(
+              '1234 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC123 -|- -|- -|- -|- course_id -|- reserve_desk -|- loan_period'
+            )
+          )
+        ).to_not be_requestable
+      end
+    end
     describe "home locations" do
       it "should not be requestable if the library is GREEN and the home location is MEDIA-MTXT" do
         expect(Holdings::Requestable.new(Holdings::Callnumber.new('123 -|- GREEN -|- MEDIA-MTXT -|- -|- -|- '))).to_not be_requestable


### PR DESCRIPTION
Based on feedback from Access Services:

```
Items that are currently on reserve and checked out on reserve should not have a request hold/recall link.  
Items currently on reserve are first come, first serve
```
### 4004319 Before

![4004319-before](https://cloud.githubusercontent.com/assets/96776/4397382/e2b6c1a2-4441-11e4-9c2b-3ee2f5539227.png)
### 4004319 After

![4004319-after](https://cloud.githubusercontent.com/assets/96776/4397383/e2bcde66-4441-11e4-86c0-e001a090528f.png)
