### PR TITLE
Refactor MARC series linking helper

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -526,62 +526,6 @@ module MarcHelper
     "8" => "Changed back to"}
   end
 
-  def link_to_series_from_marc(marc)
-    fields = []
-    tags = ["440","800","810","811","830"]
-    tags.each do |tag|
-      if marc[tag]
-        marc.find_all{|f| (tag) === f.tag}.each do |field|
-          text = ""
-          link = []
-          extra = []
-          sub_a = []
-          prep_string = []
-          field.each do |subfield|
-            if ("a".."z").to_a.delete_if{|tg| ["x","v"].include?(tg) }.include?(subfield.code)
-              link << subfield.value
-              prep_string << subfield.value
-            elsif !Constants::EXCLUDE_FIELDS.include?(subfield.code)
-              extra << subfield.value
-              prep_string << subfield.value
-            end
-            sub_a << subfield.value if subfield.code == "a"
-          end
-          if sub_a.length > 1
-            text << link.join(" ")
-            text << " #{extra.join(" ")}" unless extra.blank?
-          else
-            text << link_to(link.join(" "), catalog_index_path(q: "\"#{link.join(" ")}\"", search_field: "search_series"))
-            text << " #{extra.join(" ")}" unless extra.blank?
-          end
-          fields << text unless text.blank?
-          if field["6"]
-            field_original = field.tag
-            match_original = field['6'].split("-")[1]
-            marc.find_all{|f| ('880') === f.tag}.each do |vern_field|
-              if !vern_field['6'].nil? and vern_field['6'].include?("-")
-                field_880 = vern_field['6'].split("-")[0]
-                match_880 = vern_field['6'].split("-")[1].gsub("//r","")
-                if match_original == match_880 and field_original == field_880
-                  vern_text = ""
-                  vern_field.each{ |sub_field|
-                    if sub_field.code == "a"
-                      vern_text << link_to(sub_field.value, catalog_index_path(q: "\"#{sub_field.value}\"", search_field: "title"))
-                    elsif ["v","x"].include?(sub_field.code)
-                      vern_text << " #{sub_field.value} "
-                    end
-                  }
-                  fields << vern_text unless vern_text.blank?
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-    return fields unless fields.empty?
-  end
-
   def get_uniform_title(doc, fields, fld = nil)
     return unless fields.any? { |f| doc[f].present? }
     last_present_tag = fields.reverse.find { |f| doc[f].present? }

--- a/app/models/concerns/marc_imprint.rb
+++ b/app/models/concerns/marc_imprint.rb
@@ -2,6 +2,6 @@
 # Simple mixin to add return an Imprint statement from MARC
 module MarcImprint
   def imprint
-    @imprint = Imprint.new(self)
+    @imprint ||= Imprint.new(self)
   end
 end

--- a/app/models/concerns/marc_series.rb
+++ b/app/models/concerns/marc_series.rb
@@ -1,0 +1,11 @@
+##
+# Mixin to add access to linked and unlinked series to the SolrDocument
+module MarcSeries
+  def linked_series
+    @linked_series ||= LinkedSeries.new(self)
+  end
+
+  def unlinked_series
+    @unlinked_series ||= UnlinkedSeries.new(self)
+  end
+end

--- a/app/models/concerns/series_linkable.rb
+++ b/app/models/concerns/series_linkable.rb
@@ -1,0 +1,37 @@
+##
+# Mixin to be used when parsing MARC series fields
+# MARC series fields are 440, 490, 800, 810, 811, and 830
+# A series field is linkable as long as there are not multiple $a.
+# A 490 is only linkable if the first indicator is 0
+module SeriesLinkable
+  private
+
+  def preprocessors
+    super + [:whitelist_subfields]
+  end
+
+  def whitelist_subfields
+    relevant_fields.each do |field|
+      field.subfields = field.subfields.select do |subfield|
+        ('a'..'z').cover?(subfield.code)
+      end
+    end
+  end
+
+  def series_is_linkable?(field)
+    !many_subfield_a?(field) && field_490_has_first_indicator_0?(field)
+  end
+
+  def many_subfield_a?(field)
+    field.subfields.many? { |subfield| subfield.code == 'a' }
+  end
+
+  def field_490_has_first_indicator_0?(field)
+    return true unless field.canonical_tag == '490'
+    field.indicator1 == '0'
+  end
+
+  def tags
+    %w(440 490 800 810 811 830)
+  end
+end

