### PR TITLE
[WIP] make HV-ARCHIVE always have a request button

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -843,7 +843,7 @@ module Constants
                       'TECH-SERV',
                       'TEMP-LL']
 
-  REQUEST_LIBS = ['MEDIA-MTXT', 'RUMSEYMAP', 'SAL', 'SAL3', 'SAL-NEWARK', 'SPEC-COLL'].freeze
+  REQUEST_LIBS = ['MEDIA-MTXT', 'RUMSEYMAP', 'SAL', 'SAL3', 'SAL-NEWARK', 'SPEC-COLL', 'HV-ARCHIVE'].freeze
 
   LOCATION_LEVEL_REQUEST_LOCS = ['SSRC-DATA']
 

--- a/spec/features/request_links_spec.rb
+++ b/spec/features/request_links_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+
+describe 'Request Links', type: :feature do
+  it do
+    visit catalog_path(id: 54)
+    expect(page).to have_css '.request-button', text: 'Request on-site access'
+  end
+end

--- a/spec/fixtures/solr_documents/54.yml
+++ b/spec/fixtures/solr_documents/54.yml
@@ -1,0 +1,7 @@
+:id: 54
+:title_display: RFE/RL broadcast records, 1951-2005
+:format_main_ssim: Map
+:marcxml: <%= marc_382_instrumentation %>
+:marcbib_xml: <%= marc_382_instrumentation %>
+:item_display:
+  - "36105217238315 -|- HV-ARCHIVE -|- STACKS -|-  -|-  -|- G70.212 .A426 2011:test -|-  -|-  -|- G70.212 .A426 2011:test -|- "

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -66,6 +66,10 @@ describe Holdings::Library do
       end
     end
 
+    it 'HV-ARCHIVE is a special case that should always be requestable' do
+      expect(Holdings::Library.new('HV-ARCHIVE')).to be_location_level_request
+    end
+
     it 'is false for NONCIRC libraries that only include INPROCESS items' do
       library = Holdings::Library.new(
         'RUMSEYMAP',


### PR DESCRIPTION
This PR fixes #1316. 

cc: @jvine @seestone See screenshot below and please validate if this is the behavior we want for Hoover Archives.  Should we deploy to preview to Morrison to verify this behavior?

Marked **WIP** since we are waiting for further clarification.

## All of Hoover Archives have "Request on-site access" buttons 

![screen shot 2017-06-05 at 3 52 33 pm](https://cloud.githubusercontent.com/assets/1861171/26806679/1050a42a-4a07-11e7-9060-d08b4ad337bf.png)
