### PR TITLE
Modifying existing marc_264 helper to add  to the whitelisted subfields.

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -383,7 +383,7 @@ module MarcHelper
     normal_fields = marc.find_all{|f| ("264") === f.tag }
     unmatched_vernacular = get_unmatched_vernacular_fields(marc,"264")
     unless normal_fields.blank? and unmatched_vernacular.blank?
-      allowed_subfields = ["a","b","c"]
+      allowed_subfields = %w(3 a b c)
       new_fields = []
       normal_fields.map{|f| new_fields << f} unless normal_fields.blank?
       unmatched_vernacular.map{|f| new_fields << f} unless unmatched_vernacular.blank?

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -625,6 +625,7 @@ module MarcMetadataFixtures
     <<-xml
       <record>
         <datafield tag="264" ind1=" " ind2="0">
+          <subfield code="3">Subfield3</subfield>
           <subfield code="a">SubfieldA</subfield>
           <subfield code="b">SubfieldB</subfield>
         </datafield>
@@ -782,7 +783,7 @@ module MarcMetadataFixtures
         <datafield tag="050" ind1="0" ind2="0">
           <subfield code="a">PK2788.9.A9</subfield>
           <subfield code="b">F55 1998</subfield>
-        </datafield>      
+        </datafield>
         <datafield tag='856' ind1='0' ind2='2'>
           <subfield code='u'>http://library.stanford.edu</subfield>
           <subfield code='y'>A different finding aid</subfield>

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -419,7 +419,7 @@ describe MarcHelper do
       data = marc_264(single)
       expect(data).to have_key("Production")
       expect(data["Production"].length).to eq 1
-      expect(data["Production"].first).to eq "SubfieldA SubfieldB"
+      expect(data["Production"].first).to eq "Subfield3 SubfieldA SubfieldB"
     end
     it "should handle multiple fields under the same label" do
       data = marc_264(multiple)


### PR DESCRIPTION
Closes #1141 

## 11527026 (before)
<img width="428" alt="11527026-before" src="https://cloud.githubusercontent.com/assets/96776/12768898/2cf9c64e-c9c8-11e5-8d7e-323ee82afeb1.png">

## 11527026 (after)
<img width="486" alt="11527026-after" src="https://cloud.githubusercontent.com/assets/96776/12768899/2d08b762-c9c8-11e5-92dc-8d9c0e0e6826.png">