### PR TITLE
Move index/marc language processing to a new Language MarcField…

### DIFF
--- a/app/models/concerns/marc_metadata.rb
+++ b/app/models/concerns/marc_metadata.rb
@@ -1,0 +1,7 @@
+##
+# A mixin to include MarcField subclasses into the SolrDocument
+module MarcMetadata
+  def language
+    @language ||= Language.new(self)
+  end
+end

--- a/app/models/marc_fields/language.rb
+++ b/app/models/marc_fields/language.rb
@@ -1,0 +1,42 @@
+##
+# A class to merge content from the indexed
+# language data and the MARC 546 field
+# https://www.loc.gov/marc/bibliographic/bd546.html
+class Language < MarcField
+  def values
+    [[indexed_languages.join(', '), super.join(', ')].reject(&:blank?).join('. ')]
+  end
+
+  def label
+    return I18n.t('searchworks.marc_fields.notation.label') if notation?
+    super
+  end
+
+  private
+
+  def tags
+    %w(546)
+  end
+
+  def notation?
+    document_formats.include?('Music score') && contains_only_subfield_b?
+  end
+
+  def contains_only_subfield_b?
+    relevant_fields.all? do |field|
+      field.subfields.all? do |subfield|
+        subfield.code == 'b'
+      end
+    end
+  end
+
+  def indexed_languages
+    languages = Array.wrap(document['language'])
+    vern_languages = Array.wrap(document['language_vern'])
+    [languages, vern_languages].flatten.compact
+  end
+
+  def document_formats
+    document[document.format_key] || []
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -27,6 +27,7 @@ class SolrDocument
   include SolrBookplates
   include Citable
   include MarcLinkedSerials
+  include MarcMetadata
 
   include Blacklight::Solr::Document
 

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -9,31 +9,7 @@
       <%= render_field_from_marc(uniform_title) %>
     <%- end -%>
 
-    <%- language = get_data_with_label(document, "Language", 'language') -%>
-    <%- marc_language = get_data_with_label_from_marc(document.to_marc, "Language", '546') -%>
-    <%- unless (language.nil? and marc_language.nil?) -%>
-      <dt>Language</dt>
-      <%- languages = [] -%>
-      <%- unless (language.nil? or language[:fields].nil?) -%>
-        <%- languages << language[:fields] unless language[:fields].blank? -%>
-        <%- languages << language[:vernacular] unless language[:vernacular].blank? -%>
-        <%- languages << language[:unmatched_vernacular] unless language[:unmatched_vernacular].nil? -%>
-      <%- end -%>
-      <%- languages.flatten!
-          languages.compact! -%>
-
-      <%- marc_languages = [] -%>
-      <%- unless (marc_language.nil? or marc_language[:fields].nil?) -%>
-        <%- marc_language[:fields].each do |lang| -%>
-          <%- marc_languages << lang[:field] -%>
-          <%- marc_languages << lang[:vernacular] unless lang[:vernacular].nil? -%>
-        <%- end -%>
-        <%- marc_languages << marc_language[:unmatched_vernacular] unless marc_language[:unmatched_vernacular].nil? -%>
-      <%- end -%>
-      <%- marc_languages.flatten!
-          marc_languages.compact! -%>
-      <dd><%= [languages.join(", "), marc_languages.join(", ")].compact.join(". ") %></dd>
-    <%- end -%>
+    <%= render document.language if document.language.present? %>
 
     <% if (characteristics = document.marc_characteristics).present? %>
       <% characteristics.each do |characteristic| %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -3,8 +3,12 @@ en:
     marc_fields:
       imprint:
         label: Imprint
+      language:
+        label: Language
       linked_series:
         label: Series
+      notation:
+        label: Notation
       organization_and_arrangement:
         label: 'Organization & arrangement'
       unlinked_series:

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -417,6 +417,27 @@ module MarcMetadataFixtures
     xml
   end
 
+  def language_fixture
+    <<-xml
+      <record>
+        <datafield tag="546" ind1="1" ind2=" ">
+          <subfield code="a">Language $a</subfield>
+          <subfield code="b">Language $b</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
+  def notation_fixture
+    <<-xml
+      <record>
+        <datafield tag="546" ind1="1" ind2=" ">
+          <subfield code="b">Notation $b</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def contributor_fixture
     <<-xml
       <record>

--- a/spec/models/marc_fields/langauge_spec.rb
+++ b/spec/models/marc_fields/langauge_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Language do
+  include MarcMetadataFixtures
+
+  let(:document) { SolrDocument.new(marcxml: marc, format_main_ssim: formats) }
+  subject(:language) { described_class.new(document) }
+
+  describe 'label' do
+    context 'when the format includes "Music score"' do
+      let(:formats) { ['Music score'] }
+
+      context 'when there are subfields other that $b' do
+        let(:marc) { language_fixture }
+
+        it 'is "Language"' do
+          expect(language.label).to eq 'Language'
+        end
+      end
+
+      context 'when there are only subfield $b present' do
+        let(:marc) { notation_fixture }
+
+        it 'is "Notation"' do
+          expect(language.label).to eq 'Notation'
+        end
+      end
+    end
+
+    context 'when the format does not include "Music score"' do
+      let(:formats) { ['Not a Music score'] }
+      let(:marc) { notation_fixture }
+
+      it 'is "Language" regardless of subfield' do
+        expect(language.label).to eq 'Language'
+      end
+    end
+  end
+
+  describe 'values' do
+    let(:document) do
+      SolrDocument.new(marcxml: marc, language: ['English'], language_vern: ['English in another language'])
+    end
+    let(:marc) { language_fixture }
+
+    it 'appends language index fields with marc fields' do
+      expect(language.values.length).to eq 1
+      expect(language.values.first).to eq('English, English in another language. Language $a Language $b')
+    end
+  end
+end


### PR DESCRIPTION
…subclass.

Closes #1319 

For the screenshots below, look at the Language/Notation field for the changes.

## 11412204 (before)
<img width="843" alt="11412204-before" src="https://user-images.githubusercontent.com/96776/26853348-70b4e532-4ac6-11e7-8b4b-d8b770d03eba.png">

## 11412204 (after)
<img width="858" alt="11412204-after" src="https://user-images.githubusercontent.com/96776/26853349-70b4a068-4ac6-11e7-96ad-711e1c7e96ca.png">

## 10093706 (before)
<img width="1076" alt="10093706-before" src="https://user-images.githubusercontent.com/96776/26853350-70b4f3c4-4ac6-11e7-868b-0d770ad68911.png">

## 10093706 (after)
<img width="1111" alt="10093706-after" src="https://user-images.githubusercontent.com/96776/26853347-70b122da-4ac6-11e7-823d-f5cc3b7e2bb8.png">
