### PR TITLE
Do not render the PURL Embed element for MODS documents that do not…

### DIFF
--- a/app/views/catalog/_show_mods.html.erb
+++ b/app/views/catalog/_show_mods.html.erb
@@ -3,9 +3,11 @@
 <% add_purl_embed_header(document) %>
 
 <div class="upper-record-metadata row">
-  <div class="col-md-7">
-    <div class="purl-embed-viewer" data-behavior="purl-embed" data-embed-url="<%= embed_path(document.druid) %>"></div>
-  </div>
+  <% if document.druid %>
+    <div class="col-md-7">
+      <div class="purl-embed-viewer" data-behavior="purl-embed" data-embed-url="<%= embed_path(document.druid) %>"></div>
+    </div>
+  <% end %>
   <div class="col-md-5">
     <%= render 'catalog/record/mods_upper_metadata_section' %>
   </div>

--- a/spec/views/catalog/_show_mods.html.erb_spec.rb
+++ b/spec/views/catalog/_show_mods.html.erb_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'catalog/_show_mods.html.erb' do
+  include ModsFixtures
+  let(:document) { SolrDocument.new(modsxml: mods_001) }
+  before do
+    allow(view).to receive(:add_purl_embed_header).and_return('')
+    assign(:document, document)
+    render
+  end
+
+  context 'when a document has a druid' do
+    let(:document) { SolrDocument.new(druid: 'abc123', modsxml: mods_001) }
+    it 'includes the purl-embed-viewer element' do
+      expect(rendered).to have_css('.purl-embed-viewer')
+    end
+  end
+
+  context 'when a document does not have a druid' do
+    it 'does not include the purl-embed-viewer element' do
+      expect(rendered).not_to have_css('.purl-embed-viewer')
+    end
+  end
+end


### PR DESCRIPTION
…have druids.

_This throws an error currently since `embed_path` requires an id param_