### PR TITLE
Fix MODS date display in search result title

### DIFF
--- a/app/helpers/results_document_helper.rb
+++ b/app/helpers/results_document_helper.rb
@@ -1,11 +1,15 @@
 module ResultsDocumentHelper
 
-  def get_main_title document
+  def get_main_title(document)
     (document['title_display'] || "").html_safe
   end
 
+  def get_main_title_date(document)
+    # MODS data is indexed with the display date in Solr field pub_year_ss
+    return "[#{document["pub_year_ss"]}]" if document["pub_year_ss"].present?
 
-  def get_main_title_date document
+    # the code below is for MARC data
+    # TODO:  have solrmarc-sw index the date display string into pub_year_ss for MARC data
     publication_year    = document["publication_year_isi"].to_s
     beginning_year      = document["beginning_year_isi"].to_s
     earliest_year       = document["earliest_year_isi"].to_s

--- a/spec/helpers/results_document_helper_spec.rb
+++ b/spec/helpers/results_document_helper_spec.rb
@@ -20,9 +20,15 @@ describe ResultsDocumentHelper do
       :latest_poss_year_isi => 1837
     }
 
+    data_03 = {
+      :pub_year_ss => '199 B.C.',
+      :earliest_poss_year_isi => -199,
+      :latest_poss_year_isi => -250
+    }
     @document_01 = SolrDocument.new(data_01)
     @document_02 = SolrDocument.new(data_02)
-    @document_03 = SolrDocument.new
+    @document_03 = SolrDocument.new(data_03)
+    @document_04 = SolrDocument.new
   end
 
   describe "Render metadata" do
@@ -30,11 +36,12 @@ describe ResultsDocumentHelper do
       expect(get_main_title(@document_01)).to eq "Car : a drama of the American workplace"
     end
     it 'should return a blank title if one does not exist' do
-      expect(get_main_title(@document_03)).to eq ""
+      expect(get_main_title(@document_04)).to eq ""
     end
     it "should return date and date ranges" do
       expect(get_main_title_date(@document_01)).to eq "[1999]"
       expect(get_main_title_date(@document_02)).to eq "[1801 ... 1837]"
+      expect(get_main_title_date(@document_03)).to eq "[199 B.C.]"
     end
 
     it "should return book ids with prefixes" do


### PR DESCRIPTION
Connects to #1140  
which will be finished when:
- solrconfig change deployed to prod (sul-dlss/solrmarc-sw#123)
- MODS data reindexed with sul-dlss/sw-indexer-service#52
- This PR is deployed)

Also:
- connects to sul-dlss/sw-indexer-service#43 (search results piece of index BCE dates for coin collection)
- connects to sul-dlss/solrmarc-sw#111 (BCE dates for coin collection)
- connects to sul-dlss/stanford-mods#56:  display part of adds B.C. to dates before year 0, adds A.D. to dates
- connects to sul-dlss/stanford-mods#53:  display part of nice string for decades (1950s for 195u); nice string for centuries (18th century for 17uu)

## Roman Coins (before)
![1140 before](https://cloud.githubusercontent.com/assets/96775/12864326/1c0cd968-cc3c-11e5-9a87-8e56ddaa9f77.png)

## Roman Coins (after)
![1140 after](https://cloud.githubusercontent.com/assets/96775/12864327/21860270-cc3c-11e5-99e7-ef9ea847a3b3.png)

## Papyri (before)
![papyri dates before](https://cloud.githubusercontent.com/assets/96775/12864328/25accd70-cc3c-11e5-83fa-e96a058e9f27.png)

## Papyri (after)
![papyri dates after](https://cloud.githubusercontent.com/assets/96775/12864330/2fef4380-cc3c-11e5-8bcc-5f4c7c822347.png)
