### PR TITLE
Only show bound-with note in holdings when 590$c is present

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -657,6 +657,7 @@ module MarcHelper
       }
     end
   end
+
   def render_field_from_marc(fields,opts={})
     render "catalog/field_from_marc", :fields => fields, :options => opts
   end

--- a/app/models/concerns/marc_bound_with_note.rb
+++ b/app/models/concerns/marc_bound_with_note.rb
@@ -1,0 +1,13 @@
+###
+#  Simple mdoule to mixin BoundWithNote behavior
+###
+module MarcBoundWithNote
+  def bound_with?
+    bound_with_note.present?
+  end
+
+  def bound_with_note
+    return unless (note_object = BoundWithNote.new(self)).present?
+    @bound_with_note ||= note_object
+  end
+end

--- a/app/models/marc_field.rb
+++ b/app/models/marc_field.rb
@@ -1,0 +1,144 @@
+###
+#  MarcField is the base class to provide common
+#  behavior for other classes to inherit from
+###
+class MarcField
+  attr_reader :document, :tags
+  delegate :present?, to: :relevant_fields
+
+  def initialize(solr_document, tags = [])
+    @document = solr_document
+    @tags = tags
+    run_preprocessors
+  end
+
+  def inspect
+    "#<#{self.class.name}:0x#{object_id} @document=#<SolrDocument:#{document.id}>>"
+  end
+
+  def label
+    I18n.t(
+      "searchworks.marc_fields.#{i18n_key}.label",
+      default: :"searchworks.marc_fields.default.label"
+    )
+  end
+
+  def values
+    relevant_fields.map do |field|
+      field.subfields.map(&:value).join(subfield_delimeter)
+    end
+  end
+
+  def to_partial_path
+    'marc_fields/marc_field'
+  end
+
+  private
+
+  def marc
+    return {} unless document.respond_to?(:to_marc)
+    document.to_marc
+  end
+
+  def relevant_fields
+    return [] unless marc.present?
+    @relevant_fields ||= marc.fields(tags)
+  end
+
+  def remove_hidden_indicators
+    relevant_fields.reject! do |field|
+      (Constants::HIDE_1ST_IND.include?(field.tag) && field.indicator1 == '1') ||
+        (Constants::HIDE_1ST_IND0.include?(field.tag) && field.indicator1 == '0')
+    end
+  end
+
+  def remove_hidden_subfields
+    relevant_fields.each do |field|
+      field.subfields.reject! do |subfield|
+        Constants::EXCLUDE_FIELDS.include?(subfield.code)
+      end
+    end
+  end
+
+  def merge_matched_vernacular_fields
+    relevant_fields.each_with_index do |field, index|
+      next if field.tag =~ /^880/
+      next unless field_has_vernacular_matcher?(field)
+      vernacular_field = matching_vernacular_field(field)
+      relevant_fields.insert(index + 1, vernacular_field) if vernacular_field
+    end
+  end
+
+  def append_unmatched_vernacular_fields
+    marc.fields(['880']).each do |vernacular_field|
+      next unless field_has_vernacular_matcher?(vernacular_field)
+      tag, matcher = vernacular_field_tag(vernacular_field)
+      next unless tags.include?(tag) && matcher == '00'
+      relevant_fields.insert(tag_indexes[tag], vernacular_field)
+    end
+  end
+
+  # Returns a hash where the keys are relevant tags
+  # and the value is the index of the fields within
+  # that particular tag. This is used so we can know
+  # what the index of particular tag's fields are in
+  # the relevant_fields array in order to inject
+  # unmatched vernacular fields in the correct place
+  def tag_indexes
+    fields_index = 0
+    tags.each_with_object({}) do |tag, hash|
+      fields_index += grouped_fields[tag].length if grouped_fields[tag].present?
+      hash[tag] = fields_index
+    end
+  end
+
+  def grouped_fields
+    relevant_fields.group_by do |field|
+      if field.tag == '880'
+        vernacular_field_tag(field)[0]
+      else
+        field.tag
+      end
+    end
+  end
+
+  def run_preprocessors
+    preprocessors.map(&method(:send))
+  end
+
+  def preprocessors
+    [
+      :remove_hidden_indicators,
+      :merge_matched_vernacular_fields,
+      :append_unmatched_vernacular_fields,
+      :remove_hidden_subfields
+    ]
+  end
+
+  def subfield_delimeter
+    ' '
+  end
+
+  def i18n_key
+    self.class.to_s.underscore
+  end
+
+  def matching_vernacular_field(field)
+    tag_880, tag_matcher = vernacular_field_tag(field)
+    marc.fields([tag_880]).find do |vernacular_field|
+      next unless field_has_vernacular_matcher?(vernacular_field)
+      venacular_original_tag, vernacular_matcher = vernacular_field_tag(vernacular_field)
+      field.tag == venacular_original_tag && tag_matcher == vernacular_matcher
+    end
+  end
+
+  def field_has_vernacular_matcher?(field)
+    field['6'] && field['6'].include?('-')
+  end
+
+  def vernacular_field_tag(field)
+    return [] unless field_has_vernacular_matcher?(field)
+    field['6'][/^(\d{3})-(\d{2})/]
+    [Regexp.last_match(1), Regexp.last_match(2)]
+  end
+end