--- a/app/models/marc_fields/imprint.rb
+++ b/app/models/marc_fields/imprint.rb
@@ -7,7 +7,7 @@ class Imprint < MarcField
 
   def reject_non_imprint_subfields
     relevant_fields.each do |field|
-      field.subfields.reject! do |subfield|
+      field.subfields = field.subfields.reject do |subfield|
         !subfields.include?(subfield.code)
       end
     end

--- a/app/models/marc_fields/instrumentation.rb
+++ b/app/models/marc_fields/instrumentation.rb
@@ -18,7 +18,7 @@ class Instrumentation < MarcField
 
   def whitelist_subfields
     relevant_fields.each do |field|
-      field.subfields.reject! do |subfield|
+      field.subfields = field.subfields.reject do |subfield|
         !%w(a b d n p s v).include?(subfield.code)
       end
     end

--- a/app/models/marc_fields/linked_series.rb
+++ b/app/models/marc_fields/linked_series.rb
@@ -1,0 +1,42 @@
+##
+# A class to parse MARC Series fields that are linked to series searches
+# Link text/href is all legal alpha subfields (except $x and $v)
+class LinkedSeries < MarcField
+  include SeriesLinkable
+
+  def values
+    relevant_fields.map do |field|
+      field.subfields.each_with_object({}) do |subfield, hash|
+        key = subfield_is_linkable?(field, subfield) ? :link : :extra_text
+        hash[key] ||= ''
+        hash[key] << "#{subfield.value} "
+      end
+    end
+  end
+
+  def to_partial_path
+    'marc_fields/linked_series'
+  end
+
+  private
+
+  def preprocessors
+    super + [:select_linkable_series_fields]
+  end
+
+  def select_linkable_series_fields
+    relevant_fields.select! { |field| series_is_linkable?(field) }
+  end
+
+  def subfield_is_linkable?(field, subfield)
+    if field.canonical_tag == '490'
+      subfield.code == 'a'
+    else
+      linkable_subfields.include?(subfield.code)
+    end
+  end
+
+  def linkable_subfields
+    ('a'..'z').to_a.reject { |letter| %w(x v).include?(letter) }
+  end
+end

--- a/app/models/marc_fields/marc_field_wrapper.rb
+++ b/app/models/marc_fields/marc_field_wrapper.rb
@@ -1,0 +1,49 @@
+##
+# This class is intended to wrap Marc::DataFields that come from the marc gem.
+# This wrapper class is used to enhance the base Marc::DataField with additional behavior
+# such as parsing and retaining encoded data that might otherwise be removed for display (e.g. $6)
+# as well as add an attribute writer so subfields can be set as well as read.
+class MarcFieldWrapper
+  attr_reader :marc_field
+  attr_writer :subfields
+  delegate :[], :each, :each_with_object, :indicator1, :indicator2, :tag, to: :marc_field
+
+  def initialize(marc_field)
+    @marc_field = marc_field
+    vernacular_matching_field
+  end
+
+  # This method returns the tag for regular fields and
+  # the original field tag for vernacular matched fields
+  def canonical_tag
+    if tag == '880'
+      vernacular_matcher_tag
+    else
+      tag
+    end
+  end
+
+  def vernacular_matcher_tag
+    vernacular_matching_field[/^(\d{3})-(\d{2})/]
+    Regexp.last_match(1)
+  end
+
+  def vernacular_matcher_iterator
+    vernacular_matching_field[/^(\d{3})-(\d{2})/]
+    Regexp.last_match(2)
+  end
+
+  def vernacular_matcher?
+    vernacular_matching_field.include?('-')
+  end
+
+  def subfields
+    @subfields ||= marc_field.subfields
+  end
+
+  private
+
+  def vernacular_matching_field
+    @vernacular_matching_field ||= marc_field['6'] || ''
+  end
+end

