### PR TITLE
Add a feedback alert and a boolean settings flag to turn it off/on.

### DIFF
--- a/app/assets/stylesheets/modules/feedback-form.css.scss
+++ b/app/assets/stylesheets/modules/feedback-form.css.scss
@@ -20,3 +20,11 @@
 #feedback-form{
   border-bottom: 3px solid $sul-toolbar-border;
 }
+
+.feedback-alert {
+  color: rgb(204, 0, 0);
+  font-size: 1.2em;
+  padding: 10px;
+  border: 1px solid rgb(204, 0, 0);
+  margin: 10px 0pt;
+}

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -1,4 +1,9 @@
 <div class="container">
+  <% if Settings.FEEDBACK_ALERT %>
+    <p class="feedback-alert">
+      <%= t('blacklight.feedback_form.feedback_alert_html', href: mail_to("infocenter@stanford.edu")) %>
+    </p>
+  <% end %>
   <%= form_tag feedback_form_path, method: :post, class:"form-horizontal feedback-form", role:"form" do %>
     <div class="col-sm-6 col-sm-offset-2">
       <div class="col-sm-offset-3">

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -32,6 +32,7 @@ en:
     back_to_search: '<i class="fa fa-fast-backward"></i><span class="hidden-xs">&nbsp; Back to results</span>'
     feedback_form:
       success: '<strong>Thank you!</strong> Your feedback has been sent.'
+      feedback_alert_html: "The Stanford University Libraries will be closed for Winter Break from December 20th through January 4th. All SearchWorks inquiries submitted during the closure will not be read until January 5th. If you require a response before January 5th, please send your comments to %{href}."
     range_limit:
       submit_limit: 'Apply'
   blacklight_advanced_search:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,3 +14,4 @@ NUMBER_OF_DAYS_TO_PRUNE: '7'
 PURL_EMBED_PROVIDER: 'http://embed-service.example.com/embed'
 PURL_EMBED_URL_SCHEME: 'http://purl.stanford.edu/*'
 PURL_EMBED_RESOURCE: 'http://purl.stanford.edu/'
+FEEDBACK_ALERT: <%= false %>


### PR DESCRIPTION
This adds a boolean flag in settings.yml (default `false`) to show the `i18n`ed feedback alert.  We can change the message anytime we like and then turning the message on/off will simply require changing the `config/settings/production.yml` (instead of pushing releases).

If you want to test this out set `Settings.FEEDBACK_ALERT = <%= true %>` in your settings.yml

![feedback](https://cloud.githubusercontent.com/assets/96776/5498119/ecac3e74-86ce-11e4-8647-f1acd1d8f9c2.png)
