### PR TITLE
Couple of CSS changes

### DIFF
--- a/app/assets/stylesheets/modules/bookmarks.scss
+++ b/app/assets/stylesheets/modules/bookmarks.scss
@@ -2,6 +2,16 @@
   font-size: 0.9em;
 }
 
+.index-document-functions {
+  text-align: right;
+}
+
+label {
+  &.toggle_bookmark {
+    min-width: 0;
+  }
+}
+
 #select_all-dropdown {
   min-width: 7.5em;
   text-align: left;

--- a/app/assets/stylesheets/modules/record-view.scss
+++ b/app/assets/stylesheets/modules/record-view.scss
@@ -10,6 +10,10 @@ $show-title-left-margin: 40px;
     font-size: 1.6em;
     margin-left: $show-title-left-margin;
   }
+
+  .cover-image {
+    margin-left: 0;
+  }
 }
 
 .document {

--- a/app/assets/stylesheets/modules/top-navbar.scss
+++ b/app/assets/stylesheets/modules/top-navbar.scss
@@ -10,10 +10,6 @@
   display: table;
   padding: 2px 0;
 
-  a img {
-    float: left;
-  }
-
   .header-links {
     float: right;
     margin-top: 2px;
@@ -33,10 +29,11 @@
   }
 
   .btn-topbar-menu {
+    font-size: 1.7em;
     height: 25px;
-    margin-left: 20px;
-    font-size: 1.3em;
     margin-top: -2px;
+    padding-left: 0;
+    vertical-align: text-bottom;
   }
 
   &.open {

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,13 +1,13 @@
 <div id="topnav-container">
   <header id="topnav" class="header-logo" role="banner">
-    <%= link_to 'http://library.stanford.edu' do %>
-      <%= image_tag "sul-logo.png", class: "hidden-xs", alt: "Stanford University Libraries", height: 25 %>
-      <%= image_tag "sul-logo-small.png", class: "visible-xs", alt: "Stanford University Libraries", height: 25 %>
-    <% end %>
     <button class="btn-topbar-menu dropdown-toggle searchbar-topnav" type="button" data-toggle="dropdown" data-target="#searchbar-topnav-menu">
       <span class="sr-only">Menu</span>
       <span class="fa fa-bars"></span>
     </button>
+    <%= link_to 'http://library.stanford.edu' do %>
+      <%= image_tag "sul-logo.png", class: "hidden-xs", alt: "Stanford University Libraries", height: 25 %>
+      <%= image_tag "sul-logo-small.png", class: "visible-xs", alt: "Stanford University Libraries", height: 25 %>
+    <% end %>
     <%= render :partial => 'shared/search_navbar_top_menu' %>
     <div class="header-links">
       <% if current_user %>


### PR DESCRIPTION
(per @jvine)

## Hamburger Menu Alignment (97b5d17)

### Before
<img width="418" alt="hamburger-before" src="https://cloud.githubusercontent.com/assets/96776/13167026/cf7ee486-d683-11e5-93b5-975b692f0baf.png">

### After
<img width="451" alt="hamburger-after" src="https://cloud.githubusercontent.com/assets/96776/13167025/cf7cf43c-d683-11e5-8a42-da054aa24c6a.png">

---

## Selections Alignment (5e85b18)

### Before
<img width="169" alt="bookmark-before" src="https://cloud.githubusercontent.com/assets/96776/13167029/cf81bb3e-d683-11e5-9433-fb6b1b558f54.png">

### After
<img width="202" alt="bookmark-after" src="https://cloud.githubusercontent.com/assets/96776/13167024/cf7c7e76-d683-11e5-84b2-a19afa7c6917.png">

## Book Cover Alignment (20708e7)

### Before
<img width="525" alt="book-cover-before" src="https://cloud.githubusercontent.com/assets/96776/13167028/cf815b30-d683-11e5-82b8-084a0e612d81.png">

### After
<img width="536" alt="book-cover-after" src="https://cloud.githubusercontent.com/assets/96776/13167027/cf8050c8-d683-11e5-866f-36c2974c457f.png">
