### PR TITLE
Updated rails and related dependencies to fix security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,14 +171,14 @@ GEM
     jquery-datatables-rails (2.2.1)
       jquery-rails
       sass-rails
-    jquery-rails (3.1.2)
+    jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.2)
+    json (1.8.3)
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     logger (1.2.8)
     lyberteam-capistrano-devel (3.1.0)
       capistrano (~> 3.0)
@@ -190,9 +190,9 @@ GEM
     marc (0.8.1)
       ensure_valid_encoding
       unf
-    mime-types (2.4.3)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
-    minitest (5.5.0)
+    minitest (5.7.0)
     mods (0.0.23)
       iso-639
       nokogiri
@@ -200,7 +200,7 @@ GEM
     mods_display (0.3.3)
       i18n
       stanford-mods
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     multipart-post (2.0.0)
     mysql (2.9.1)
     net-scp (1.2.1)
@@ -222,7 +222,7 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    rack (1.5.2)
+    rack (1.5.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.8)
@@ -293,7 +293,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.2)
+    sprockets-rails (2.3.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
@@ -314,7 +314,7 @@ GEM
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tilt (1.4.1)
     tins (1.3.0)
     turbolinks (2.2.2)


### PR DESCRIPTION
http://weblog.rubyonrails.org/2015/6/16/Rails-3-2-22-4-1-11-and-4-2-2-have-been-released-and-more/