--- a/app/models/marc_fields/unlinked_series.rb
+++ b/app/models/marc_fields/unlinked_series.rb
@@ -1,0 +1,16 @@
+##
+# A class to parse MARC Series fields that are not linked to series searches
+# All alpha subfields are included in the text
+class UnlinkedSeries < MarcField
+  include SeriesLinkable
+
+  private
+
+  def preprocessors
+    super + [:reject_linkable_series_fields]
+  end
+
+  def reject_linkable_series_fields
+    relevant_fields.reject! { |field| series_is_linkable?(field) }
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -15,6 +15,7 @@ class SolrDocument
   include ModsData
   include IndexAuthors
   include MarcImprint
+  include MarcSeries
   include Druid
   include StacksImages
   include DigitalImage

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -57,10 +57,7 @@
   <%= render_field_from_marc(date_range) %>
 <% end %>
 
-<% series_490 = get_data_with_label_from_marc(document.to_marc, 'Series', '490') %>
-<% unless series_490.nil? %>
-  <%= render_field_from_marc(series_490) %>
-<% end %>
+<%= render document.unlinked_series if document.unlinked_series.present? %>
 
 <% note_500 = get_data_with_label_from_marc(document.to_marc, "Note", '500') %>
 <% unless note_500.nil? %>

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -68,12 +68,6 @@
       <%= render instrumentation %>
     <% end %>
 
-    <% series = link_to_series_from_marc(document.to_marc) %>
-    <% if series.present? %>
-      <dt>Series</dt>
-      <dd>
-        <%= series.join("<br/>").html_safe %>
-      </dd>
-    <% end %>
+    <%= render document.linked_series if document.linked_series.present? %>
   </dl>
 <% end %>

--- a/app/views/marc_fields/_linked_series.html.erb
+++ b/app/views/marc_fields/_linked_series.html.erb
@@ -1,0 +1,6 @@
+<dt><%= linked_series.label %></dt>
+<% linked_series.values.each do |series| %>
+  <dd>
+    <%= link_to(series[:link].strip, catalog_index_path(q: "\"#{series[:link].strip}\"", search_field: 'search_series')) %> <%= series[:extra_text] %>
+  </dd>
+<% end %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -3,6 +3,10 @@ en:
     marc_fields:
       imprint:
         label: Imprint
+      linked_series:
+        label: Series
+      unlinked_series:
+        label: Series
       default:
         label: 'Field'
   blacklight:

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -789,6 +789,37 @@ module MarcMetadataFixtures
     xml
   end
 
+  def complex_series_fixture
+    <<-xml
+      <record>
+        <datafield tag="440" ind1=" " ind2=" ">
+          <subfield code="a">440 $a</subfield>
+          <subfield code="v">440 $v</subfield>
+          <subfield code="x">440 $x</subfield>
+        </datafield>
+        <datafield tag="490" ind1="0" ind2=" ">
+          <subfield code="a">Linkable 490</subfield>
+          <subfield code="b">490 $b</subfield>
+          <subfield code="4">$4 should not display</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+          <subfield code="a">Non-linkable 490</subfield>
+          <subfield code="4">$4 should not display</subfield>
+        </datafield>
+        <datafield tag="800" ind1=" " ind2=" ">
+          <subfield code="a">Name</subfield>
+          <subfield code="v">SubV800</subfield>
+          <subfield code="z">SubZ</subfield>
+        </datafield>
+        <datafield tag="800" ind1=" " ind2=" ">
+          <subfield code="a">Sub $a 1</subfield>
+          <subfield code="a">Sub $a 2</subfield>
+          <subfield code="b">Non-linkable 800</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def uniform_title_fixture
     <<-xml
       <record>

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -496,19 +496,4 @@ describe MarcHelper do
       expect(title[:fields].first[:field]).to match(%r{<a href=.*>Instrumental music.</a> Selections})
     end
   end
-
-  describe "#link_to_series_from_marc" do
-    let(:single_series_record) { SolrDocument.new(marcxml: marc_single_series_fixture ) }
-    let(:multi_series_record) { SolrDocument.new(marcxml: marc_multi_series_fixture ) }
-    it "should return a valid series" do
-      data = link_to_series_from_marc(single_series_record.to_marc)
-      expect(data.length).to eq(1)
-      expect(data.first).to match(/<a href=.*q=%22Name\+SubZ%22.*search_field=search_series.*>Name SubZ<\/a> SubV/)
-    end
-    it "should not include $x or $v" do
-      data = link_to_series_from_marc(multi_series_record.to_marc)
-      expect(data.length).to eq(2)
-      expect(data.first).to match(/<a href=.*%22440\+%24a%22.*search_field=search_series.*>440 \$a<\/a> 440 \$v 440 \$x/)
-    end
-  end
 end

