### PR TITLE
Use full_shelfkey in shelfkey XML field instead callnumber object

### DIFF
--- a/app/helpers/xml_api_helper.rb
+++ b/app/helpers/xml_api_helper.rb
@@ -180,7 +180,7 @@ module XmlApiHelper
         xml_doc[:home_location] = record.xpath(".//item_record/home_location").text
         xml_doc[:date_time_due] = record.xpath(".//item_record/date_time_due").text
         xml_doc[:current_location] = record.xpath(".//item_record/current_location").text
-        xml_doc[:shelfkey] = doc.holdings.find_by_barcode(xml_doc[:id]) || "XXXX#{xml_doc[:item_number]}"
+        xml_doc[:shelfkey] = doc.holdings.find_by_barcode(xml_doc[:id]).try(:full_shelfkey) || "XXXX#{xml_doc[:item_number]}"
         item_details << xml_doc
       end
       availability[:item_details] = item_details

--- a/spec/integration/external-data/requests_xml_api_spec.rb
+++ b/spec/integration/external-data/requests_xml_api_spec.rb
@@ -2,22 +2,26 @@ require 'spec_helper'
 
 describe 'mobile api', :'data-integration' => true do
   it 'should display correct elements for standard record' do
-    visit catalog_path('713891', format: 'request')
+    visit catalog_path('713891', format: 'request', lib: 'SAL3')
     expect(page.body).to have_xml('//record')
     expect(page.body).to have_xml('//title')
     expect(page.body).to have_xml('//pub_info')
     expect(page.body).to have_xml('//physical_description')
     # Shouldn't have any brackets
     expect(page.body).to_not match /(\[|\])/
-    # Ported over tests, but failing in current prod
-    # expect(page.body).to have_xml('//item_details')
-    # expect(page.body).to have_xml('//item')
-    # expect(page.body).to have_xml('//id')
-    # expect(page.body).to have_xml('//shelfkey')
-    # expect(page.body).to have_xml('//copy_number')
-    # expect(page.body).to have_xml('//item_number')
-    # expect(page.body).to have_xml('//home_location')
-    # expect(page.body).to have_xml('//current_location')
+    expect(page.body).to have_xml('//item_details')
+    expect(page.body).to have_xml('//item')
+    expect(page.body).to have_xml('//id')
+    expect(page.body).to have_xml('//shelfkey')
+    expect(page.body).to have_xml('//copy_number')
+    expect(page.body).to have_xml('//item_number')
+    expect(page.body).to have_xml('//home_location')
+    expect(page.body).to have_xml('//current_location')
+  end
+  it 'should include a proper shelfkey' do
+    visit catalog_path('351080', format: 'request', lib: "SAL3")
+    expect(page.body).to have_xml('//shelfkey')
+    expect(page.body).to match(/<shelfkey>lc bf  0001\.000000 a0.500000.*~~~~~~<\/shelfkey>/)
   end
   it 'SAL request links should have specific content' do
   end


### PR DESCRIPTION
Example: `/view/351080.request?lib=SAL3`
#### Before

![351080-before](https://cloud.githubusercontent.com/assets/96776/5445990/d24ac82e-846d-11e4-82a3-680f4729d4a3.png)
#### After

![351080-after](https://cloud.githubusercontent.com/assets/96776/5445991/d24c6850-846d-11e4-81d9-91295c4d9082.png)
