### PR TITLE
Short-circuit location level request link helper to ensure…

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -17,7 +17,8 @@ module CatalogHelper
   end
 
   def location_level_request_link?(library, location)
-    return false if location.reserve_location?
+    return if location.reserve_location?
+    return if Constants::NON_REQUESTABLE_HOME_LOCS.include?(location.try(:code))
     library.location_level_request? || location.location_level_request?
   end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -16,21 +16,26 @@ describe CatalogHelper do
     let(:non_request) { double(reserve_location?: false, location_level_request?: false) }
     let(:reserve_location) { double(reserve_location?: true) }
     let(:location_level_request) { double(reserve_location?: false, location_level_request?: true) }
+    let(:non_requestable_home_loc) { double(reserve_location?: false, code: 'SEE-OTHER') }
 
     it 'is false when the location ends in -RESV' do
-      expect(location_level_request_link?(non_request, reserve_location)).to be false
+      expect(location_level_request_link?(non_request, reserve_location)).to be_falsy
     end
 
     it 'is false when the library and location are not location level requests' do
-      expect(location_level_request_link?(non_request, non_request)).to be false
+      expect(location_level_request_link?(non_request, non_request)).to be_falsy
     end
 
     it 'is true when the library is a location level request library' do
-      expect(location_level_request_link?(location_level_request, non_request)).to be true
+      expect(location_level_request_link?(location_level_request, non_request)).to be_truthy
     end
 
     it 'is true when the location is a location level request location' do
-      expect(location_level_request_link?(non_request, location_level_request)).to be true
+      expect(location_level_request_link?(non_request, location_level_request)).to be_truthy
+    end
+
+    it 'is false for requestable libraries if the home location is a non-requestable home location' do
+      expect(location_level_request_link?(location_level_request, non_requestable_home_loc)).to be_falsy
     end
   end
 


### PR DESCRIPTION
…non-requestable home locations do never get request links.

Fixes #1203 

The following examples all have the `Request` link removed from the `See related record(s) to request item` location.

## 495733
<img width="377" alt="495733" src="https://cloud.githubusercontent.com/assets/96776/13024669/5b874d1e-d1ad-11e5-9168-f4e296f9e43e.png">

## 10164799
<img width="372" alt="10164799" src="https://cloud.githubusercontent.com/assets/96776/13024670/5b87811c-d1ad-11e5-8de5-19c16bd60a9e.png">

## 351225
<img width="379" alt="351225" src="https://cloud.githubusercontent.com/assets/96776/13024671/5b8b8bd6-d1ad-11e5-8d2a-1dd5ab42aad4.png">