### PR TITLE
Update PURL embed URL to include metadata panel.

### DIFF
--- a/lib/purl_embed.rb
+++ b/lib/purl_embed.rb
@@ -1,19 +1,22 @@
 require 'oembed'
 class PURLEmbed
+  delegate :html, to: :resource
+
   def initialize(druid)
     @druid = druid
     set_url_scheme
   end
-  def html
-    resource.html
-  end
+
   private
+
   def resource
     @resource ||= provider.get("#{Settings.PURL_EMBED_RESOURCE}#{@druid}")
   end
+
   def provider
-    @provider ||= OEmbed::Provider.new("#{Settings.PURL_EMBED_PROVIDER}.{format}?hide_title=true&hide_metadata=true", :json)
+    @provider ||= OEmbed::Provider.new("#{Settings.PURL_EMBED_PROVIDER}.{format}?hide_title=true", :json)
   end
+
   def set_url_scheme
     provider << Settings.PURL_EMBED_URL_SCHEME
   end

--- a/spec/lib/purl_embed_spec.rb
+++ b/spec/lib/purl_embed_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe PURLEmbed do
   let(:druid) { 'abc123' }
@@ -6,29 +6,36 @@ describe PURLEmbed do
   before do
     expect(provider).to receive(:<<).with(Settings.PURL_EMBED_URL_SCHEME)
   end
+
   describe 'provider' do
     let(:resource) { double('resource') }
     before do
       PURLEmbed.any_instance.stub(:provider).and_return(provider)
     end
+
     describe 'URL Scheme' do
       it 'should set the PURL Embed URL scheme in the settings when instantiated' do
         PURLEmbed.new(druid) # expectation in before block
       end
     end
+
     describe 'resource' do
       before do
-        expect(resource).to receive(:html).and_return("<html/>")
+        expect(resource).to receive(:html).and_return('<html/>')
         expect(provider).to receive(:get).with("#{Settings.PURL_EMBED_RESOURCE}#{druid}").and_return(resource)
       end
+
       it 'should get from the provider given the instantiated druid and return the html from the resource' do
-        expect(PURLEmbed.new(druid).html).to eq "<html/>"
+        expect(PURLEmbed.new(druid).html).to eq '<html/>'
       end
     end
   end
+
   describe 'OEmbed Provider params' do
     it 'should pass the hide_title and hide_metadata params' do
-      expect(OEmbed::Provider).to receive(:new).with("#{Settings.PURL_EMBED_PROVIDER}.{format}?hide_title=true&hide_metadata=true", :json).and_return(provider)
+      expect(OEmbed::Provider).to receive(:new).with(
+        "#{Settings.PURL_EMBED_PROVIDER}.{format}?hide_title=true", :json
+      ).and_return(provider)
       PURLEmbed.new(druid)
     end
   end


### PR DESCRIPTION
This is an immediate solution to the PURL not existing in records.