### PR TITLE
Update formats in fixture data to ones that correspond with icons.

### DIFF
--- a/spec/fixtures/solr_documents/31.yml
+++ b/spec/fixtures/solr_documents/31.yml
@@ -6,7 +6,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :modsxml: <%= mods_everything %>
 :pub_date: 2010
 :beginning_year_isi: 2010

--- a/spec/fixtures/solr_documents/32.yml
+++ b/spec/fixtures/solr_documents/32.yml
@@ -4,7 +4,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :collection:
   - 31
 :building_facet:

--- a/spec/fixtures/solr_documents/33.yml
+++ b/spec/fixtures/solr_documents/33.yml
@@ -4,7 +4,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :collection:
   - 31
 :building_facet:

--- a/spec/fixtures/solr_documents/38.yml
+++ b/spec/fixtures/solr_documents/38.yml
@@ -7,7 +7,7 @@
   - file
   - sirsi
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :marcxml: <%= metadata1 %>
 :marcbib_xml: <%= metadata1 %>
 :pub_date: 2010

--- a/spec/fixtures/solr_documents/39.yml
+++ b/spec/fixtures/solr_documents/39.yml
@@ -4,7 +4,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :collection:
   - 38
 :building_facet:

--- a/spec/fixtures/solr_documents/40.yml
+++ b/spec/fixtures/solr_documents/40.yml
@@ -4,7 +4,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :collection:
   - 38
 :building_facet:

--- a/spec/fixtures/solr_documents/41.yml
+++ b/spec/fixtures/solr_documents/41.yml
@@ -4,7 +4,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :collection:
   - 38
 :building_facet:

--- a/spec/fixtures/solr_documents/42.yml
+++ b/spec/fixtures/solr_documents/42.yml
@@ -4,7 +4,7 @@
 :display_type:
   - file
 :format: File
-:format_main_ssim: File
+:format_main_ssim: Dataset
 :collection:
   - 38
 :building_facet:

--- a/spec/fixtures/solr_documents/43.yml
+++ b/spec/fixtures/solr_documents/43.yml
@@ -4,6 +4,6 @@
 :display_type:
   - sirsi
 :format: music
-:format_main_ssim: Music
+:format_main_ssim: Music recording
 :marcxml: <%= marc_382_instrumentation %>
 :pub_date: 2008


### PR DESCRIPTION
**Note: This only applies to the fixtures in dev/test**
## Before
<img width="394" alt="facet-before" src="https://cloud.githubusercontent.com/assets/96776/13135298/41717d80-d5c4-11e5-830b-e860c5a0cfa4.png">

## After
<img width="397" alt="facet-after" src="https://cloud.githubusercontent.com/assets/96776/13135299/417361d6-d5c4-11e5-80e9-e966091a3c87.png">