--- a/spec/models/concerns/marc_series_spec.rb
+++ b/spec/models/concerns/marc_series_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe MarcSeries do
+  subject { SolrDocument.new }
+
+  it 'includes the linked_series method' do
+    expect(subject).to respond_to :linked_series
+  end
+
+  it 'includes the unlinked_series method' do
+    expect(subject).to respond_to :unlinked_series
+  end
+end

--- a/spec/models/marc_field_spec.rb
+++ b/spec/models/marc_field_spec.rb
@@ -70,6 +70,17 @@ describe MarcField do
   describe 'preprocessors' do
     let(:tags) { %w(600) }
 
+    context 'MarcFieldWrapper classes' do
+      let(:marc) { complex_vernacular_fixture }
+      let(:tags) { %w(245 300 350) }
+
+      it 'are used to wrap all relevant fields' do
+        expect(subject.send(:relevant_fields)).to be_all do |field|
+          field.is_a?(MarcFieldWrapper)
+        end
+      end
+    end
+
     context 'fields that should not be displayed' do
       let(:marc) { metadata2 }
       let(:tags) { %w(541 760) }

--- a/spec/models/marc_fields/linked_series_spec.rb
+++ b/spec/models/marc_fields/linked_series_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe LinkedSeries do
+  include MarcMetadataFixtures
+  let(:document) { SolrDocument.new(marcxml: complex_series_fixture) }
+  subject { described_class.new(document) }
+
+  describe '#label' do
+    it 'is Series' do
+      expect(subject.label).to eq 'Series'
+    end
+  end
+
+  describe '#values' do
+    it 'returns values for each linkable field' do
+      expect(subject.values.length).to eq 3
+    end
+
+    context '490 local series field' do
+      it 'returns only the $a in the link' do
+        expect(subject.values[1][:link]).to match(/Linkable 490/)
+      end
+
+      it 'appends the rest of the alpha subfields at the end of the link' do
+        expect(subject.values[1][:extra_text]).to match(/490 \$b/)
+        expect(subject.values[1][:extra_text]).not_to match(/\$4 should not display/)
+      end
+    end
+
+    context 'other series fields' do
+      it 'returns all alpha (except $v and $x) in the link' do
+        expect(subject.values[0][:link]).to match(/440 \$a/)
+        expect(subject.values[2][:link]).to match(/Name SubZ/)
+      end
+
+      it 'appends $v and $x to the end of the link' do
+        expect(subject.values[0][:extra_text]).to match(/440 \$v 440 \$x/)
+        expect(subject.values[2][:extra_text]).to match(/SubV800/)
+      end
+    end
+  end
+
+  describe '#to_partial_path' do
+    it 'is overriden from the base partial path' do
+      expect(subject.to_partial_path).to eq 'marc_fields/linked_series'
+    end
+  end
+end

--- a/spec/models/marc_fields/marc_field_wrapper_spec.rb
+++ b/spec/models/marc_fields/marc_field_wrapper_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+def marc_fields(marc, field)
+  SolrDocument.new(marcxml: marc).to_marc.fields(field)
+end
+
+describe MarcFieldWrapper do
+  include MarcMetadataFixtures
+  subject { described_class.new(field) }
+
+  describe '#canonical_tag' do
+    context 'for regular fields' do
+      let(:field) { marc_fields(complex_vernacular_fixture, '245').first }
+
+      it 'returns the fields original tag' do
+        expect(subject.canonical_tag).to eq '245'
+      end
+    end
+
+    context 'for vernacualr fields' do
+      let(:field) { marc_fields(complex_vernacular_fixture, '880').first }
+
+      it 'returns the tag of the field it matches' do
+        expect(subject.canonical_tag).to eq '245'
+      end
+    end
+  end
+
+  describe '#vernacular_matcher_tag' do
+    let(:field) { marc_fields(complex_vernacular_fixture, '880').first }
+
+    it 'returns the tag of the field it matches' do
+      expect(subject.vernacular_matcher_tag).to eq '245'
+    end
+  end
+
+  describe '#vernacular_matcher_iterator' do
+    let(:field) { marc_fields(complex_vernacular_fixture, '880').first }
+
+    it 'returns the iterator associated with that parituclar vernacular matching field' do
+      expect(subject.vernacular_matcher_iterator).to eq '01'
+    end
+  end
+
+  describe '#vernacular_matcher?' do
+    context 'when $6 is present' do
+      let(:field) { marc_fields(complex_vernacular_fixture, '880').first }
+
+      it 'is true' do
+        expect(subject).to be_vernacular_matcher
+      end
+    end
+
+    context 'when $6 is not present' do
+      let(:field) { marc_fields(metadata1, '100').first }
+
+      it 'is false' do
+        expect(subject).not_to be_vernacular_matcher
+      end
+    end
+  end
+end