--- a/app/models/marc_fields/bound_with_note.rb
+++ b/app/models/marc_fields/bound_with_note.rb
@@ -1,0 +1,34 @@
+###
+#  MarcBoundWith class to return 590 fields that have a $c
+###
+class BoundWithNote < MarcField
+  def values
+    relevant_fields.map do |field|
+      field.each_with_object({}) do |subfield, hash|
+        hash[:value] ||= ''
+        hash[:value] << "#{subfield.value} "
+        hash[:id] = subfield.value[/^(\d+)/] if subfield.code == 'c'
+      end
+    end.flatten
+  end
+
+  def to_partial_path
+    'marc_fields/bound_with_note'
+  end
+
+  private
+
+  def preprocessors
+    super + [:select_if_c_present]
+  end
+
+  def select_if_c_present
+    relevant_fields.select! do |field|
+      field['c'].present?
+    end
+  end
+
+  def tags
+    %w(590)
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -21,6 +21,7 @@ class SolrDocument
   include OpenSeadragon
   include SolrHoldings
   include MarcInstrumentation
+  include MarcBoundWithNote
   include SolrBookplates
   include Citable
 

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -22,13 +22,9 @@
               <li>
                 <%= render partial: "catalog/stackmap_link", locals: { document: document, location: location, location_name_class: "location-name" } %>
                 <% if location.items.present? %>
-                  <% if location.bound_with? && document.respond_to?(:to_marc) %>
+                  <% if location.bound_with? && document.bound_with? %>
                     <p class="bound-with-note note-highlight">
-                      <% if (bound_with_note = get_data_with_label_from_marc(document.to_marc,"Note", '590')).present? %>
-                        <%= bound_with_note[:fields].map do |note|
-                              note[:field]
-                            end.join.html_safe %>
-                      <% end %>
+                      <%= render document.bound_with_note %>
                     </p>
                   <% else %>
                     <% if location_level_request_link?(library, location) %>

--- a/app/views/marc_fields/_bound_with_note.html.erb
+++ b/app/views/marc_fields/_bound_with_note.html.erb
@@ -1,0 +1,10 @@
+<% bound_with_note.values.each do |value| %>
+  <% if value[:id] %>
+    <%= value[:value].gsub(
+          value[:id],
+          link_to(value[:id], catalog_path(value[:id]))
+        ).html_safe %>
+  <% else %>
+    <%= value[:value] %>
+  <% end %>
+<% end %>

