### PR TITLE
Update government documents access point masthead text.

### DIFF
--- a/app/views/catalog/mastheads/_government_documents.html.erb
+++ b/app/views/catalog/mastheads/_government_documents.html.erb
@@ -3,13 +3,17 @@
     <div id="masthead" class="government-documents-masthead">
       <h1>Government documents</h1>
       <div>
-        <p>Stanford is a depository library for state, federal, UN, and EU government documents.</p>
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Stanford is a depository library for California state, federal, UN, and EU government documents,
+          and has extensive holdings of documents from foreign national and local <abbr title="International Governmental Organizations">IGOs</abbr>
+          and <abbr title="Non-Governmental Organizations">NGOs</abbr>. These include publications, data, statistics, archival records, and more.
         </p>
+
+        <p>
+          The Libraries acquire materials via depository agreements, subscriptions, mailing lists, and by contacting agencies directly.
+          We also subscribe to commercial databases containing government publications, data, and archival records.
+        </p>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #1125 

<img width="1193" alt="govdocs-masthead" src="https://cloud.githubusercontent.com/assets/96776/11156566/86511a64-8a01-11e5-96aa-1e33914e8e4f.png">
