### PR TITLE
Reduce number of records we send in a batch to Google to 15. 25 was…

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -12,7 +12,7 @@
 
   $.fn.plugGoogleBookContent = function() {
     var $parent,
-      booksPerAjaxCall = 25,
+      booksPerAjaxCall = 15,
       booksApiUrl = 'https://books.google.com/books?jscmd=viewapi&bibkeys=',
       selectorCoverImg = 'img.cover-image',
       batches = [];


### PR DESCRIPTION
…causing too-large requests and failing.

Closes #1138 