--- a/app/views/marc_fields/_marc_field.html.erb
+++ b/app/views/marc_fields/_marc_field.html.erb
@@ -1,0 +1,6 @@
+<% if marc_field.values.present? %>
+  <dt><%= marc_field.label %></dt>
+  <% marc_field.values.each do |value| %>
+    <dd><%= value %></dd>
+  <% end  %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,10 +28,13 @@ module SearchWorks
     require 'blacklight_advanced_search/parsing_nesting_parser'
     require 'search_works_marc'
 
+    # load all marc fields
+    config.autoload_paths += %W(#{config.root}/app/models/marc_fields)
+
     # load all access panels
     config.autoload_paths += %W(#{config.root}/lib/access_panels)
 
-     # load all SearchWorksMarc
+    # load all SearchWorksMarc
     config.autoload_paths += %W(#{config.root}/lib/search_works_marc)
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -1,4 +1,8 @@
 en:
+  searchworks:
+    marc_fields:
+      default:
+        label: 'Field'
   blacklight:
     course_reserves:
       page_title: "Browse course reserves in %{application_name}"

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -368,6 +368,9 @@ module MarcMetadataFixtures
           <subfield code="a">Copy 1 bound with v. 140</subfield>
           <subfield code="c">55523 (parent record’s ckey)</subfield>
         </datafield>
+        <datafield tag="590" ind1=" " ind2=" ">
+          <subfield code="a">A 590 that does not have $c</subfield>
+        </datafield>
       </record>
     xml
   end

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -141,15 +141,15 @@ module MarcMetadataFixtures
           <subfield code="a">Pīrzādah, Shāh Muḥammad.</subfield>
         </datafield>
         <datafield tag="760" ind1="1" ind2=" ">
-          <subfield code="6">880-00</subfield>
+          <subfield code="6">880-01</subfield>
           <subfield code="a">Item that should not show</subfield>
         </datafield>
         <datafield tag="880" ind1="1" ind2=" ">
-          <subfield code="6">760-00</subfield>
+          <subfield code="6">760-01</subfield>
           <subfield code="a">Vern that should not display</subfield>
         </datafield>
         <datafield tag="880" ind1="0" ind2=" ">
-          <subfield code="6">541-00</subfield>
+          <subfield code="6">541-01</subfield>
           <subfield code="a">541 Vern that should not display</subfield>
         </datafield>
       </record>
@@ -227,6 +227,45 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
+  def complex_vernacular_fixture
+    <<-xml
+      <record>
+        <datafield tag="245" ind1=" " ind2=" ">
+          <subfield code="6">880-01</subfield>
+          <subfield code="a">245 Matched Romanized</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+          <subfield code="a">300 Unmatched Romanized</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+          <subfield code="6">880-02</subfield>
+          <subfield code="a">300 Matched Romanized</subfield>
+        </datafield>
+        <datafield tag="350" ind1=" " ind2=" ">
+          <subfield code="6">880-03</subfield>
+          <subfield code="a">350 Matched Romanized</subfield>
+        </datafield>
+        <datafield tag="880" ind1=" " ind2=" ">
+          <subfield code="6">245-01</subfield>
+          <subfield code="a">245 Matched Vernacular</subfield>
+        </datafield>
+        <datafield tag="880" ind1=" " ind2=" ">
+          <subfield code="6">300-02</subfield>
+          <subfield code="a">300 Matched Vernacular</subfield>
+        </datafield>
+        <datafield tag="880" ind1=" " ind2=" ">
+          <subfield code="6">300-00</subfield>
+          <subfield code="a">300 Unmatched Vernacular</subfield>
+        </datafield>
+        <datafield tag="880" ind1=" " ind2=" ">
+          <subfield code="6">350-03</subfield>
+          <subfield code="a">350 Matched Vernacular</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def bad_vernacular_fixture
     <<-xml
       <record>

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -96,7 +96,7 @@ describe MarcHelper do
       end
       it "should handle linking to parent ckeys correctly" do
         data = get_data_with_label_from_marc(linked_ckey_590_record.to_marc,"Label:", "590")
-        expect(data[:fields].length).to eq 1
+        expect(data[:fields].length).to eq 2
         expect(data[:fields].first[:field]).to match(/Copy.*<a href=\"55523\">55523<\/a> \(.*\)/)
         expect(data[:fields].first[:field]).to_not match(/&gt;|&lt;|&quot;/)
       end

--- a/spec/models/marc_field_spec.rb
+++ b/spec/models/marc_field_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe MarcField do
+  include MarcMetadataFixtures
+  let(:marc) { metadata1 }
+  let(:document) { SolrDocument.new(marcxml: marc) }
+  let(:tags) { [] }
+  subject { described_class.new(document, tags) }
+
+  describe '#label' do
+    it 'falls back to a default label' do
+      expect(subject.label).to eq 'Field'
+    end
+  end
+
+  describe '#values' do
+    let(:tags) { %w(600) }
+
+    it 'returns an array of concatenated subfields' do
+      expect(subject.values.length).to eq 3
+      expect(subject.values).to include 'Arbitrary, Stewart.'
+    end
+
+    context 'matching vernacular values' do
+      let(:tags) { %w(245 505) }
+      let(:marc) { matched_vernacular_fixture }
+
+      it 'are interfiled in the metadata' do
+        expect(subject.values.length).to eq 4
+        expect(subject.values[0]).to eq 'This is not Vernacular'
+        expect(subject.values[1]).to eq 'This is Vernacular'
+        expect(subject.values[2]).to eq '1.This is not Vernacular -- 2.This is also not Vernacular'
+        expect(subject.values[3]).to eq '1.This is Vernacular -- 2.This is also Vernacular'
+      end
+    end
+
+    context 'unmatched vernacular fields' do
+      let(:tags) { %w(245 505) }
+      let(:marc) { unmatched_vernacular_fixture }
+
+      it 'returns fields for the requested tags even when there is no data present' do
+        expect(subject.values.length).to eq 2
+      end
+    end
+
+    context 'complex vernacular matching' do
+      let(:tags) { %w(245 300 350) }
+      let(:marc) { complex_vernacular_fixture }
+
+      it 'interfiles the matched and unmatched vernacular properly' do
+        expect(subject.values.length).to eq 8
+        expect(subject.values[0]).to eq '245 Matched Romanized'
+        expect(subject.values[1]).to eq '245 Matched Vernacular'
+        expect(subject.values[2]).to eq '300 Unmatched Romanized'
+        expect(subject.values[3]).to eq '300 Matched Romanized'
+        expect(subject.values[4]).to eq '300 Matched Vernacular'
+        expect(subject.values[5]).to eq '300 Unmatched Vernacular'
+        expect(subject.values[6]).to eq '350 Matched Romanized'
+        expect(subject.values[7]).to eq '350 Matched Vernacular'
+      end
+    end
+  end
+
+  describe '#to_partial_path' do
+    it 'has a fallback partial path' do
+      expect(subject.to_partial_path).to eq 'marc_fields/marc_field'
+    end
+  end
+
+  describe 'preprocessors' do
+    let(:tags) { %w(600) }
+
+    context 'fields that should not be displayed' do
+      let(:marc) { metadata2 }
+      let(:tags) { %w(541 760) }
+
+      it 'are not present' do
+        expect(subject.values).to be_blank
+      end
+    end
+
+    context 'subfields that should not be displayed' do
+      it 'are not present' do
+        subject.values.each do |value|
+          expect(value).not_to include 'UNAUTHORIZED'
+          expect(value).not_to include 'A170662'
+        end
+      end
+    end
+  end
+end

--- a/spec/models/marc_fields/bound_with_note_spec.rb
+++ b/spec/models/marc_fields/bound_with_note_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe BoundWithNote do
+  include MarcMetadataFixtures
+  let(:marc) { linked_ckey_fixture }
+  let(:document) { SolrDocument.new(marcxml: marc) }
+  subject { described_class.new(document, %w(590)) }
+
+  describe '#values' do
+    it 'returns an array of hashes that include a value and an ID' do
+      expect(subject.values.length).to eq 1
+      expect(subject.values.first[:id]).to eq '55523'
+      expect(subject.values.first[:value]).to include 'Copy 1 bound with v. 140 55523 (parent record’s ckey)'
+    end
+  end
+
+  describe '#to_partial_path' do
+    it 'provides a custom partial path' do
+      expect(subject.to_partial_path).to eq 'marc_fields/bound_with_note'
+    end
+  end
+
+  describe 'preprocessors' do
+    it 'removes any fields that do not include a $c' do
+      expect(subject.values.length).to eq 1
+      expect(subject.values.first[:value]).to_not match(/A 590 that does not have \$c/)
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -97,4 +97,10 @@ describe SolrDocument do
       expect(subject).to be_kind_of Citable
     end
   end
+
+  describe 'MarcBoundWithNote' do
+    it 'is included' do
+      expect(subject).to be_kind_of MarcBoundWithNote
+    end
+  end
 end

--- a/spec/views/marc_fields/_bound_with_note.html.erb_spec.rb
+++ b/spec/views/marc_fields/_bound_with_note.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'marc_fields/_bound_with_note.html.erb' do
+  subject { Capybara.string(rendered) }
+  let(:bound_with_note) do
+    double(
+      'BoundWithNote',
+      values: [
+        { value: '12345 Bound With', id: '12345' }
+      ]
+    )
+  end
+  before do
+    allow(view).to receive_messages(bound_with_note: bound_with_note)
+    render
+  end
+
+  it 'replaces the ID in the value with a link' do
+    expect(subject).to have_link('12345', href: '/view/12345')
+    expect(subject).to have_content('12345 Bound With')
+  end
+end

--- a/spec/views/marc_fields/_marc_field.html.erb_spec.rb
+++ b/spec/views/marc_fields/_marc_field.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'marc_fields/_marc_field.html.erb' do
+  subject { Capybara.string(rendered) }
+  let(:marc_field) do
+    double('MarcField', label: 'Field Label', values: %w(Value1 Value2))
+  end
+  before do
+    allow(view).to receive_messages(marc_field: marc_field)
+    render
+  end
+
+  it 'renders the label in a dt element' do
+    expect(subject).to have_css('dt', text: 'Field Label')
+  end
+
+  it 'renders the values in individual dd elements' do
+    expect(subject).to have_css('dd', count: 2)
+    expect(subject).to have_css('dd', text: 'Value1')
+    expect(subject).to have_css('dd', text: 'Value2')
+  end
+end


### PR DESCRIPTION
Closes #1092 

Note 6d7eadc adds a Base MARC Field parsing class that handles most,if not all of the universal parsing code.

1ac3d40 build on top of that class to allow us to easily pull out the bound-with note.

My hope is that we can use (and enhance) this new MARC field parsing class for the upcoming MARC issues when possible, instead of trying to coerce the existing parsing code.

## 3942974 (has $c)
<img width="391" alt="3942974-holdings" src="https://cloud.githubusercontent.com/assets/96776/12740261/64796630-c926-11e5-8c29-d73dff3ae794.png">

## 351225 Before (no $c)
<img width="385" alt="351225-before" src="https://cloud.githubusercontent.com/assets/96776/12740263/647b015c-c926-11e5-90e1-ddadceb5b852.png">

## 351225 After (no $c)
<img width="371" alt="351225-after" src="https://cloud.githubusercontent.com/assets/96776/12740262/647a7c8c-c926-11e5-805e-0761ad171c64.png">