### PR TITLE
Fix bug in mods primary vs. secondary name identification

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,33 +1,32 @@
 # encoding: UTF-8
 module RecordHelper
-
-  def display_content_field field
+  def display_content_field(field)
     if field.respond_to?(:label, :values) &&
-        field.values.any?(&:present?)
+       field.values.any?(&:present?)
       display_content_label(field.label) +
-      display_content_values(field.values)
+        display_content_values(field.values)
     end
   end
 
-  def display_content_label label
+  def display_content_label(label)
     content_tag :dt, label
   end
 
-  def display_content_values values
+  def display_content_values(values)
     values.map do |value|
       content_tag :dd, value
     end.join('').html_safe
   end
 
-  def mods_display_label label
-    content_tag(:dt, label.gsub(":",""))
+  def mods_display_label(label)
+    content_tag(:dt, label.delete(':'))
   end
 
-  def mods_display_content(values, delimiter=nil)
+  def mods_display_content(values, delimiter = nil)
     if delimiter
-      content_tag(:dd, values.map{|value|
+      content_tag(:dd, values.map do|value|
         link_urls_and_email(value) if value.present?
-      }.compact.join(delimiter).html_safe)
+      end.compact.join(delimiter).html_safe)
     else
       Array[values].flatten.map do |value|
         content_tag(:dd, link_urls_and_email(value).html_safe) if value.present?
@@ -35,11 +34,11 @@ module RecordHelper
     end
   end
 
-  def mods_record_field(field, delimiter=nil)
+  def mods_record_field(field, delimiter = nil)
     if field.respond_to?(:label, :values) &&
        field.values.any?(&:present?)
       mods_display_label(field.label) +
-      mods_display_content(field.values, delimiter)
+        mods_display_content(field.values, delimiter)
     end
   end
 
@@ -47,7 +46,7 @@ module RecordHelper
     if field.respond_to?(:label, :values) &&
        field.values.any?(&:present?)
       mods_display_label(field.label) +
-      mods_display_name(field.values)
+        mods_display_name(field.values)
     end
   end
 
@@ -56,7 +55,7 @@ module RecordHelper
       if author_creator_label?(name.label)
         name
       elsif names_include_primary?(name)
-        OpenStruct.new(label: name.label, values: name.values.select{|n| roles_include_primary?(n) })
+        OpenStruct.new(label: name.label, values: name.values.select { |n| roles_include_primary?(n) })
       end
     end.compact
   end
@@ -64,7 +63,7 @@ module RecordHelper
   def mods_secondary_names(names)
     names.map do |name|
       if !author_creator_label?(name.label) && names_include_secondary?(name)
-        OpenStruct.new(label: name.label, values: name.values.reject{|n| roles_include_primary?(n) })
+        OpenStruct.new(label: name.label, values: name.values.reject { |n| roles_include_primary?(n) })
       end
     end.compact
   end
@@ -136,10 +135,10 @@ module RecordHelper
     matches = [val.scan(url), val.scan(email)].flatten.uniq
     unless val =~ /<a/ # we'll assume that linking has alraedy occured and we don't want to double link
       matches.each do |match|
-        if match =~ email
-          val = val.gsub(match, "<a href='mailto:#{match}'>#{match}</a>")
-        else
-          val = val.gsub(match, "<a href='#{match}'>#{match}</a>")
+        val = if match =~ email
+                val.gsub(match, "<a href='mailto:#{match}'>#{match}</a>")
+              else
+                val.gsub(match, "<a href='#{match}'>#{match}</a>")
         end
       end
     end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -53,7 +53,7 @@ module RecordHelper
 
   def mods_primary_names(names)
     names.map do |name|
-      if name.label == "Author/Creator"
+      if author_creator_label?(name.label)
         name
       elsif names_include_primary?(name)
         OpenStruct.new(label: name.label, values: name.values.select{|n| roles_include_primary?(n) })
@@ -63,7 +63,7 @@ module RecordHelper
 
   def mods_secondary_names(names)
     names.map do |name|
