### PR TITLE
Don't try to link to a barcoded LANE item when there are only MHLDS.

### DIFF
--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -21,7 +21,11 @@ class Holdings
     end
     def location_link
       if external_location?
-        "http://lmldb.stanford.edu/cgi-bin/Pwebrecon.cgi?DB=local&Search_Arg=SOCW+#{items.first.barcode.gsub(/^L/,'')}&Search_Code=CMD*&CNT=10"
+        if items.first.try(:barcode)
+          "http://lmldb.stanford.edu/cgi-bin/Pwebrecon.cgi?DB=local&Search_Arg=SOCW+#{items.first.barcode.gsub(/^L/,'')}&Search_Code=CMD*&CNT=10"
+        else
+          'http://lmldb.stanford.edu'
+        end
       end
     end
     def present?

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -79,6 +79,11 @@ describe Holdings::Location do
         expect(external_location.location_link).to match /L12345/
         expect(external_location.location_link).to_not match /LL12345/
       end
+      it 'should just return a link to the lane library catalog if there are no barcoded items' do
+        allow(external_location).to receive(:items).and_return([])
+        external_location.mhld = [double('mhld', library: "LANE-MED")]
+        expect(external_location.location_link).to eq 'http://lmldb.stanford.edu'
+      end
       it 'should not provide a link for non-external locations' do
         expect(non_external_location.location_link).to be_nil
       end


### PR DESCRIPTION
This is currently causing an error for any LANE record that has no barcoded items and only has MHLD data.