### PR TITLE
Add database cleaner and implement in spec helper.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ end
 group :development, :test do
   gem 'rspec-rails', '< 2.99'
   gem 'capybara'
+  # We use database cleaner to empty out the database between tests (see spec_helper for usage)
+  gem 'database_cleaner'
   gem 'poltergeist'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       thor
     css_parser (1.3.5)
       addressable
+    database_cleaner (1.5.1)
     deprecation (0.1.0)
       activesupport
     devise (3.2.4)
@@ -358,6 +359,7 @@ DEPENDENCIES
   capybara
   coderay
   coveralls
+  database_cleaner
   deprecation
   devise
   devise-guests
@@ -396,4 +398,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.10.4
+   1.10.6

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,27 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of


### PR DESCRIPTION
This is to try and get rid of the `ActiveRecord::StatementInvalid: SQLite3::BusyException: database is locked` errors we see intermittently on travis.