### PR TITLE
fixes the missing browse nearby mystery

### DIFF
--- a/app/views/catalog/record/_callnumber_browse.html.erb
+++ b/app/views/catalog/record/_callnumber_browse.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <% document.holdings.browsable_callnumbers.each_with_index do |callnumber, index| %>
-    <div id="callnumber-<%=index%>" class="embed-callnumber-browse-container">
+    <div id="callnumber-<%=index%>" class="embed-callnumber-browse-container" style="<%= 'display:none;' unless index == 0 %>">
       <div class="embedded-items"><div class="gallery"></div></div>
       <a class="left embed-browse-control" href="#" data-slide="prev">
         <span class="glyphicon glyphicon-chevron-left"></span>

--- a/app/views/catalog/record/_callnumber_browse.html.erb
+++ b/app/views/catalog/record/_callnumber_browse.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <% document.holdings.browsable_callnumbers.each_with_index do |callnumber, index| %>
-    <div id="callnumber-<%=index%>" class="collapse embed-callnumber-browse-container">
+    <div id="callnumber-<%=index%>" class="embed-callnumber-browse-container">
       <div class="embedded-items"><div class="gallery"></div></div>
       <a class="left embed-browse-control" href="#" data-slide="prev">
         <span class="glyphicon glyphicon-chevron-left"></span>


### PR DESCRIPTION
Removed no longer necessary `collapse` class

This commit introduced `visibility: hidden` to `collapse` class: https://github.com/twbs/bootstrap/commit/6cfd176ac3d0eedc5b9b50fd88bf0774af0f1222