### PR TITLE
Add javascript to set explicitly set focus on skip-to-nav elements.

### DIFF
--- a/app/assets/javascripts/skip-to-nav.js
+++ b/app/assets/javascripts/skip-to-nav.js
@@ -1,0 +1,36 @@
+// Inspired from https://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/
+
+Blacklight.onLoad(function() {
+  function setFocusBehaviorForExisintURLHashes() {
+    var locationHash = location.hash.substring(1);
+    if (locationHash) {
+      var clickElement = $('[href="#' + locationHash + '"]');
+      var targetElement = $('#' + locationHash);
+      removeTabIndex(targetElement);
+      targetElement.focus();
+      clickElement.on('click', function() {
+        targetElement.focus();
+      });
+    }
+  }
+
+  function removeTabIndex(element) {
+    if (element && isTabableElement(element)) {
+      element.attr('tabIndex', -1);
+    }
+  }
+
+  function isTabableElement(element) {
+    return (!/^(?:a|select|input|button|textarea)$/i.test(element.attr('name')));
+  }
+
+  setFocusBehaviorForExisintURLHashes();
+
+  window.addEventListener('hashchange', function(event) {
+    var element = $('#' + location.hash.substring(1));
+    if (element) {
+      removeTabIndex(element);
+      element.focus();
+    }
+  }, false);
+});

--- a/spec/features/skip_to_nav_spec.rb
+++ b/spec/features/skip_to_nav_spec.rb
@@ -25,7 +25,7 @@ feature "Skip-to Navigation" do
   scenario "should have skip-to navigation links to search field, main container and records in selections page", js: true do
     visit root_path
     fill_in 'q', with: '20'
-    click_button 'search'
+    find('button#search').trigger('click')
     find(:css, '#toggle_bookmark_20').set(true)
     visit selections_path
 
@@ -33,6 +33,16 @@ feature "Skip-to Navigation" do
       expect(page).to have_css("a[href='#search_field']", text: "Skip to search")
       expect(page).to have_css("a[href='#main-container']", text: "Skip to main content")
       expect(page).to have_css("a[href='#documents']", text: "Skip to first result")
+    end
+  end
+
+  scenario 'places focus on traditionally non-focusable elements', js: true do
+    visit root_path
+
+    within '#skip-link' do
+      find('a[href="#main-container"]', text: 'Skip to main content').trigger('click')
+      active_element = page.evaluate_script('$(document.activeElement).attr("id")')
+      expect(active_element).to eq 'main-container'
     end
   end
 


### PR DESCRIPTION
Closes #976 

![skip-to-nav](https://cloud.githubusercontent.com/assets/96776/12570217/8f8b9600-c38a-11e5-86e2-aac8f1e69c06.gif)
