### PR TITLE
Fix wrapping of library names in access panel

### DIFF
--- a/app/assets/stylesheets/modules/access-panel.css.scss
+++ b/app/assets/stylesheets/modules/access-panel.css.scss
@@ -6,19 +6,23 @@
   font-size: 1.125em;
   font-weight: 400;
 }
+
 .access-panel-heading {
   &.library-location-heading h3 {
-    border-bottom: 1px dotted white;
-    display: inline-block; /* so the border won't extend past the text */
-    margin-right: 10px;
-    &:hover,&:active {
-      border-bottom: 1px solid white;
+    border-bottom: 1px dotted $white;
+    width: 95%; // so the border won't extend past the text
+
+    &:hover,
+    &:active {
+      border-bottom: 1px solid $white;
     }
+
     &.no-link {
-      border-bottom: none;
+      border-bottom: 0;
     }
   }
 }
+
 .access-panel {
   .panel-body {
     h4 {


### PR DESCRIPTION
## Before
<img width="306" alt="before" src="https://cloud.githubusercontent.com/assets/96776/12693054/9e3aea6a-c6b5-11e5-9842-fe68b3fe4b84.png">

## After
<img width="308" alt="after" src="https://cloud.githubusercontent.com/assets/96776/12693055/9e3c7a6a-c6b5-11e5-9740-69436d53ff96.png">
