### PR TITLE
Only set the thumbnail URL if it's not already set.

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -38,7 +38,6 @@
         $.ajax({
           type: 'GET',
           url: batchBooksApiUrl,
-          async: false,
           contentType: "application/json",
           dataType: 'jsonp',
 
@@ -58,30 +57,37 @@
       $.each(json, function(bibkey, data) {
         if (typeof data.thumbnail_url !== 'undefined') {
           renderCoverImage(bibkey, data);
+          return;
         }
+      });
 
+      $.each(json, function(bibkey, data) {
         if (typeof data.info_url !== 'undefined') {
           renderAccessPanel(bibkey, data);
+          return;
         }
       });
     }
 
     function renderCoverImage(bibkey, data) {
       var thumbUrl = data.thumbnail_url,
-        selectorCoverImg = 'img.' + bibkey;
+          selectorCoverImg = 'img.' + bibkey;
 
       thumbUrl = thumbUrl.replace(/zoom=5/, 'zoom=1');
       thumbUrl = thumbUrl.replace(/&?edge=curl/, '');
 
       var imageEl = $parent.find(selectorCoverImg);
 
-      imageEl
-        .attr('src', thumbUrl)
-        .removeClass('hide')
-        .addClass('show');
+      // Only set the thumb src if it's not already set
+      if(typeof imageEl.attr('src') === 'undefined') {
+        imageEl
+          .attr('src', thumbUrl)
+          .removeClass('hide')
+          .addClass('show');
 
-      imageEl.parent().parent().find('span.fake-cover')
-        .addClass('hide');
+        imageEl.parent().parent().find('span.fake-cover')
+          .addClass('hide');
+      }
     }
 
 

--- a/spec/features/blacklight_customizations/record_metadata_spec.rb
+++ b/spec/features/blacklight_customizations/record_metadata_spec.rb
@@ -13,7 +13,7 @@ feature "Record view" do
       expect(page).to have_css("img.cover-image[data-isbn='ISBN0393040801,ISBN9780393040807']", visible: true)
       expect(page).to have_css("img.cover-image[data-lccn='LCCN96049953']", visible: true)
       expect(page).to have_css("img.cover-image[data-oclc='OCLC36024029']", visible: true)
-      expect(find('img.cover-image')['src']).to match /books\.google\.com\/.*id=3xmDzzNiwiUC/
+      expect(find('img.cover-image')['src']).to match /books\.google\.com\/.*id=crOdQgAACAAJ/
     end
 
   end

--- a/spec/features/blacklight_customizations/results_document_spec.rb
+++ b/spec/features/blacklight_customizations/results_document_spec.rb
@@ -35,7 +35,7 @@ feature "Results Document Metadata" do
         expect(page).to have_css("img.cover-image[data-isbn='ISBN0393040801,ISBN9780393040807']", visible: true)
         expect(page).to have_css("img.cover-image[data-lccn='LCCN96049953']", visible: true)
         expect(page).to have_css("img.cover-image[data-oclc='OCLC36024029']", visible: true)
-        expect(find("img.cover-image")['src']).to match /books\.google\.com\/.*id=3xmDzzNiwiUC/
+        expect(find("img.cover-image")['src']).to match /books\.google\.com\/.*id=crOdQgAACAAJ/
       end
     end
   end


### PR DESCRIPTION
Closes #963 

@jchristo4 does this seem reasonable to you?  I think Google will return the numbers in the order we send them in and since we'll only try to set the image for the first match we have in the response this should address the issue where OCLC/LCCN matches are being used when an ISBN is returned first.