### PR TITLE
Update fixture indexer spec be more tolerant of changing catalog dates.

### DIFF
--- a/spec/tasks/fixtures_indexer_spec.rb
+++ b/spec/tasks/fixtures_indexer_spec.rb
@@ -8,7 +8,7 @@ describe FixturesIndexer do
   end
   describe "run" do
     it "should index the fixtures and commit them" do
-      expect(stub_solr).to receive(:add).twice.with(subject.fixtures).and_return(true)
+      expect(stub_solr).to receive(:add).twice.and_return(true)
       expect(stub_solr).to receive(:commit).twice.and_return(true)
       FixturesIndexer.run
       subject.run


### PR DESCRIPTION
We currently get intermittent failures when the document's catalog date is 1 second off (since one fixture sets its cataloged date to the current time).

This changes the test to ensure that documents are being added but does not evaluate that all the fields are identical (which really is not necessary).