### PR TITLE
Set a 2.5 second timer for receiving height updates from requests.

### DIFF
--- a/app/assets/javascripts/jquery.requestsModal.js
+++ b/app/assets/javascripts/jquery.requestsModal.js
@@ -48,7 +48,9 @@
       }
 
       function addPostMessageListener() {
+        var timer;
         $(window).on('message onmessage', function(e) {
+          if (timer !== null) { window.clearTimeout(timer); }
           // If we ever extend this to include more data than contentHeight
           // and the successPage boolean then we may want to validate that
           // the event.origin is what we expect it to be. As it stands we
@@ -58,15 +60,28 @@
           updateModalHeight(data.contentHeight);
           updateCancelButton(data.successPage);
           closeModal(data.closeModal);
+
+          // In the case the user has navigated away from the request form
+          // (e.g. webauth login) we will stop receiving post messages. In
+          // this case, we can't know if the height that our modal was last
+          // set is tall enough to display all the content. Setting scroll='yes'
+          // unfortunately doesn't work w/o reloading the iframe entirely.
+          timer = window.setTimeout(function(){
+            setIframeToLargeHeight();
+          }, 2500);
         });
       }
 
+      function setIframeToLargeHeight(){
+        iframeForRequest().height('900px');
+      }
+
       function updateModalHeight(contentHeight) {
-        var iframeHeight = modalForRequest().find('iframe').height();
+        var iframeHeight = iframeForRequest().height();
         var setHeight = parseInt(contentHeight, 10);
 
         if (iframeHeight != setHeight && contentHeight > 0) {
-          modalForRequest().find('iframe').height(setHeight + 'px');
+          iframeForRequest().height(setHeight + 'px');
         }
       }
 
@@ -84,6 +99,10 @@
 
       function modalForRequest() {
         return $('[data-request-modal-url="' + requestURL + '"]');
+      }
+
+      function iframeForRequest() {
+        return modalForRequest().find('iframe');
       }
 
       function modalCancelButton() {


### PR DESCRIPTION
If the timer expires we set the height to something that should be large enough to handle the WebAuth form.

Part of sul-dlss/sul-requests#492
## WebAuth Form Before

<img width="627" alt="before" src="https://cloud.githubusercontent.com/assets/96776/19825192/fd5c7544-9d2a-11e6-9c3c-3c013f2b9e68.png">
## WebAuth Form After

_Note: The bottom of the page is cutoff by the browser not the modal and is scrollable_
<img width="466" alt="after" src="https://cloud.githubusercontent.com/assets/96776/19825193/fd6ae7fa-9d2a-11e6-8ea9-1e7bd70c3884.png">
