### PR TITLE
Fix MARC relator code translations in a few places

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -151,7 +151,7 @@ module MarcHelper
             temp_text << " #{relator_text.join(" ")}" unless relator_text.blank?
             vernacular = get_marc_vernacular(marc,field)
             temp_vern = "\"#{vernacular}\""
-            temp_text << "#{link_to h(vernacular), catalog_index_path(:q => temp_vern, :search_field => 'search_author')}" unless vernacular.nil?
+            temp_text << "<br/>#{link_to h(vernacular), catalog_index_path(:q => temp_vern, :search_field => 'search_author')}" unless vernacular.nil?
             contributors << temp_text
           end
         end
@@ -202,9 +202,8 @@ module MarcHelper
           match_880 = field['6'].split("-")[1].gsub("//r","")
           if match_original == match_880 and field_original == field_880
             field.each do |sub|
-              if !Constants::EXCLUDE_FIELDS.include?(sub.code)
-                return_text << sub.value
-              end
+              next if Constants::EXCLUDE_FIELDS.include?(sub.code) || sub.code == '4'
+              return_text << sub.value
             end
           end
         end
@@ -496,8 +495,11 @@ module MarcHelper
       marc["100"].each do |sub_field|
         unless Constants::EXCLUDE_FIELDS.include?(sub_field.code)
           subs << sub_field.code
-          if subs.include?("e") or subs.include?("4")
+          case
+          when subs.include?('e')
             extra << sub_field.value
+          when subs.include?('4')
+            extra << Constants::RELATOR_TERMS[sub_field.value] || sub_field.value
           else
             link << sub_field.value
           end

--- a/app/models/marc_field.rb
+++ b/app/models/marc_field.rb
@@ -66,6 +66,18 @@ class MarcField
     end
   end
 
+  def translate_relator_terms
+    relevant_fields.map do |field|
+      field.subfields = field.subfields.map do |subfield|
+        if subfield.code == '4'
+          subfield.tap { |s| s.value = Constants::RELATOR_TERMS[s.value] || s.value }
+        else
+          subfield
+        end
+      end
+    end
+  end
+
   def merge_matched_vernacular_fields
     relevant_fields.each_with_index do |field, index|
       next if field.tag =~ /^880/
@@ -113,7 +125,8 @@ class MarcField
       :remove_hidden_indicators,
       :merge_matched_vernacular_fields,
       :append_unmatched_vernacular_fields,
-      :remove_hidden_subfields
+      :remove_hidden_subfields,
+      :translate_relator_terms
     ]
   end
 

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -400,6 +400,22 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
+  def relator_code_fixture
+    <<-xml
+      <record>
+        <datafield tag="100" ind1="1" ind2=" ">
+          <subfield code="a">100 $a</subfield>
+          <subfield code="4">prf</subfield>
+        </datafield>
+        <datafield tag="100" ind1="1" ind2=" ">
+          <subfield code="a">100 $a</subfield>
+          <subfield code="4">bad-relator</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def contributor_fixture
     <<-xml
       <record>

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -866,7 +866,13 @@ module MarcMetadataFixtures
           <subfield code="a">Unpublished listing available in the department.</subfield>
         </datafield>
         <datafield tag="700" ind1="1" ind2=" ">
+          <subfield code="6">880-01</subfield>
           <subfield code="a">Contributor</subfield>
+          <subfield code="4">prf</subfield>
+        </datafield>
+        <datafield tag="880" ind1="1" ind2=" ">
+          <subfield code="6">700-01</subfield>
+          <subfield code="a">Vernacular Contributor</subfield>
           <subfield code="4">prf</subfield>
         </datafield>
       </record>

--- a/spec/models/marc_field_spec.rb
+++ b/spec/models/marc_field_spec.rb
@@ -98,5 +98,24 @@ describe MarcField do
         end
       end
     end
+
+    describe 'relator codes' do
+      let(:marc) { relator_code_fixture }
+      let(:tags) { ['100'] }
+
+      context 'when a valid term' do
+        it 'translates the code to the appropriate term' do
+          expect(subject.values.length).to eq 2
+          expect(subject.values.first).to eq '100 $a Performer'
+        end
+      end
+
+      context 'when an invalid term' do
+        it 'dispalys the raw relator code' do
+          expect(subject.values.length).to eq 2
+          expect(subject.values.last).to eq '100 $a bad-relator'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #1091 

This PR also includes adding this behavior to the base `MarcField` class although it is not actually used (yet) for parsing the fields in question.

## 10104862 (before)
![10104862-before](https://cloud.githubusercontent.com/assets/96776/13128373/271f4ba4-d58a-11e5-9091-8e5d713dc592.png)

## 10104862 (after)
![10104862-after](https://cloud.githubusercontent.com/assets/96776/13128370/271e7d32-d58a-11e5-9dbc-3c847fcf30ea.png)

## 9855858 (before)
![9855858-before](https://cloud.githubusercontent.com/assets/96776/13128369/271ca552-d58a-11e5-9a97-b106c84314a9.png)

## 9855858 (after)
![9855858-after](https://cloud.githubusercontent.com/assets/96776/13128371/271f18fa-d58a-11e5-93bb-3fa375102e9c.png)

## 9580226 (before)
![9580226-before](https://cloud.githubusercontent.com/assets/96776/13128372/271f41ae-d58a-11e5-9e08-e9364413ffeb.png)

## 9580226 (after)
![9580226-after](https://cloud.githubusercontent.com/assets/96776/13128374/2720da3c-d58a-11e5-9fd1-9199f22bdd81.png)

_Note, that @jvine approved the dropping of $4 in the old MARC vernacular helper_