### PR TITLE
Address a few issues around GBS book covers

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -159,8 +159,9 @@
         bibkeys += [isbn, oclc, lccn].join(',') + ',';
       });
 
-      bibkeys = bibkeys.replace(/,,/, '');
-      bibkeys = bibkeys.replace(/,$/, '');
+      bibkeys = bibkeys.replace(/,{2,}/, ','); // Replace 2 or more commas with a single
+      bibkeys = bibkeys.replace(/^,/, ''); // Remove leading comma
+      bibkeys = bibkeys.replace(/,$/, ''); // Remove trailing comma
 
       return bibkeys;
     }

--- a/app/helpers/results_document_helper.rb
+++ b/app/helpers/results_document_helper.rb
@@ -45,34 +45,17 @@ module ResultsDocumentHelper
     date = "[#{date}]" unless date.empty?
   end
 
+  def get_book_ids(document)
+    isbn = add_prefix_to_elements(Array(document['isbn_display']), 'ISBN')
+    oclc = add_prefix_to_elements(Array(document['oclc']), 'OCLC')
+    lccn = add_prefix_to_elements(Array(document['lccn']), 'LCCN')
 
-  def get_book_ids document
-    isbn = add_prefix_to_elements( convert_to_array(document['isbn_display']), 'ISBN' )
-    oclc = add_prefix_to_elements( convert_to_array(document['oclc']), 'OCLC' )
-    lccn = add_prefix_to_elements( convert_to_array(document['lccn']), 'LCCN' )
-
-    return { 'isbn' => isbn, 'oclc' => oclc, 'lccn' => lccn }
+    { 'isbn' => isbn, 'oclc' => oclc, 'lccn' => lccn }
   end
 
-
-  def add_prefix_to_elements arr, prefix
-    new_array = []
-
-    arr.each do |i|
-      new_array.push("#{prefix}#{i}")
+  def add_prefix_to_elements(arr, prefix)
+    arr.map do |i|
+      "#{prefix}#{i.to_s.gsub(/\W/, '')}"
     end
-
-    new_array
   end
-
-
-  def convert_to_array value = []
-    arr = []
-
-    arr = value if value.kind_of?(Array)
-    arr.push(value) if value.kind_of?(String)
-
-    arr
-  end
-
 end

--- a/spec/helpers/results_document_helper_spec.rb
+++ b/spec/helpers/results_document_helper_spec.rb
@@ -10,9 +10,9 @@ describe ResultsDocumentHelper do
     data_01 = {
       :publication_year_isi => 1999,
       :title_display => "Car : a drama of the American workplace",
-      :isbn_display => [ "0393040801", "9780393040807" ],
-      :lccn => "96049953",
-      :oclc => "36024029"
+      :isbn_display => [ "0393040801x", "9780393040807" ],
+      :lccn => "a 96049953",
+      :oclc => 36024029
     }
 
     data_02 = {
@@ -40,8 +40,8 @@ describe ResultsDocumentHelper do
     it "should return book ids with prefixes" do
       book_ids = get_book_ids(@document_01)
 
-      expect(book_ids['isbn']).to eq ["ISBN0393040801", "ISBN9780393040807"]
-      expect(book_ids['lccn']).to eq ["LCCN96049953"]
+      expect(book_ids['isbn']).to eq ["ISBN0393040801x", "ISBN9780393040807"]
+      expect(book_ids['lccn']).to eq ["LCCNa96049953"]
       expect(book_ids['oclc']).to eq ["OCLC36024029"]
     end
 


### PR DESCRIPTION
Closes #720

1. Normalize standard numbers to remove whitespace and useless characters before sending to into the Google API (this was causing some LCCNs to be viewed as ISBNs).
2. Instead of looping through the indeterminately sorted JSON response we are looping through the images, and selecting the piece from the JSON response based on the best key available.