### PR TITLE
Add feature to handle many managed PURLs in one record

### DIFF
--- a/app/assets/javascripts/jquery.managed-purl.js
+++ b/app/assets/javascripts/jquery.managed-purl.js
@@ -1,0 +1,61 @@
+;(function ($, window, document, undefined ) {
+  'use strict';
+  
+  // Create the defaults once
+  var pluginName = "managedPurl";
+  var defaults = {};
+  var $el;
+
+  function Plugin(element, options) {
+    $el = $(element);
+    
+    this.options = $.extend({}, defaults, options);
+    this._defaults = defaults;
+    this._name = pluginName;
+    
+    this.init();
+  }
+
+  Plugin.prototype = {
+    init: function() {
+      this.embedIframe($el.find('li').first());
+      this.setupListeners();
+    },
+    setupListeners: function() {
+      var _this = this;
+      $el.find('li').on('click', function(e, f) {
+        $el.find('li').removeClass('active');
+        _this.embedIframe($(this));
+      });
+    },
+    embedIframe: function($li) {
+      $li.addClass('active');
+      var data = $li.data();
+      var $embedArea = $('.managed-purl-embed');
+      var provider = data.embedProvider.replace(/\/embed$/, '/iframe');
+      var iFrameHtml = '<iframe src="' +
+                       provider + '?url=' + data.embedTarget +
+                       '&hide_title=true&maxheight=500"' +
+                       ' frameborder=0 width="100%" scrolling="no"' +
+                       ' allowfullscreen=true' +
+                       ' style="height: 520px;"><iframe>';
+      $embedArea.html(iFrameHtml);
+    }
+  };
+
+  // A really lightweight plugin wrapper around the constructor,
+  // preventing against multiple instantiations
+  $.fn[pluginName] = function ( options ) {
+    return this.each(function () {
+      if (!$.data(this, "plugin_" + pluginName)) {
+        $.data(this, "plugin_" + pluginName,
+        new Plugin( this, options ));
+      }
+    });
+  };
+
+})(jQuery, window, document);
+
+Blacklight.onLoad(function() {
+  $('.managed-purl-panel').managedPurl();
+});

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -11,8 +11,7 @@ body {
 }
 
 a, a:hover, a:focus {
-	text-decoration: none;
-  border-bottom: 1px dotted $sul-link-color-border;
+  @include link-styling;
 }
 
 h1 {

--- a/app/assets/stylesheets/modules/access-panel-library-locations.css.scss
+++ b/app/assets/stylesheets/modules/access-panel-library-locations.css.scss
@@ -1,10 +1,8 @@
 .panel-library-location {
   .library-location-heading {
-    border-bottom: 1px solid $sul-access-location-bg;
-    padding-bottom: 6px;
-    background: $sul-access-location-bg;
-    color: $sul-access-font;
+    @include panel-heading($sul-access-location-bg, $sul-access-font);
     height: 50px;
+    padding-bottom: 6px;
     a {
       color: #fff;
       text-decoration: underline;

--- a/app/assets/stylesheets/modules/managed_purl_panel.scss
+++ b/app/assets/stylesheets/modules/managed_purl_panel.scss
@@ -1,0 +1,45 @@
+.managed-purl {
+  @include show-page-row-layout;
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  li {
+    border: 1px solid $white;
+    padding: 4px;
+
+    &.active {
+      background: $beige-5-percent;
+      border: 1px solid $sul-managed-purl-border;
+    }
+
+    &:hover,
+    &:active {
+      background: $beige-5-percent;
+      border: 1px solid $sul-managed-purl-border-hover;
+    }
+
+    button {
+      background: none !important;
+      border: none;
+      cursor: pointer;
+      font: inherit;
+      padding: 0 !important;
+      margin-left: 8px;
+      @include link-styling;
+    }
+  }
+}
+
+.managed-purl-panel {
+  .managed-purl-heading {
+    @include panel-heading($sul-managed-purl-panel-background, $sul-managed-purl-panel-font);
+    height: 40px;
+    padding: 10px;
+  }
+}
+
+.managed-purl-embed {
+  margin: -8px;
+}

--- a/app/assets/stylesheets/modules/record-metadata-section.css.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.css.scss
@@ -12,7 +12,7 @@
 }
 
 .record-metadata, .upper-record-metadata {
-  margin-right: 25px;
+  @include show-page-row-layout;
 
   dt {
     width: auto;

--- a/app/assets/stylesheets/searchworks-mixins.css.scss
+++ b/app/assets/stylesheets/searchworks-mixins.css.scss
@@ -103,3 +103,18 @@
     margin-right: 2px;
   }
 }
+
+@mixin panel-heading($background, $font-color) {
+  background: $background;
+  border-bottom: 1px solid $background;
+  color: $font-color;
+}
+
+@mixin show-page-row-layout {
+  margin-right: 25px;
+}
+
+@mixin link-styling {
+  border-bottom: 1px dotted $sul-link-color-border;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/searchworks.css.scss
+++ b/app/assets/stylesheets/searchworks.css.scss
@@ -36,6 +36,7 @@
 @import 'modules/image-icons';
 @import 'modules/item-preview';
 @import 'modules/license-icons';
+@import 'modules/managed_purl_panel';
 @import 'modules/mastheads';
 @import 'modules/online-resource-links';
 @import 'modules/pagination';

--- a/app/assets/stylesheets/sul-variables.css.scss
+++ b/app/assets/stylesheets/sul-variables.css.scss
@@ -115,6 +115,11 @@ $sul-stackmap-image-border-color: $gray-90-percent;
 $sul-icon-refworks-color: $strong-red;
 $sul-icon-endnote-color: $mostly-pure-orange;
 $sul-tooltip-bg: $cadet-blue;
+$sul-managed-purl-panel-background: $pantone-405;
+$sul-managed-purl-panel-font: $white;
+$sul-managed-purl-list-background: $beige-5-percent;
+$sul-managed-purl-border: $beige-30-percent;
+$sul-managed-purl-border-hover: $beige-20-percent;
 
 // Sizes
 $gallery-document-width: 176px;

--- a/app/models/concerns/digital_image.rb
+++ b/app/models/concerns/digital_image.rb
@@ -8,18 +8,24 @@ module DigitalImage
 
 
   # Get stacks urls for a document using file ids
+  # @return [Array]
   def image_urls(size=:default)
     return nil unless has_image_behavior?
-
-    stacks_url = Settings.STACKS_URL
-
     file_ids.map do |image_id|
-      image_id = image_id.gsub(/\.jp2$/, '')
-
-      "#{stacks_url}/#{self.druid}/#{image_id}#{image_dimensions[size]}"
+      craft_image_url(druid, image_id, size)
     end
   end
 
+  ##
+  # Generates a Stacks image url using given arguments
+  # @param [String] druid
+  # @param [String] image_id
+  # @param [Symbol] size
+  # @return [String]
+  def craft_image_url(druid, image_id, size)
+    image_id = image_id.gsub(/\.jp2$/, '')
+    "#{Settings.STACKS_URL}/#{druid}/#{image_id}#{image_dimensions[size]}"
+  end
 
   # Size definitions for stacks urls
   def image_dimensions(size=:default)

--- a/app/models/concerns/marc_links.rb
+++ b/app/models/concerns/marc_links.rb
@@ -21,7 +21,8 @@ module MarcLinks
             stanford_only: stanford_only?(link),
             finding_aid: link_is_finding_aid?(link_field),
             managed_purl: link_is_managed_purl?(link),
-            file_id: file_id(link_field)
+            file_id: file_id(link_field),
+            druid: druid(link)
           )
         end
       end.compact
@@ -125,6 +126,10 @@ module MarcLinks
 
     def link_is_managed_purl?(link)
       @document[:managed_purl_urls] && @document[:managed_purl_urls].include?(link[:href])
+    end
+
+    def druid(link)
+      link[:href].gsub(%r{^https?:\/\/purl.stanford.edu\/?}, '') if link[:href] =~ /purl.stanford.edu/
     end
 
     def stanford_affiliated_regex

--- a/app/views/catalog/_managed_purl_embed.html.erb
+++ b/app/views/catalog/_managed_purl_embed.html.erb
@@ -1,0 +1,25 @@
+<div class="managed-purl row">
+  <div class="col-md-4">
+    <div class="panel panel-default managed-purl-panel ">
+      <div class="managed-purl-heading">
+        <%= "#{@document.marc_links.managed_purls.count} parts" %>
+      </div>
+      <div class="panel-body">
+        <ul>
+          <% @document.marc_links.managed_purls.each_with_index do |purl, i| %>
+            <li data-embed-target = '<%= "#{Settings.PURL_EMBED_RESOURCE}#{purl.druid}" %>' data-embed-provider = '<%= Settings.PURL_EMBED_PROVIDER %>'>
+              <% if purl.file_id %>
+                <img src="<%= @document.craft_image_url(purl.druid, purl.file_id, :thumbnail) %>">
+              <% end %>
+              <%= button_tag "part #{i + 1}" %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-8">
+    <div class='managed-purl-embed'>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_show_merged_image.html.erb
+++ b/app/views/catalog/_show_merged_image.html.erb
@@ -1,10 +1,14 @@
 <% add_purl_embed_header(@document) %>
 
-<div class='upper-record-metadata row'>
-  <div class="col-md-7">
-    <div class="purl-embed-viewer" data-behavior="purl-embed" data-embed-url="<%= embed_path(@document.druid) %>"></div>
+<% if @document.marc_links.managed_purls.many? %>
+  <%= render 'catalog/managed_purl_embed' %>
+<% else %>
+  <div class='upper-record-metadata row'>
+    <div class="col-md-7">
+      <div class="purl-embed-viewer" data-behavior="purl-embed" data-embed-url="<%= embed_path(@document.druid) %>"></div>
+    </div>
+    <div class="col-md-5">
+      <%= render 'catalog/record/marc_upper_metadata_items' %>
+    </div>
   </div>
-  <div class="col-md-5">
-    <%= render 'catalog/record/marc_upper_metadata_items' %>
-  </div>
-</div>
+<% end %>

--- a/app/views/catalog/record/_record_metadata_merged_image.html.erb
+++ b/app/views/catalog/record/_record_metadata_merged_image.html.erb
@@ -3,6 +3,9 @@
     <%= render "catalog/record/metadata_panels" %>
   </div>
   <div class="record-sections col-md-8">
+    <% if @document.marc_links.managed_purls.many? %>
+      <%= render 'catalog/record/marc_upper_metadata_items' %>
+    <% end %>
     <% if @document.respond_to?(:to_marc) %>
       <%= render "catalog/record/marc_metadata_sections" %>
     <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ SQUASH_DISABLE: <%= (Rails.env.development? || Rails.env.test?) %>
 STACKMAP_API_URL: "http://stanford.stackmap.com/json/"
 WHEN_TO_PRUNE_DATA: '12:30am'
 NUMBER_OF_DAYS_TO_PRUNE: '7'
-PURL_EMBED_PROVIDER: 'http://embed-service.example.com/embed'
+PURL_EMBED_PROVIDER: 'https://embed.stanford.edu/embed'
 PURL_EMBED_URL_SCHEME: 'http://purl.stanford.edu/*'
 PURL_EMBED_RESOURCE: 'http://purl.stanford.edu/'
 FEEDBACK_ALERT: <%= false %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,1 +1,2 @@
 HOSTNAME: "TEST-HOST"
+PURL_EMBED_PROVIDER: 'http://embed.stanford.edu/embed'

--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -163,6 +163,7 @@
     <!-- sfx urls should rarely occur more than once in a marc bib record -->
     <field name="url_sfx" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="url_restricted" type="string" indexed="false" stored="true" multiValued="true" />
+    <field name="managed_purl_urls" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!-- Physical Fields -->
     <field name="physical" type="text" indexed="true" stored="true" multiValued="true" />

--- a/lib/access_panels/online.rb
+++ b/lib/access_panels/online.rb
@@ -1,12 +1,16 @@
 class Online < AccessPanel
   delegate :present?, to: :links
   def links
-    unless @document.is_a_collection_member?
-      if @document.index_links.sfx.present?
-        @document.index_links.sfx
-      elsif @document.marc_links.present?
-        @document.marc_links.fulltext
-      end
-    end
+    sfx_links || marc_fulltext_links
+  end
+
+  private
+
+  def sfx_links
+    @document.index_links.sfx if @document.index_links.sfx.present?
+  end
+
+  def marc_fulltext_links
+    @document.marc_links.fulltext if @document.marc_links.present?
   end
 end

--- a/lib/links.rb
+++ b/lib/links.rb
@@ -29,7 +29,7 @@ module SearchWorks
     end
 
     class Link
-      attr_accessor :html, :text, :href, :file_id
+      attr_accessor :html, :text, :href, :file_id, :druid
       def initialize(options={})
         @html = options[:html]
         @text = options[:text]
@@ -40,6 +40,7 @@ module SearchWorks
         @sfx = options[:sfx]
         @managed_purl = options[:managed_purl]
         @file_id = options[:file_id]
+        @druid = options[:druid]
       end
 
       def ==(other)

--- a/lib/links.rb
+++ b/lib/links.rb
@@ -9,11 +9,11 @@ module SearchWorks
     end
 
     def fulltext
-      all.select(&:fulltext?).reject(&:finding_aid?)
+      all.select(&:fulltext?).reject(&:finding_aid?).reject(&:managed_purl?)
     end
 
     def supplemental
-      all.reject(&:fulltext?).reject(&:finding_aid?)
+      all.reject(&:fulltext?).reject(&:finding_aid?).reject(&:managed_purl?)
     end
 
     def finding_aid
@@ -24,8 +24,12 @@ module SearchWorks
       all.select(&:sfx?)
     end
 
+    def managed_purls
+      all.select(&:managed_purl?)
+    end
+
     class Link
-      attr_accessor :html, :text, :href
+      attr_accessor :html, :text, :href, :file_id
       def initialize(options={})
         @html = options[:html]
         @text = options[:text]
@@ -34,21 +38,32 @@ module SearchWorks
         @stanford_only = options[:stanford_only]
         @finding_aid = options[:finding_aid]
         @sfx = options[:sfx]
+        @managed_purl = options[:managed_purl]
+        @file_id = options[:file_id]
       end
+
       def ==(other)
         [@html, @fulltext, @stanford_only, @finding_aid, @sfx] == [other.html, other.fulltext?, other.stanford_only?, other.finding_aid?, other.sfx?]
       end
+
       def fulltext?
         @fulltext
       end
+
       def stanford_only?
         @stanford_only
       end
+
       def finding_aid?
         @finding_aid
       end
+
       def sfx?
         @sfx
+      end
+
+      def managed_purl?
+        @managed_purl
       end
     end
   end

--- a/spec/features/purl_embed_spec.rb
+++ b/spec/features/purl_embed_spec.rb
@@ -1,12 +1,43 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "PURL Embed", js: true do
-  pending 'should be present for images' do
+describe 'PURL Embed', js: true do
+  it 'should be present for images' do
+    pending('Passes locally, not on Travis.') if ENV['CI']
     visit catalog_path('mf774fs2413')
-    within(".purl-embed-viewer") do
+
+    within('.purl-embed-viewer') do
       expect(page).to have_css('#sul-embed-object')
-      expect(page).to have_content("180 images")
-      expect(page).to have_css(".sul-embed-purl-link", text: "purl.stanford.edu/mf774fs2413")
+      expect(page).to have_content('180 images')
+      expect(page).to have_css('.sul-embed-purl-link', text: 'purl.stanford.edu/mf774fs2413')
+    end
+  end
+
+  describe 'many purls for one ckey' do
+    before do
+      visit catalog_path('8923346')
+    end
+
+    it 'has the managed purl panel with an item for each managed purl' do
+      within('.managed-purl-panel') do
+        expect(page).to have_css('li[data-embed-target="http://purl.stanford.edu/ct493wg6431"]')
+        expect(page).to have_css('li[data-embed-target="http://purl.stanford.edu/zg338xh5248"]')
+      end
+    end
+
+    it 'switches iframe src attributes on item selection' do
+      first_item = all('li[data-embed-target="http://purl.stanford.edu/ct493wg6431"]').first
+      last_item = all('li[data-embed-target="http://purl.stanford.edu/zg338xh5248"]').first
+      expect(all('iframe').first['src']).to include('purl.stanford.edu/ct493wg6431')
+
+      last_item.click
+      expect(all('iframe').first['src']).to include('purl.stanford.edu/zg338xh5248')
+
+      first_item.click
+      expect(all('iframe').first['src']).to include('purl.stanford.edu/ct493wg6431')
+    end
+
+    it 'should not include the online panel' do
+      expect(page).not_to have_css('.panel-online', visible: true)
     end
   end
 end

--- a/spec/fixtures/marc_records/marc_856_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_856_fixtures.rb
@@ -163,4 +163,22 @@ module Marc856Fixtures
       </record>
     xml
   end
+
+  def many_managed_purl_856
+    <<-xml
+      <record>
+      <datafield tag="245" ind1=" " ind2=" ">
+        <subfield code="a">Many PURLs for One CKey</subfield>
+      </datafield>
+        <datafield tag='856' ind1='0' ind2='0'>
+          <subfield code='u'>http://purl.stanford.edu/ct493wg6431</subfield>
+          <subfield code='x'>file:ct493wg6431_00_0001.jp2</subfield>
+        </datafield>
+        <datafield tag='856' ind1='0' ind2='0'>
+          <subfield code='u'>http://purl.stanford.edu/zg338xh5248</subfield>
+          <subfield code='x'>file:zg338xh5248_00_0001.jp2</subfield>
+        </datafield>
+      </record>
+    xml
+  end
 end

--- a/spec/fixtures/marc_records/marc_856_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_856_fixtures.rb
@@ -151,4 +151,16 @@ module Marc856Fixtures
       </record>
     xml
   end
+
+  def managed_purl_856
+    <<-xml
+      <record>
+        <datafield tag='856' ind1='0' ind2='0'>
+          <subfield code='u'>http://library.stanford.edu</subfield>
+          <subfield code='x'>file:abc123</subfield>
+          <subfield code='y'>Link text 2</subfield>
+        </datafield>
+      </record>
+    xml
+  end
 end

--- a/spec/fixtures/solr_documents/11.yml
+++ b/spec/fixtures/solr_documents/11.yml
@@ -15,4 +15,3 @@
 :format_main_ssim: Newspaper
 :access_facet: Online
 :building_facet: SAL3 (off-campus storage)
-

--- a/spec/fixtures/solr_documents/8923346.yml
+++ b/spec/fixtures/solr_documents/8923346.yml
@@ -1,0 +1,13 @@
+:id: 8923346
+:title_display: Many PURLs for One CKey
+:language: English
+:format: Book
+:format_main_ssim: Book
+:access_facet: At the Library
+:marcxml: <%= many_managed_purl_856 %>
+:display_type:
+  - sirsi
+  - image
+:managed_purl_urls:
+  - http://purl.stanford.edu/ct493wg6431
+  - http://purl.stanford.edu/zg338xh5248

--- a/spec/lib/access_panels/online_spec.rb
+++ b/spec/lib/access_panels/online_spec.rb
@@ -1,49 +1,76 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe AccessPanel::Online do
   include ModsFixtures
   include Marc856Fixtures
+
   let(:fulltext) { Online.new(SolrDocument.new(marcxml: fulltext_856)) }
   let(:supplemental) { Online.new(SolrDocument.new(marcxml: supplemental_856)) }
-  let(:sfx) { Online.new(
-    SolrDocument.new(url_sfx: 'http://example.com/sfx-link', marcxml: fulltext_856)
-  ) }
-  let(:image_collection_member) {
+
+  let(:sfx) do
+    Online.new(
+      SolrDocument.new(url_sfx: 'http://example.com/sfx-link', marcxml: fulltext_856)
+    )
+  end
+
+  let(:image_collection_member) do
     Online.new(
       SolrDocument.new(
         collection: ['12345'],
-        url_fulltext: 'http://library.stanford.edu'
+        marcxml: fulltext_856
       )
     )
-  }
-  let(:mods) { Online.new(
-    SolrDocument.new(
-      collection: ['12345'],
-      url_fulltext: 'http://purl.stanford.edu/',
-      modsxml: mods_everything
+  end
+
+  let(:managed_purl_doc) do
+    Online.new(
+      SolrDocument.new(
+        managed_purl_urls: ['http://library.stanford.edu'],
+        marcxml: managed_purl_856
+      )
     )
-  ) }
-  it "should delegate present? to links" do
+  end
+
+  let(:mods) do
+    Online.new(
+      SolrDocument.new(
+        collection: ['12345'],
+        url_fulltext: 'http://purl.stanford.edu/',
+        modsxml: mods_everything
+      )
+    )
+  end
+
+  it 'should delegate present? to links' do
     expect(fulltext).to be_present
     expect(supplemental).to_not be_present
   end
-  describe "#links" do
-    it "should not return links when they are present in MODS records" do
+
+  describe '#links' do
+    it 'should not return links when they are present in MODS records' do
       expect(mods.links).to_not be_present
     end
-    it "should return fulltext links" do
+
+    it 'should return fulltext links' do
       expect(fulltext.links.all?(&:fulltext?)).to be_true
     end
-    it "should return the SFX link even if there are other links" do
+
+    it 'should return the SFX link even if there are other links' do
       links = sfx.links
       expect(links.length).to eq 1
       expect(links.first).to be_sfx
-      expect(links.first.html).to match /^<a href=.*class='sfx'>Find full text<\/a>$/
+      expect(links.first.html).to match %r{^<a href=.*class='sfx'>Find full text<\/a>$}
     end
-    it 'should not return fulltext links from the index for collection members' do
-      expect(image_collection_member.links).to_not be_present
+
+    it 'returns fulltext links for collection members' do
+      expect(image_collection_member.links).to be_present
     end
-    it "should not return any non-fulltext links" do
+
+    it 'does not return managed purls' do
+      expect(managed_purl_doc.links).to be_blank
+    end
+
+    it 'should not return any non-fulltext links' do
       expect(supplemental.links).to be_blank
     end
   end

--- a/spec/lib/links_spec.rb
+++ b/spec/lib/links_spec.rb
@@ -1,44 +1,67 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe SearchWorks::Links do
   let(:links) { SearchWorks::Links.new({}) }
   before do
     links.stub(:all).and_return([
-      OpenStruct.new(html: "non-fulltext link", fulltext?: false),
-      OpenStruct.new(html: "fulltext link",     fulltext?: true),
-      OpenStruct.new(html: "1st finding aid link", fulltext?: true,  finding_aid?: true),
-      OpenStruct.new(html: "2nd finding aid link", fulltext?: false, finding_aid?: true)
+      OpenStruct.new(html: 'non-fulltext link', fulltext?: false),
+      OpenStruct.new(html: 'fulltext link',     fulltext?: true),
+      OpenStruct.new(html: '1st finding aid link', fulltext?: true,  finding_aid?: true),
+      OpenStruct.new(html: '2nd finding aid link', fulltext?: false, finding_aid?: true),
+      OpenStruct.new(html: 'Managed purl link', fulltext?: true, managed_purl?: true)
     ])
   end
-  it "should identify fulltext links" do
+
+  it 'should identify fulltext links' do
     expect(links.fulltext.length).to eq 1
-    expect(links.fulltext.first.html).to eq "fulltext link"
+    expect(links.fulltext.first.html).to eq 'fulltext link'
   end
-  it "should identify supplemental links" do
+
+  it 'should identify supplemental links' do
     expect(links.supplemental.length).to eq 1
-    expect(links.supplemental.first.html).to eq "non-fulltext link"
+    expect(links.supplemental.first.html).to eq 'non-fulltext link'
   end
-  it "should identify finding aid links" do
+
+  it 'should identify finding aid links' do
     expect(links.finding_aid.length).to eq 2
-    expect(links.finding_aid.first.html).to eq "1st finding aid link"
-    expect(links.finding_aid.last.html).to eq "2nd finding aid link"
+    expect(links.finding_aid.first.html).to eq '1st finding aid link'
+    expect(links.finding_aid.last.html).to eq '2nd finding aid link'
   end
-  describe "Link" do
-    let(:link) { SearchWorks::Links::Link.new(html: "text", fulltext: true, stanford_only: true, finding_aid: true, sfx: true) }
-    it "should parse the text option" do
-      expect(link.html).to eq "text"
+
+  it 'should identify the managed_purl links' do
+    expect(links.managed_purls.length).to eq 1
+    expect(links.managed_purls.first.html).to eq 'Managed purl link'
+  end
+
+  describe 'Link' do
+    let(:link) do
+      SearchWorks::Links::Link.new(
+        html: 'text', fulltext: true, stanford_only: true, finding_aid: true, sfx: true, managed_purl: true
+      )
     end
-    it "should parse the fulltext option" do
+
+    it 'should parse the text option' do
+      expect(link.html).to eq 'text'
+    end
+
+    it 'should parse the fulltext option' do
       expect(link).to be_fulltext
     end
-    it "should parse the stanford only option" do
+
+    it 'should parse the stanford only option' do
       expect(link).to be_stanford_only
     end
-    it "should parse the finding_aid option" do
+
+    it 'should parse the finding_aid option' do
       expect(link).to be_finding_aid
     end
-    it "should parse the sfx option" do
+
+    it 'should parse the sfx option' do
       expect(link).to be_sfx
+    end
+
+    it 'should parse the managed_purl option' do
+      expect(link).to be_managed_purl
     end
   end
 end

--- a/spec/models/concerns/digital_image_spec.rb
+++ b/spec/models/concerns/digital_image_spec.rb
@@ -1,20 +1,32 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "Image object" do
-
-  let(:image_document) { SolrDocument.new(id: 4488, druid: 4488, display_type: ['image'], img_info: ['abc123defg']) }
-
-  it "should return default size" do
-    expect(image_document.image_dimensions[:large]).to eq "_thumb"
+describe 'Image object' do
+  let(:image_document) do
+    SolrDocument.new(
+      id: 4488,
+      druid: 4488,
+      display_type: ['image'],
+      img_info: ['abc123defg']
+    )
   end
 
-  it "should validate digital image object" do
+  it 'should return default size' do
+    expect(image_document.image_dimensions[:large]).to eq '_thumb'
+  end
+
+  it 'should validate digital image object' do
     expect(image_document.has_image_behavior?).to be_true
   end
 
-  it "should return stacks image urls" do
+  it 'should return stacks image urls' do
     expect(image_document.image_urls.length).to eq 1
-    expect(image_document.image_urls.first).to include("/4488/abc123defg")
+    expect(image_document.image_urls.first).to include('/4488/abc123defg')
+  end
+
+  it 'provides a method to craft a stacks image url given parameters (removing the .jp2 extension)' do
+    expect(image_document.craft_image_url('abc', '123.jp2', :thumbnail)).to match(
+      %r{stanford.edu/image/abc/123_square}
+    )
   end
 
   it 'should return false if there is no display_type' do

--- a/spec/models/concerns/index_links_spec.rb
+++ b/spec/models/concerns/index_links_spec.rb
@@ -5,91 +5,114 @@ class IndexLinksTestClass
 end
 
 describe IndexLinks do
-  let(:solr_document) {
+  let(:solr_document) do
     SolrDocument.new(
-      url_fulltext:   ["http://library.stanford.edu"],
-      url_suppl:      ["http://searchworks.stanford.edu"],
-      url_restricted: ["http://library.stanford.edu"]
+      url_fulltext:   ['http://library.stanford.edu'],
+      url_suppl:      ['http://searchworks.stanford.edu'],
+      url_restricted: ['http://library.stanford.edu']
     )
-  }
-  let(:finding_aid_document) {
+  end
+  let(:finding_aid_document) do
     SolrDocument.new(
-      url_suppl: ["http://oac.cdlib.org/findaid/something-else"]
+      url_suppl: ['http://oac.cdlib.org/findaid/something-else']
     )
-  }
-  let(:sfx_document) {
+  end
+  let(:managed_purl_document) do
+    SolrDocument.new(
+      managed_purl_urls: ['http://purl.stanford.edu/abc123']
+    )
+  end
+  let(:sfx_document) do
     SolrDocument.new(
       url_sfx: ['http://example.com/sfx-link']
     )
-  }
-  let(:ezproxy_document) {
+  end
+  let(:ezproxy_document) do
     SolrDocument.new(
-      url_fulltext: ["http://ezproxy.stanford.edu/login?url=http://library.stanford.edu", "http://ezproxy.stanford.edu:2197/stable/i403360"]
+      url_fulltext: [
+        'http://ezproxy.stanford.edu/login?url=http://library.stanford.edu',
+        'http://ezproxy.stanford.edu:2197/stable/i403360'
+      ]
     )
-  }
-  let(:bad_url_document) {
+  end
+  let(:bad_url_document) do
     SolrDocument.new(
-      url_fulltext: ["http://www.example.com/lookup?^The+Query+Is+No+Good", " http://www.example.com/{1234-1431324-431313}Img100.jpg ", " at: "]
+      url_fulltext: [
+        'http://www.example.com/lookup?^The+Query+Is+No+Good',
+        ' http://www.example.com/{1234-1431324-431313}Img100.jpg ', ' at: '
+      ]
     )
-  }
-  describe "mixin" do
-    it "should add the #index_links method" do
+  end
+  describe 'mixin' do
+    it 'should add the #index_links method' do
       expect(solr_document).to respond_to(:index_links)
     end
-    it "#index_links should return SearchWorks::Links" do
+    it '#index_links should return SearchWorks::Links' do
       expect(solr_document.index_links).to be_a_kind_of(SearchWorks::Links)
       solr_document.index_links.each do |index_link|
         expect(index_link).to be_a_kind_of SearchWorks::Links::Link
       end
     end
   end
-  describe "SearchWorks::Links" do
-    let(:index_links) {solr_document.index_links}
-    let(:finding_aid_links) {finding_aid_document.index_links}
+  describe 'SearchWorks::Links' do
+    let(:index_links) { solr_document.index_links }
+    let(:finding_aid_links) { finding_aid_document.index_links }
+    let(:managed_purl_links) { managed_purl_document.index_links }
     let(:sfx_links) { sfx_document.index_links }
     let(:ezproxy_links) { ezproxy_document.index_links }
     let(:bad_links) { bad_url_document.index_links }
-    it "should return both fulltext and supplemental links" do
+    it 'should return both fulltext and supplemental links' do
       expect(index_links.all.length).to eq 2
-      expect(index_links.all.first.html).to match /^<a.*>library\.stanford\.edu<\/a>$/
-      expect(index_links.all.last.html).to match  /^<a.*>searchworks\.stanford\.edu<\/a>$/
+      expect(index_links.all.first.html).to match(%r{^<a.*>library\.stanford\.edu<\/a>$})
+      expect(index_links.all.last.html).to match(%r{^<a.*>searchworks\.stanford\.edu<\/a>$})
     end
     it 'should return the plain text and href separately' do
       expect(index_links.all.length).to eq 2
-      expect(index_links.all.first.text).to eq "library.stanford.edu"
-      expect(index_links.all.first.href).to eq "http://library.stanford.edu"
-      expect(index_links.all.last.text).to eq "searchworks.stanford.edu"
-      expect(index_links.all.last.href).to eq "http://searchworks.stanford.edu"
+      expect(index_links.all.first.text).to eq 'library.stanford.edu'
+      expect(index_links.all.first.href).to eq 'http://library.stanford.edu'
+      expect(index_links.all.last.text).to eq 'searchworks.stanford.edu'
+      expect(index_links.all.last.href).to eq 'http://searchworks.stanford.edu'
     end
-    it "should identify urls that are in the url_restricted field as stanford only" do
-      expect(index_links.all.first).to    be_stanford_only
+    it 'should identify urls that are in the url_restricted field as stanford only' do
+      expect(index_links.all.first).to be_stanford_only
       expect(index_links.all.last).to_not be_stanford_only
     end
-    it "should identify urls that are in the url_fulltext field as fulltext" do
-      expect(index_links.all.first).to    be_fulltext
+    it 'should identify urls that are in the url_fulltext field as fulltext' do
+      expect(index_links.all.first).to be_fulltext
       expect(index_links.all.last).to_not be_fulltext
     end
-    it "should identify finding aid links" do
+    it 'should identify finding aid links' do
       expect(finding_aid_links.all.first).to be_finding_aid
       expect(finding_aid_links.finding_aid.length).to eq 1
-      expect(finding_aid_links.finding_aid.first.html).to match /<a href='.*oac\.cdlib\.org\/findaid\/something-else'>Online Archive of California<\/a>/
+      expect(finding_aid_links.finding_aid.first.html).to match(
+        %r{<a href='.*oac\.cdlib\.org\/findaid\/something-else'>Online Archive of California<\/a>}
+      )
     end
-    it "should parse bad links properly" do
+
+    it 'should identnify managed purls' do
+      expect(managed_purl_links.all.length).to eq 1
+      expect(managed_purl_links.managed_purls.length).to eq 1
+      expect(managed_purl_links.all.first).to eq(managed_purl_links.managed_purls.first)
+    end
+
+    it 'should parse bad links properly' do
       expect(bad_links.all.length).to eq 3
-      expect(bad_links.all.first.html).to match /<a href=.*example\.com\/lookup\?\^The\+Query.*>www\.example\.com<\/a>/
-      expect(bad_links.all.last.html).to match /<a.*> at: <\/a>/
+      expect(bad_links.all.first.html).to match(
+        %r{<a href=.*example\.com\/lookup\?\^The\+Query.*>www\.example\.com<\/a>}
+      )
+      expect(bad_links.all.last.html).to match(%r{<a.*> at: <\/a>})
     end
     it 'should return the URL in the url parameter for ezproxy links (but fallback on the URL host)' do
       expect(ezproxy_links.all.length).to eq 2
-      expect(ezproxy_links.all.first.html).to match /<a href=.*>library\.stanford\.edu<\/a>/
-      expect(ezproxy_links.all.last.html).to match /<a href=.*>ezproxy\.stanford\.edu<\/a>/
+      expect(ezproxy_links.all.first.html).to match(%r{<a href=.*>library\.stanford\.edu<\/a>})
+      expect(ezproxy_links.all.last.html).to match(%r{<a href=.*>ezproxy\.stanford\.edu<\/a>})
     end
-    it "should identify sfx URLs and link them appropriately" do
+    it 'should identify sfx URLs and link them appropriately' do
       expect(sfx_links.all.length).to eq 1
       expect(sfx_links.all.first).to be_sfx
       expect(sfx_links.sfx.length).to eq 1
       expect(sfx_links.sfx.first).to be_sfx
-      expect(sfx_links.sfx.first.html).to match /^<a href=.*class='sfx'>Find full text<\/a>$/
+      expect(sfx_links.sfx.first.html).to match(%r{^<a href=.*class='sfx'>Find full text<\/a>$})
     end
   end
 end

--- a/spec/models/concerns/marc_links_spec.rb
+++ b/spec/models/concerns/marc_links_spec.rb
@@ -63,6 +63,23 @@ describe MarcLinks do
       expect(links.all?(&:fulltext?)).to be_true
     end
   end
+
+  describe 'managed_purl?' do
+    let(:document) { SolrDocument.new(marcxml: managed_purl_856, managed_purl_urls: ['http://library.stanford.edu']) }
+    let(:links) { document.marc_links }
+
+    it 'should return the managed purl links' do
+      expect(links.all).to be_present
+      expect(links.managed_purls).to be_present
+      expect(links.all).to eq(links.managed_purls)
+      expect(links.all.all?(&:managed_purl?)).to be true
+    end
+
+    it 'should return the file_id (without "file:")' do
+      expect(links.all.first.file_id).to eq 'abc123'
+    end
+  end
+
   describe "#supplemental" do
     let(:document) {  SolrDocument.new(marcxml: supplemental_856) }
     let(:links) { document.marc_links.all }


### PR DESCRIPTION
@mejackreed I've added some tests here.  I think it's ready to :ship: for deploy this week.

![many-purls](https://cloud.githubusercontent.com/assets/96776/10773342/158f509e-7cb8-11e5-869a-0be7f8dd46ca.gif)