--- a/spec/models/marc_fields/unlinked_series_spec.rb
+++ b/spec/models/marc_fields/unlinked_series_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe UnlinkedSeries do
+  include MarcMetadataFixtures
+  let(:document) { SolrDocument.new(marcxml: complex_series_fixture) }
+  subject { described_class.new(document) }
+
+  describe '#label' do
+    it 'is Series' do
+      expect(subject.label).to eq 'Series'
+    end
+  end
+
+  describe '#values' do
+    it 'returns an item in the array for every unlinked series' do
+      expect(subject.values.length).to eq 2
+    end
+
+    it 'returns only alpha subfields' do
+      expect(subject.values.first).to eq 'Non-linkable 490'
+    end
+
+    it 'does not link 490s if the indicator1 is not 0' do
+      expect(subject.values.first).to eq 'Non-linkable 490'
+    end
+
+    it 'does not link series if they have multiple $a' do
+      expect(subject.values.last).to include 'Non-linkable 800'
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -103,4 +103,10 @@ describe SolrDocument do
       expect(subject).to be_kind_of MarcBoundWithNote
     end
   end
+
+  describe 'MarcSeries' do
+    it 'is included' do
+      expect(subject).to be_kind_of MarcSeries
+    end
+  end
 end

--- a/spec/views/marc_fields/_linked_series.html.erb_spec.rb
+++ b/spec/views/marc_fields/_linked_series.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'marc_fields/_linked_series.html.erb' do
+  subject { Capybara.string(rendered) }
+  let(:linked_series) do
+    double(
+      'LinkedSeries',
+      label: 'Series',
+      values: [
+        { link: 'The Link Value ', extra_text: 'Some other text' },
+        { link: 'Another Link Value' }
+      ]
+    )
+  end
+
+  before do
+    allow(view).to receive_messages(linked_series: linked_series)
+    render
+  end
+
+  it 'renders the label in a dt' do
+    expect(subject).to have_css('dt', text: 'Series')
+  end
+
+  it 'renders each series in a dd' do
+    expect(subject).to have_css('dd', count: 2)
+  end
+
+  it 'links the (stripped) link value as a phrase search to the search_series search field' do
+    expect(subject).to have_css('dd a', text: 'The Link Value')
+    expect(subject.first('a')['href']).to match(/q=%22The\+Link\+Value%22/)
+    expect(subject.first('a')['href']).to match(/search_field=search_series/)
+  end
+
+  it 'included the extra text after the link' do
+    expect(subject).to have_css('dd', text: 'The Link Value Some other text')
+  end
+end


### PR DESCRIPTION
This refactor closes #1095 and closes #94 

## #1095 
### 9219601 (Before)
<img width="435" alt="9219601-before" src="https://cloud.githubusercontent.com/assets/96776/12940161/3c75349c-cf7b-11e5-98f8-5927bad53d9f.png">

### 9219601 (After)
<img width="422" alt="9219601-after" src="https://cloud.githubusercontent.com/assets/96776/12940159/3c724d72-cf7b-11e5-838f-f7a8d497702a.png">

## #94 

### 10419326 (Before)
<img width="301" alt="10419326-before" src="https://cloud.githubusercontent.com/assets/96776/12940160/3c73f276-cf7b-11e5-9590-2dd91ebff95b.png">

### 10419326 (After)
<img width="792" alt="10419326-after" src="https://cloud.githubusercontent.com/assets/96776/12940158/3c6d71c6-cf7b-11e5-82ef-2655fc670dfe.png">