-      if name.label != "Author/Creator" && !names_include_primary?(name)
+      if !author_creator_label?(name.label) && names_include_secondary?(name)
         OpenStruct.new(label: name.label, values: name.values.reject{|n| roles_include_primary?(n) })
       end
     end.compact
@@ -145,15 +145,27 @@ module RecordHelper
     end
     val
   end
+
   private
+
+  def author_creator_label?(label)
+    label =~ %r{author/creator:?}i
+  end
+
   def names_include_primary?(names)
     names.values.any? do |name|
       roles_include_primary?(name)
     end
   end
-  def roles_include_primary?(name)
-    if name.roles.present?
-      name.roles.include?('Author') || name.roles.include?('Creator')
+
+  def names_include_secondary?(names)
+    names.values.any? do |name|
+      !roles_include_primary?(name)
     end
+  end
+
+  def roles_include_primary?(name)
+    return unless name.roles.present?
+    name.roles.include?('Author') || name.roles.include?('Creator')
   end
 end

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -95,6 +95,14 @@ describe RecordHelper do
           ]
         )
       }
+      let(:author_creator_bad_label) {
+        OpenStruct.new(
+          label: "Author/creator:",
+          values: [
+            OpenStruct.new(name: "Jane Lathrop")
+          ]
+        )
+      }
       let(:primary_contributor) {
         OpenStruct.new(
           label: "Contributor",
@@ -105,6 +113,9 @@ describe RecordHelper do
       }
       it "should identify primary authors by label" do
         expect(mods_primary_names([author_creator])).to be_present
+      end
+      it "should be lenient to capitalization and punctuation when identifying primary authors by label" do
+        expect(mods_primary_names([author_creator_bad_label])).to be_present
       end
       it "should identify primary authors by role" do
         expect(mods_primary_names([primary_contributor])).to be_present

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -1,10 +1,10 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RecordHelper do
-  let(:empty_field) { OpenStruct.new({label: "test", values: [""] }) }
+  let(:empty_field) { OpenStruct.new(label: 'test', values: ['']) }
   describe 'display_content_field' do
-    let(:values) {['guitar (1)', 'solo cowbell, trombone (2)']}
-    let(:content) { OpenStruct.new(label: 'Instrumentation', values: values)}
+    let(:values) { ['guitar (1)', 'solo cowbell, trombone (2)'] }
+    let(:content) { OpenStruct.new(label: 'Instrumentation', values: values) }
     it 'should return dt with label and dd with values' do
       expect(helper.display_content_field(content)).to have_css('dt', text: 'Instrumentation')
       expect(helper.display_content_field(content)).to have_css('dd', count: 2)
@@ -17,7 +17,7 @@ describe RecordHelper do
   end
 
   describe 'display_content_values' do
-    let(:values) {['guitar (1)', 'solo cowbell, trombone (2)']}
+    let(:values) { ['guitar (1)', 'solo cowbell, trombone (2)'] }
     it 'should return dds of values' do
       expect(helper.display_content_values(values)).to have_css('dd', count: 2)
       expect(helper.display_content_values(values)).to have_css('dd', text: 'guitar (1)')
@@ -25,203 +25,203 @@ describe RecordHelper do
     end
   end
 
-  describe "mods_display_label" do
-    it "should return correct label" do
-      expect(helper.mods_display_label("test:")).to_not have_content ":"
-      expect(helper.mods_display_label("test:")).to have_css("dt", text: "test")
+  describe 'mods_display_label' do
+    it 'should return correct label' do
+      expect(helper.mods_display_label('test:')).to_not have_content ':'
+      expect(helper.mods_display_label('test:')).to have_css('dt', text: 'test')
     end
   end
 
-  describe "mods_display_content" do
-    it "should return correct content" do
-      expect(helper.mods_display_content("hello, there")).to have_css("dd", text: "hello, there")
+  describe 'mods_display_content' do
+    it 'should return correct content' do
+      expect(helper.mods_display_content('hello, there')).to have_css('dd', text: 'hello, there')
     end
-    it "should return multiple dd elements when a multi-element array is passed" do
-      expect(helper.mods_display_content(["hello", "there"])).to have_css("dd", count: 2)
+    it 'should return multiple dd elements when a multi-element array is passed' do
+      expect(helper.mods_display_content(%w(hello there))).to have_css('dd', count: 2)
     end
-    it "should handle nil values correctly" do
-      expect(helper.mods_display_content(['something', nil])).to have_css("dd", count: 1)
+    it 'should handle nil values correctly' do
+      expect(helper.mods_display_content(['something', nil])).to have_css('dd', count: 1)
     end
   end
 
-  describe "mods_record_field" do
-    let(:mods_field)  { OpenStruct.new({label: "test", values: ["hello, there"]}) }
-    let(:url_field)  { OpenStruct.new({label: "test", values: ["http://library.stanford.edu"]}) }
-    let(:multi_values) { double(label: 'test', values: ['123', '321']) }
-    it "should return correct content" do
-      expect(helper.mods_record_field(mods_field)).to have_css("dt", text: "test")
-      expect(helper.mods_record_field(mods_field)).to have_css("dd", text: "hello, there")
+  describe 'mods_record_field' do
+    let(:mods_field) { OpenStruct.new(label: 'test', values: ['hello, there']) }
+    let(:url_field) { OpenStruct.new(label: 'test', values: ['http://library.stanford.edu']) }
+    let(:multi_values) { double(label: 'test', values: %w(123 321)) }
+    it 'should return correct content' do
+      expect(helper.mods_record_field(mods_field)).to have_css('dt', text: 'test')
+      expect(helper.mods_record_field(mods_field)).to have_css('dd', text: 'hello, there')
     end
-    it "should link fields with URLs" do
-      expect(mods_record_field(url_field)).to have_css("a[href='http://library.stanford.edu']", text: "http://library.stanford.edu")
+    it 'should link fields with URLs' do
+      expect(mods_record_field(url_field)).to have_css("a[href='http://library.stanford.edu']", text: 'http://library.stanford.edu')
     end
-    it "should not print empty labels" do
+    it 'should not print empty labels' do
       expect(helper.mods_record_field(empty_field)).to_not be_present
     end
     it 'should join values with a <dd> by default' do
-      expect(helper.mods_record_field(multi_values)).to have_css("dd", count: 2)
+      expect(helper.mods_record_field(multi_values)).to have_css('dd', count: 2)
     end
     it 'should join values with a supplied delimiter' do
-      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css("dd", count: 1)
-      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css("dd", text: '123DELIM321')
+      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css('dd', count: 1)
+      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css('dd', text: '123DELIM321')
     end
   end
-  describe "names" do
-    let(:name_field) {
+  describe 'names' do
+    let(:name_field) do
       OpenStruct.new(
-        label: "Contributor",
+        label: 'Contributor',
         values: [
-          OpenStruct.new(name: "Winefrey, Oprah", roles: ["Host", "Producer"]),
-          OpenStruct.new(name: "Kittenz, Emergency")
+          OpenStruct.new(name: 'Winefrey, Oprah', roles: %w(Host Producer)),
+          OpenStruct.new(name: 'Kittenz, Emergency')
         ]
       )
-    }
-    describe "#mods_name_field" do
-      it "should join the label and values" do
+    end
+    describe '#mods_name_field' do
+      it 'should join the label and values' do
         name = mods_name_field(name_field)
         expect(name).to match /<dt>Contributor<\/dt>/
         expect(name).to match /<dd><a href.*<\/dd>/
       end
-      it "should not print empty labels" do
+      it 'should not print empty labels' do
         expect(mods_name_field(empty_field)).to_not be_present
       end
     end
-    describe "#mods_primary_names" do
-      let(:author_creator) {
+    describe '#mods_primary_names' do
+      let(:author_creator) do
         OpenStruct.new(
-          label: "Author/Creator",
+          label: 'Author/Creator',
           values: [
-            OpenStruct.new(name: "Jane Lathrop")
+            OpenStruct.new(name: 'Jane Lathrop')
           ]
         )
-      }
-      let(:author_creator_bad_label) {
+      end
+      let(:author_creator_bad_label) do
         OpenStruct.new(
-          label: "Author/creator:",
+          label: 'Author/creator:',
           values: [
-            OpenStruct.new(name: "Jane Lathrop")
+            OpenStruct.new(name: 'Jane Lathrop')
           ]
         )
-      }
-      let(:primary_contributor) {
+      end
+      let(:primary_contributor) do
         OpenStruct.new(
-          label: "Contributor",
+          label: 'Contributor',
           values: [
-            OpenStruct.new(name: "Jane Lathrop", roles: ["Author"])
+            OpenStruct.new(name: 'Jane Lathrop', roles: ['Author'])
           ]
         )
-      }
-      it "should identify primary authors by label" do
+      end
+      it 'should identify primary authors by label' do
         expect(mods_primary_names([author_creator])).to be_present
       end
-      it "should be lenient to capitalization and punctuation when identifying primary authors by label" do
+      it 'should be lenient to capitalization and punctuation when identifying primary authors by label' do
         expect(mods_primary_names([author_creator_bad_label])).to be_present
       end
-      it "should identify primary authors by role" do
+      it 'should identify primary authors by role' do
         expect(mods_primary_names([primary_contributor])).to be_present
       end
-      it "should not include secondary authors" do
+      it 'should not include secondary authors' do
         expect(mods_primary_names([name_field])).to_not be_present
       end
     end
-    describe "#mods_secondary_names" do
-      let(:primary_authors) {
+    describe '#mods_secondary_names' do
+      let(:primary_authors) do
         OpenStruct.new(
-          label: "Contributor",
+          label: 'Contributor',
           values: [
-            OpenStruct.new(name: "Primary1", roles: ['Author']),
-            OpenStruct.new(name: "Primary2", roles: ['Creator'])
+            OpenStruct.new(name: 'Primary1', roles: ['Author']),
+            OpenStruct.new(name: 'Primary2', roles: ['Creator'])
           ]
         )
-      }
-      it "should identify secondary authors" do
+      end
+      it 'should identify secondary authors' do
         expect(mods_secondary_names([name_field])).to be_present
         expect(mods_secondary_names([name_field]).length).to eq 1
         expect(mods_secondary_names([name_field]).first.values.length).to eq 2
       end
-      it "should not include primary authors" do
+      it 'should not include primary authors' do
         expect(mods_secondary_names([primary_authors])).to_not be_present
       end
     end
-    describe "#mods_display_name" do
+    describe '#mods_display_name' do
       let(:name) { mods_display_name(name_field.values) }
-      it "should link to the name" do
+      it 'should link to the name' do
         expect(name).to match /<a href=.*%22Winefrey%2C\+Oprah%22.*>Winefrey, Oprah<\/a>/
         expect(name).to match /<a href=.*%22Kittenz%2C\+Emergency%22.*>Kittenz, Emergency<\/a>/
       end
-      it "should link to an author search" do
+      it 'should link to an author search' do
         expect(name).to match /<a href.*search_field=search_author.*>/
       end
       it "should join the person's roles" do
         expect(name).to match /\(Host, Producer\)/
       end
-      it "should not attempt to print empty roles" do
+      it 'should not attempt to print empty roles' do
         expect(name).not_to match /\(\)/
       end
     end
   end
-  describe "subjects" do
-    let(:subjects) { [OpenStruct.new(label: 'Subjects', values: [["Subject1a", "Subject1b"], ["Subject2a", "Subject2b", "Subject2c"]])] }
-    let(:name_subjects) { [OpenStruct.new(label: 'Subjects', values: [OpenStruct.new(name: "Person Name", roles: ["Role1", "Role2"])])] }
-    let(:genres) { [OpenStruct.new(label: 'Genres', values: ["Genre1", "Genre2", "Genre3"])] }
-    describe "#mods_subject_field" do
-      it "should join the subject fields in a dd" do
+  describe 'subjects' do
+    let(:subjects) { [OpenStruct.new(label: 'Subjects', values: [%w(Subject1a Subject1b), %w(Subject2a Subject2b Subject2c)])] }
+    let(:name_subjects) { [OpenStruct.new(label: 'Subjects', values: [OpenStruct.new(name: 'Person Name', roles: %w(Role1 Role2))])] }
+    let(:genres) { [OpenStruct.new(label: 'Genres', values: %w(Genre1 Genre2 Genre3))] }
+    describe '#mods_subject_field' do
+      it 'should join the subject fields in a dd' do
         expect(mods_subject_field(subjects)).to match /<dd><a href=*.*\">Subject1a*.*Subject1b<\/a><\/dd><dd><a/
       end
       it "should join the individual subjects with a '>'" do
         expect(mods_subject_field(subjects)).to match /Subject2b<\/a> &gt; <a href/
       end
-      it "should not print empty labels" do
+      it 'should not print empty labels' do
         expect(mods_subject_field(empty_field)).to_not be_present
       end
     end
-    describe "#mods_genre_field" do
-      it "should join the genre fields with a dd" do
+    describe '#mods_genre_field' do
+      it 'should join the genre fields with a dd' do
         expect(mods_genre_field(genres)).to match /<dd><a href=*.*>Genre1*.*<\/a><\/dd><dd><a*.*Genre2<\/a><\/dd>/
       end
-      it "should not print empty labels" do
+      it 'should not print empty labels' do
         expect(mods_genre_field(empty_field)).to_not be_present
       end
     end
-    describe "#link_mods_subjects" do
+    describe '#link_mods_subjects' do
       let(:linked_subjects) { link_mods_subjects(subjects.first.values.last) }
-      it "should return all subjects" do
+      it 'should return all subjects' do
         expect(linked_subjects.length).to eq 3
       end
-      it "should link to the subject hierarchically" do
+      it 'should link to the subject hierarchically' do
         expect(linked_subjects[0]).to match /^<a href=.*q=%22Subject2a%22.*>Subject2a<\/a>$/
         expect(linked_subjects[1]).to match /^<a href=.*q=%22Subject2a\+Subject2b%22.*>Subject2b<\/a>$/
         expect(linked_subjects[2]).to match /^<a href=.*q=%22Subject2a\+Subject2b\+Subject2c%22.*>Subject2c<\/a>$/
       end
-      it "should link to subject terms search field" do
+      it 'should link to subject terms search field' do
         linked_subjects.each do |subject|
           expect(subject).to match /search_field=subject_terms/
         end
       end
     end
-    describe "#link_mods_genres" do
+    describe '#link_mods_genres' do
       let(:linked_genres) { link_mods_genres(genres.first.values.last) }
-      it "should return correct link" do
+      it 'should return correct link' do
         expect(linked_genres).to match /<a href=*.*Genre3*.*<\/a>/
       end
-      it "should link to subject terms search field" do
+      it 'should link to subject terms search field' do
         expect(linked_genres).to match /search_field=subject_terms/
       end
     end
-    describe "#link_to_mods_subject" do
-      it "should handle subjects that behave like names" do
+    describe '#link_to_mods_subject' do
+      it 'should handle subjects that behave like names' do
         name_subject = link_to_mods_subject(name_subjects.first.values.first, [])
         expect(name_subject).to match /<a href=.*%22Person\+Name%22.*>Person Name<\/a> \(Role1, Role2\)/
       end
     end
   end
-  describe "#link_urls_and_email" do
-    let(:url) { "This is a field that contains an http://library.stanford.edu URL" }
-    let(:email) { "This is a field that contains an email@email.com address" }
-    it "should link URLs" do
+  describe '#link_urls_and_email' do
+    let(:url) { 'This is a field that contains an http://library.stanford.edu URL' }
+    let(:email) { 'This is a field that contains an email@email.com address' }
+    it 'should link URLs' do
       expect(link_urls_and_email(url)).to eq "This is a field that contains an <a href='http://library.stanford.edu'>http://library.stanford.edu</a> URL"
     end
-    it "should link email addresses" do
+    it 'should link email addresses' do
       expect(link_urls_and_email(email)).to eq "This is a field that contains an <a href='mailto:email@email.com'>email@email.com</a> address"
     end
   end


### PR DESCRIPTION
Note that the functional change is in 5c0a804.
21e9881 is just rubocop autofixes.

This addresses an issue reported by a stakeholder but not ticketed.