### PR TITLE
Don't link $h in uniform titles

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -602,10 +602,10 @@ module MarcHelper
     end_link = false
     uniform_title.each do |sub_field|
       unless Constants::EXCLUDE_FIELDS.include?(sub_field.code)
-        if !end_link and sub_field.value.strip =~ /[\.|;]$/
+        if !end_link && sub_field.value.strip =~ /[\.|;]$/ && sub_field.code != 'h'
           link_text << sub_field.value
           end_link = true
-        elsif end_link
+        elsif end_link || sub_field.code == 'h'
           extra_text << sub_field.value
         else
           link_text << sub_field.value

--- a/spec/features/marc_results_metadata_spec.rb
+++ b/spec/features/marc_results_metadata_spec.rb
@@ -7,11 +7,11 @@ describe "MARC Metadata in search results" do
       fill_in 'q', with: '18'
       click_button 'search'
     end
-    it "should link the uniform title" do
+    it "should link the uniform title (but not $h)" do
       within(first('.document')) do
         within('ul.document-metadata') do
-          expect(page).to have_css('li', text: 'Instrumental music. Selections')
-          expect(page).to have_css('li a', text: 'Instrumental music.')
+          expect(page).to have_css('li', text: 'Instrumental music Selections [print/digital].')
+          expect(page).to have_css('li a', text: 'Instrumental music Selections')
         end
       end
     end

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -742,16 +742,30 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
   def uniform_title_fixture
     <<-xml
       <record>
         <datafield tag="240" ind1=" " ind2=" ">
-          <subfield code="a">Instrumental music.</subfield>
-          <subfield code="k">Selections</subfield>
+          <subfield code="a">Instrumental music</subfield>
+          <subfield code="b">Selections</subfield>
+          <subfield code="h">[print/digital].</subfield>
         </datafield>
       </record>
     xml
   end
+
+  def uniform_title_fixture2
+    <<-xml
+      <record>
+        <datafield tag="240" ind1=" " ind2=" ">
+          <subfield code="a">Instrumental music.</subfield>
+          <subfield code="b">Selections</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def marc_characteristics_fixture
     <<-xml
       <record>
@@ -782,7 +796,7 @@ module MarcMetadataFixtures
         <datafield tag="050" ind1="0" ind2="0">
           <subfield code="a">PK2788.9.A9</subfield>
           <subfield code="b">F55 1998</subfield>
-        </datafield>      
+        </datafield>
         <datafield tag='856' ind1='0' ind2='2'>
           <subfield code='u'>http://library.stanford.edu</subfield>
           <subfield code='y'>A different finding aid</subfield>

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -468,6 +468,23 @@ describe MarcHelper do
       expect(results_imprint_string(no_fields)).to be_blank
     end
   end
+
+  describe '#get_uniform_title' do
+    it 'does not link $h' do
+      marc = SolrDocument.new(marcxml: uniform_title_fixture).to_marc
+      title = get_uniform_title(marc, %w(240 130))
+      expect(title[:fields].length).to eq 1
+      expect(title[:fields].first[:field]).to match(%r{<a href=.*>Instrumental music Selections</a> \[print/digital\]})
+    end
+
+    it 'does not link subfields after a certain punctuation' do
+      marc = SolrDocument.new(marcxml: uniform_title_fixture2).to_marc
+      title = get_uniform_title(marc, %w(240 130))
+      expect(title[:fields].length).to eq 1
+      expect(title[:fields].first[:field]).to match(%r{<a href=.*>Instrumental music.</a> Selections})
+    end
+  end
+
   describe "#link_to_series_from_marc" do
     let(:single_series_record) { SolrDocument.new(marcxml: marc_single_series_fixture ) }
     let(:multi_series_record) { SolrDocument.new(marcxml: marc_multi_series_fixture ) }


### PR DESCRIPTION
Closes #1093 

Note that 6591f9e is the commit with the functional change.  ef74181 is a little bit of a refactor.

## 11534515 (before)
<img width="640" alt="11534515-before" src="https://cloud.githubusercontent.com/assets/96776/12772940/7552d4d0-c9eb-11e5-8382-9de4705d455d.png">

## 11534515 (after)
<img width="647" alt="11534515-after" src="https://cloud.githubusercontent.com/assets/96776/12772936/724dc72c-c9eb-11e5-9b07-51c8527afa16.png">
