### PR TITLE
Use canonical tag for fetching label in linked serials.

### DIFF
--- a/app/models/marc_fields/linked_serials.rb
+++ b/app/models/marc_fields/linked_serials.rb
@@ -70,16 +70,16 @@ class LinkedSerials < MarcField
         'and with'
       end
     else
-      FIELD_LABELS[field.tag][field.indicator2] || FIELD_LABELS[field.tag]['*']
+      FIELD_LABELS[field.canonical_tag][field.indicator2] || FIELD_LABELS[field.canonical_tag]['*']
     end
   end
 
   def merged_with?(field)
-    field.tag == '785' && field.indicator2 == '7'
+    field.canonical_tag == '785' && field.indicator2 == '7'
   end
 
   def merged_with_785s
-    @merged_with_785s ||= marc.fields('785').select(&method(:merged_with?))
+    @merged_with_785s ||= relevant_fields.select(&method(:merged_with?))
   end
 
   def tags

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -646,6 +646,24 @@ module MarcMetadataFixtures
     xml
   end
 
+  def vernacular_serial_fixture
+    <<-xml
+      <record>
+        <datafield tag="780" ind1="0" ind2="0">
+          <subfield code="6">880-01</subfield>
+          <subfield code="i">Other Data:</subfield>
+          <subfield code="t">Serial Title</subfield>
+          <subfield code="s">Serial Uniform Title</subfield>
+        </datafield>
+        <datafield tag="880" ind1="0" ind2="0">
+          <subfield code="6">780-01</subfield>
+          <subfield code="t">Vernacular Serial Title</subfield>
+          <subfield code="s">Vernacular Serial Uniform Title</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def single_marc_264_fixture
     <<-xml
       <record>

--- a/spec/models/marc_fields/linked_serials_spec.rb
+++ b/spec/models/marc_fields/linked_serials_spec.rb
@@ -63,6 +63,16 @@ describe LinkedSerials do
           expect(subject.values.first[:values].first[:search_field]).to eq 'search'
         end
       end
+
+      context 'for vernacular' do
+        let(:marc) { vernacular_serial_fixture }
+
+        it 'labels vernacular fields correctly' do
+          expect(subject.values.length).to eq 2
+          expect(subject.values.last[:label]).to eq 'Continues'
+          expect(subject.values.last[:values].first[:link]).to eq 'Vernacular Serial Uniform Title'
+        end
+      end
     end
 
     context 'for standard number ($x or $z)' do


### PR DESCRIPTION
This fixes a bug that was reported automatically via squash.