### PR TITLE
Move find-it/stackmap link styling out of nesting so it applies…

### DIFF
--- a/app/assets/stylesheets/modules/access-panel-library-locations.scss
+++ b/app/assets/stylesheets/modules/access-panel-library-locations.scss
@@ -35,10 +35,10 @@
         color: #990000;
       }
     }
-
-    .request-button,
-    .stackmap-find-it {
-      @include location-buttons;
-    }
   }
+}
+
+.request-button,
+.stackmap-find-it {
+  @include location-buttons;
 }

--- a/app/assets/stylesheets/modules/accordion-sections.scss
+++ b/app/assets/stylesheets/modules/accordion-sections.scss
@@ -142,7 +142,6 @@
 
       .stackmap-find-it {
         font-weight: normal;
-        @include location-buttons;
       }
     }
   }

--- a/app/assets/stylesheets/searchworks-mixins.scss
+++ b/app/assets/stylesheets/searchworks-mixins.scss
@@ -111,6 +111,7 @@
 
   &:focus,
   &:hover {
+    color: $white;
     background-color: $sul-location-panel-btn-background-hover;
     border-color: $sul-location-panel-btn-border-hover;
   }


### PR DESCRIPTION
… wherever the buttons exist.

Fixes #1226 

## Before
<img width="548" alt="before" src="https://cloud.githubusercontent.com/assets/96776/13192659/4ca3c2fc-d723-11e5-9219-58605dff29a9.png">

## After
<img width="540" alt="after" src="https://cloud.githubusercontent.com/assets/96776/13192660/4ca66fac-d723-11e5-9962-e2315f0da24c.png">
