### PR TITLE
Don't publish to releaseboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem "devise"
 gem "devise-guests"
 gem 'devise-remote-user'
 gem "blacklight-marc", "~> 5.0"
-gem "faraday"
+gem "faraday", "<= 0.9.1"
 gem "config"
 gem "mods_display", "~> 0.4.0"
 gem "blacklight-gallery", github: 'projectblacklight/blacklight-gallery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    airbrussh (1.2.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     ast (2.2.0)
     bcrypt (3.1.10)
@@ -94,16 +96,17 @@ GEM
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     builder (3.2.3)
-    bundler-audit (0.4.0)
+    bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.1)
-    capistrano (3.4.0)
+    capistrano (3.8.0)
+      airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
-    capistrano-bundle_audit (0.0.5)
-      bundler-audit
+      sshkit (>= 1.9.0)
+    capistrano-bundle_audit (0.2.1)
+      bundler-audit (~> 0.5)
       capistrano (~> 3.0)
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
@@ -115,11 +118,10 @@ GEM
     capistrano-rails (1.1.6)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-releaseboard (0.0.1)
-      faraday
     capistrano-rvm (0.1.1)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    capistrano-shared_configs (0.1.2)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -168,11 +170,11 @@ GEM
       devise
       rails (>= 3.2, < 5.0)
     diff-lcs (1.3)
-    dlss-capistrano (3.2.0)
+    dlss-capistrano (3.4.1)
       capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.0.3)
+      capistrano-bundle_audit (>= 0.1.0)
       capistrano-one_time_key
-      capistrano-releaseboard
+      capistrano-shared_configs
     domain_name (0.5.23)
       unf (>= 0.0.5, < 1.0.0)
     ensure_valid_encoding (0.5.3)
@@ -237,7 +239,7 @@ GEM
     mysql2 (0.3.18)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
+    net-ssh (4.1.0)
     netrc (0.10.3)
     newrelic_rpm (3.12.0.288)
     nokogiri (1.7.1)
@@ -355,7 +357,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.9)
-    sshkit (1.8.1)
+    sshkit (1.13.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stanford-mods (1.1.5)
@@ -421,7 +423,7 @@ DEPENDENCIES
   devise-guests
   devise-remote-user
   dlss-capistrano
-  faraday
+  faraday (<= 0.9.1)
   font-awesome-sass
   honeybadger (~> 2.0)
   jbuilder (~> 2.0)
@@ -454,4 +456,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.3
+   1.14.6


### PR DESCRIPTION
  Related to sul-dlss/operations-tasks#112

  I didn't want to lock faraday down so tightly,
  but the difference between v0.9.1 and v0.9.2 is
  41 failing tests