### PR TITLE
add new LinkedAuthor class for rendering linked "authors" and 711 $j suppression

### DIFF
--- a/app/models/concerns/marc_metadata.rb
+++ b/app/models/concerns/marc_metadata.rb
@@ -4,4 +4,9 @@ module MarcMetadata
   def language
     @language ||= Language.new(self)
   end
+
+  def linked_author(target)
+    @linked_author = {} if @linked_author.blank?
+    @linked_author[target] ||= LinkedAuthor.new(self, target)
+  end
 end

--- a/app/models/marc_fields/linked_author.rb
+++ b/app/models/marc_fields/linked_author.rb
@@ -1,0 +1,71 @@
+##
+# A class to parse MARC "author" fields that have hyperlinks for searching/display
+# (i.e., href vs link/anchor) and post text for display (context).
+#
+# Initially, ported over from solrmarc-sw `author_corp_display`, `author_meeting_display`, and
+# based in part on SearchWorks' `link_to_author_from_marc`
+#
+class LinkedAuthor < MarcField
+  TAGS = {
+    creator: %w[100],
+    corporate_author: %w[110],
+    meeting: %w[111]
+  }.freeze
+
+  attr_reader :target
+
+  def initialize(document, target)
+    @target = target.to_sym
+    super(document, TAGS[@target] || [])
+  end
+
+  def to_partial_path
+    'marc_fields/linked_author'
+  end
+
+  def i18n_key
+    super + '.' + target.to_s
+  end
+
+  def values
+    relevant_fields.map do |field|
+      field.subfields.each_with_object({}) do |subfield, hash|
+        output_for(field, subfield).each do |key|
+          hash[key] ||= ''
+          hash[key] << "#{subfield.value} "
+        end
+      end
+    end
+  end
+
+  private
+
+  # @return [Array<Symbol>] `:link`, `:search`, or `:post_text`
+  def output_for(field, subfield)
+    keys = []
+    keys << :link if linkable?(field, subfield)
+    keys << :search if searchable?(field, subfield)
+    keys << :post_text if post_text?(field, subfield)
+    keys
+  end
+
+  def linkable?(_field, subfield)
+    case target
+    when :creator, :corporate_author
+      !%w[e i 4].include?(subfield.code) # exclude 100/110 $e $i $4
+    when :meeting
+      !%w[j 4].include?(subfield.code) # exclude 111 $j $4
+    end
+  end
+
+  def searchable?(field, subfield)
+    return false unless linkable?(field, subfield) # must first be linkable
+    !%w[t].include?(subfield.code) # exclude $t
+  end
+
+  def post_text?(field, subfield)
+    return true if %w[e 4].include?(subfield.code) # always $e $4
+    return false if linkable?(field, subfield) || searchable?(field, subfield) # cannot be linkable or searchable
+    !%w[i].include?(subfield.code) # exclude $i
+  end
+end

--- a/app/views/catalog/_marc_search_results_document_fields.html.erb
+++ b/app/views/catalog/_marc_search_results_document_fields.html.erb
@@ -17,19 +17,8 @@
       <% end if uniform_title[:unmatched_vernacular].present? %>
     <% end %>
 
-    <% author_creator = link_to_author_from_marc(document.to_marc) %>
-    <% unless author_creator.blank? %>
-      <li><%= render_field_list_from_marc(author_creator) %></li>
-    <% end %>
-
-    <% author_corp = link_to_data_with_label(document, "Corporate Author", 'author_corp_display', {controller: 'catalog', action: 'index', search_field: 'search_author'}) %>
-    <% unless author_corp.blank? %>
-      <%= render "field_list_from_index", :fields => author_corp %>
-    <% end %>
-
-    <% author_meeting = link_to_data_with_label(document, "Meeting", 'author_meeting_display', {controller: 'catalog', action: 'index', search_field: 'search_author'}) %>
-    <% unless author_meeting.nil? %>
-      <%= render "field_list_from_index", :fields => author_meeting %>
+    <% %i[creator corporate_author meeting].each do |target| %>
+      <%= render 'marc_fields/linked_author_index', linked_author: document.linked_author(target) %>
     <% end %>
 
     <% if (imprint = results_imprint_string(document)).present? %>

--- a/app/views/catalog/record/_marc_contributors.html.erb
+++ b/app/views/catalog/record/_marc_contributors.html.erb
@@ -1,11 +1,8 @@
 <% document ||= @document %>
-<% author_creator = link_to_author_from_marc(document.to_marc) %>
-<%= render_field_from_marc(author_creator) if author_creator.present? %>
 
-<% author_corp = link_to_data_with_label(document, 'Corporate Author', 'author_corp_display', { action: 'index', search_field: 'search_author' }) %>
-<%= render('catalog/field_from_index', fields: author_corp) if author_corp.present? %>
+<% %i[creator corporate_author meeting].each do |target| %>
+  <%= render document.linked_author(target) %>
+<% end %>
 
-<% author_meeting = link_to_data_with_label(document, 'Meeting', 'author_meeting_display', { action: 'index', search_field: 'search_author' }) %>
-<%= render('catalog/field_from_index', fields: author_meeting) if author_meeting.present? %>
-
+<%# TODO: this code has not been ported over yet %>
 <%= link_to_contributor_from_marc(document.to_marc) %>

--- a/app/views/marc_fields/_linked_author.html.erb
+++ b/app/views/marc_fields/_linked_author.html.erb
@@ -1,0 +1,9 @@
+<% if linked_author.present? %>
+  <dt><%= linked_author.label %></dt>
+  <% linked_author.values.each do |author| %>
+    <dd>
+      <%= link_to(author[:link].strip, catalog_index_path(q: '"' + author[:search] + '"', search_field: 'search_author')) %>
+      <%= author[:post_text] if author[:post_text] %>
+    </dd>
+  <% end %>
+<% end %>

--- a/app/views/marc_fields/_linked_author_index.html.erb
+++ b/app/views/marc_fields/_linked_author_index.html.erb
@@ -1,0 +1,8 @@
+<% if linked_author.present? %>
+  <% linked_author.values.each do |author| %>
+    <li>
+      <%= link_to(author[:link].strip, catalog_index_path(q: '"' + author[:search] + '"', search_field: 'search_author')) %>
+      <%= author[:post_text] if author[:post_text] %>
+    </li>
+  <% end %>
+<% end %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -5,6 +5,13 @@ en:
         label: Imprint
       language:
         label: Language
+      linked_author:
+        corporate_author:
+          label: Corporate Author
+        creator:
+          label: Author/Creator
+        meeting:
+          label: Meeting
       linked_series:
         label: Series
       notation:

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -5,7 +5,16 @@ module MarcMetadataFixtures
       <record>
         <datafield tag="100" ind1="1" ind2=" ">
           <subfield code="a">Arbitrary, Stewart.</subfield>
+          <subfield code="e">fantastic.</subfield>
           <subfield code="=">^A170662</subfield>
+        </datafield>
+        <datafield tag="110" ind1="1" ind2=" ">
+          <subfield code="a">Arbitrary, Corporate.</subfield>
+          <subfield code="e">fantastic.</subfield>
+        </datafield>
+        <datafield tag="111" ind1="1" ind2=" ">
+          <subfield code="a">Arbitrary Meeting.</subfield>
+          <subfield code="j">fantastic.</subfield>
         </datafield>
         <datafield tag="245" ind1="1" ind2="0">
           <subfield code="a">Some intersting papers,</subfield>
@@ -492,6 +501,7 @@ module MarcMetadataFixtures
         </datafield>
         <datafield tag="711" ind1=" " ind2="2">
           <subfield code="a">711 with t ind2</subfield>
+          <subfield code="j">middle</subfield>
           <subfield code="t">Title!</subfield>
           <subfield code="u">subu.</subfield>
           <subfield code="n">sub n after .</subfield>
@@ -499,6 +509,20 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
+  def contributed_works_without_title_fixture
+    <<-xml
+      <record>
+        <datafield tag="711" ind1=" " ind2=" ">
+          <subfield code="a">711 with t ind2</subfield>
+          <subfield code="u">subu.</subfield>
+          <subfield code="n">sub n after .</subfield>
+          <subfield code="j">last.</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def multi_role_contributor_fixture
     <<-xml
       <record>
@@ -1029,6 +1053,55 @@ module MarcMetadataFixtures
           <subfield code="a">351 $a</subfield>
           <subfield code="b">351 $b</subfield>
           <subfield code="z">351 $z</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
+  def linked_author_creator_fixture
+    <<-xml
+      <record>
+        <datafield tag="100" ind1="1" ind2=" "><!-- adapated from 9952016 -->
+          <subfield code="a">Dodaro, Gene L.</subfield>
+          <subfield code="e">author.</subfield>
+          <subfield code="4">aut</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
+  def linked_author_corporate_author_fixture
+    <<-xml
+      <record>
+        <datafield tag="110" ind1="1" ind2=" "><!-- adapated from 10159310 -->
+          <subfield code="a">Ecuador.</subfield>
+          <subfield code="b">Procuraduría General del Estado,</subfield>
+          <subfield code="t">A Title</subfield>
+          <subfield code="e">author,</subfield>
+          <subfield code="e">issuing body.</subfield>
+          <subfield code="4">acp</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
+  def linked_author_meeting_fixture
+    <<-xml
+      <record>
+        <datafield tag="111" ind1="2" ind2=" "><!-- adapated from 10165011 -->
+          <subfield code="6">880-01</subfield>
+          <subfield code="a">Technical Workshop on Organic Agriculture</subfield>
+          <subfield code="n">(1st :</subfield>
+          <subfield code="d">2010 :</subfield>
+          <subfield code="c">Ogbomoso, Nigeria)</subfield>
+          <subfield code="t">A title</subfield>
+          <subfield code="j">creator.</subfield>
+          <subfield code="4">oth</subfield>
+        </datafield>
+        <datafield tag="880" ind1="0" ind2="0">
+          <subfield code="6">111-01</subfield>
+          <subfield code="t">Vernacular Title</subfield>
+          <subfield code="s">Vernacular Uniform Title</subfield>
         </datafield>
       </record>
     xml

--- a/spec/lib/search_works_marc_spec.rb
+++ b/spec/lib/search_works_marc_spec.rb
@@ -25,9 +25,9 @@ describe SearchWorksMarc do
     it 'should return an array' do
       expect(sw_marc.parse_marc_record.class).to eq Array
     end
-    it 'should have 14 values grouped by tag' do
-      expect(sw_marc.parse_marc_record.count).to eq 14
-      expect(sw_marc.parse_marc_record.map{ |f| f.label }.uniq.length).to eq 14
+    it 'should have 16 values grouped by tag' do
+      expect(sw_marc.parse_marc_record.count).to eq 16
+      expect(sw_marc.parse_marc_record.map{ |f| f.label }.uniq.length).to eq 16
     end
     it 'grouped values should be an array' do
       sw_marc.parse_marc_record.each do |group|
@@ -44,7 +44,7 @@ describe SearchWorksMarc do
     end
     describe 'subfields' do
       it 'should equal the value' do
-        expect(sw_marc.parse_marc_record[1].values.first).to match /Some intersting papers,/
+        expect(sw_marc.parse_marc_record[3].values.first).to match /Some intersting papers,/
       end
     end
   end

--- a/spec/models/marc_fields/linked_author_spec.rb
+++ b/spec/models/marc_fields/linked_author_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe LinkedAuthor, type: :model do # rubocop: disable Metrics/BlockLength
+  include MarcMetadataFixtures
+
+  subject(:instance) { described_class.new(document, target) }
+  let(:document) { SolrDocument.new(marcxml: send("linked_author_#{target}_fixture".to_sym)) }
+  let(:target) { :corporate_author }
+
+  context 'base' do
+    it '#to_partial_path is overriden from the base partial path' do
+      expect(instance.to_partial_path).to eq 'marc_fields/linked_author'
+    end
+  end
+
+  context 'corporate_author' do
+    it '#label' do
+      expect(instance.label).to eq 'Corporate Author'
+    end
+    it '#values' do
+      expect(instance.values).to include(
+        link: 'Ecuador. Procuraduría General del Estado, A Title ',
+        search: 'Ecuador. Procuraduría General del Estado, ',
+        post_text: 'author, issuing body. Art copyist '
+      )
+    end
+  end
+
+  context 'meeting' do
+    let(:target) { :meeting }
+
+    it '#label' do
+      expect(instance.label).to eq 'Meeting'
+    end
+    it '#values' do
+      expect(instance.values).to include(
+        link: 'Technical Workshop on Organic Agriculture (1st : 2010 : Ogbomoso, Nigeria) A title ',
+        search: 'Technical Workshop on Organic Agriculture (1st : 2010 : Ogbomoso, Nigeria) ',
+        post_text: 'creator. Other '
+      )
+    end
+  end
+
+  context 'creator' do
+    let(:target) { :creator }
+
+    it '#label' do
+      expect(instance.label).to eq 'Author/Creator'
+    end
+
+    it '#values' do
+      expect(instance.values).to include(
+        link: 'Dodaro, Gene L. ',
+        search: 'Dodaro, Gene L. ',
+        post_text: 'author. Author '
+      )
+    end
+  end
+end

--- a/spec/views/catalog/_index_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_index_marc.html.erb_spec.rb
@@ -18,6 +18,18 @@ describe "catalog/_index_marc.html.erb" do
     end
     it "should link to the author" do
       expect(rendered).to have_css('li a', text: 'Arbitrary, Stewart.')
+      expect(rendered).not_to have_css('li a', text: /fantastic/)
+      expect(rendered).to have_css('li', text: /fantastic\./)
+    end
+    it "should link to the corporate author" do
+      expect(rendered).to have_css('li a', text: 'Arbitrary, Corporate.')
+      expect(rendered).not_to have_css('li a', text: /fantastic/)
+      expect(rendered).to have_css('li', text: /fantastic\./)
+    end
+    it "should link to the meeting" do
+      expect(rendered).to have_css('li a', text: 'Arbitrary Meeting.')
+      expect(rendered).not_to have_css('li a', text: /fantastic/)
+      expect(rendered).to have_css('li', text: /fantastic\./)
     end
     it "should render the imprint" do
       expect(rendered).to have_css('li', text: 'Imprint Statement')

--- a/spec/views/marc_fields/_linked_author.html.erb_spec.rb
+++ b/spec/views/marc_fields/_linked_author.html.erb_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe 'marc_fields/_linked_author.html.erb', type: :view do
+  include MarcMetadataFixtures
+  let(:document) { SolrDocument.new(marcxml: send("linked_author_#{target}_fixture".to_sym)) }
+
+  before do
+    allow(view).to receive_messages(linked_author: LinkedAuthor.new(document, target))
+    render
+  end
+
+  context 'Creator' do
+    let(:target) { :creator }
+
+    it 'renders the label in a dt' do
+      expect(rendered).to have_css('dt', text: 'Author/Creator')
+    end
+
+    it 'renders author in a dd' do
+      expect(rendered).to have_css('dd', count: 1)
+    end
+
+    it 'renders link, search, and post_text correctly' do
+      expect(rendered).to have_css('dd a', text: 'Dodaro, Gene L.')
+      expect(rendered).to have_css('dd a @href', text: /q=%22Dodaro%2C\+Gene\+L\.\+%22/)
+      expect(rendered).to have_css('dd a @href', text: /search_field=search_author/)
+      expect(rendered).not_to have_css('dd a @href', text: /author\./)
+      expect(rendered).not_to have_css('dd a @href', text: /\sAuthor/)
+    end
+
+    it 'included the extra text after the link' do
+      expect(rendered).to have_css('dd', text: 'author. Author')
+    end
+  end
+
+  context 'Corporate Author' do
+    let(:target) { :corporate_author }
+
+    it 'renders the label in a dt' do
+      expect(rendered).to have_css('dt', text: 'Corporate Author')
+    end
+
+    it 'renders author in a dd' do
+      expect(rendered).to have_css('dd', count: 1)
+    end
+
+    it 'renders link, search, and post_text correctly' do
+      expect(rendered).to have_css('dd a', text: 'Ecuador. Procuraduría General del Estado, A Title')
+      expect(rendered).to have_css('dd a @href', text: /q=%22Ecuador.\+Procuradur%C3%ADa\+General\+del\+Estado%2C\+%22/)
+      expect(rendered).to have_css('dd a @href', text: /search_field=search_author/)
+      expect(rendered).not_to have_css('dd a @href', text: /A Title/)
+      expect(rendered).not_to have_css('dd a @href', text: /issuing body/)
+    end
+
+    it 'included the extra text after the link' do
+      expect(rendered).to have_css('dd', text: 'author, issuing body. Art copyist ')
+    end
+  end
+
+  context 'Meeting (with venacular)' do
+    let(:target) { :meeting }
+
+    it 'renders the label in a dt' do
+      expect(rendered).to have_css('dt', text: 'Meeting')
+    end
+
+    it 'renders author and a venacular in dd' do
+      expect(rendered).to have_css('dd', count: 2)
+    end
+
+    it 'renders link, search, and post_text correctly' do
+      expect(rendered).to have_css('dd a', text: 'Technical Workshop on Organic Agriculture (1st : 2010 : Ogbomoso, Nigeria) A title')
+      expect(rendered).to have_css('dd a', text: 'Vernacular Title Vernacular Uniform Title')
+      expect(rendered).to have_css('dd a @href', text: /q=%22Technical\+Workshop\+on\+Organic\+Agriculture\+%281st\+%3A\+2010\+%3A\+Ogbomoso%2C\+Nigeria%29\+%22/)
+      expect(rendered).to have_css('dd a @href', text: /q=%22Vernacular\+Uniform\+Title\+%22/)
+      expect(rendered).to have_css('dd a @href', text: /search_field=search_author/)
+      expect(rendered).not_to have_css('dd a @href', text: /A title/)
+      expect(rendered).not_to have_css('dd a @href', text: /creator/)
+    end
+
+    it 'included the extra text after the link' do
+      expect(rendered).to have_css('dd', text: 'creator. ')
+    end
+  end
+end

--- a/spec/views/marc_fields/_linked_author_index.html.erb_spec.rb
+++ b/spec/views/marc_fields/_linked_author_index.html.erb_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe 'marc_fields/_linked_author_index.html.erb', type: :view do
+  include MarcMetadataFixtures
+  let(:document) { SolrDocument.new(marcxml: send("linked_author_#{target}_fixture".to_sym)) }
+
+  before do
+    allow(view).to receive_messages(linked_author: LinkedAuthor.new(document, target))
+    render
+  end
+
+  context 'Creator' do
+    let(:target) { :creator }
+
+    it 'does not render the label' do
+      expect(rendered).not_to match(/Author\/Creator/)
+    end
+
+    it 'renders link, search, and post_text correctly' do
+      expect(rendered).to have_css('li a', text: 'Dodaro, Gene L.')
+      expect(rendered).to have_css('li a @href', text: /q=%22Dodaro%2C\+Gene\+L\.\+%22/)
+      expect(rendered).to have_css('li a @href', text: /search_field=search_author/)
+      expect(rendered).not_to have_css('li a @href', text: /author\./)
+      expect(rendered).not_to have_css('li a @href', text: /\sAuthor/)
+    end
+
+    it 'included the extra text after the link' do
+      expect(rendered).to match(/author\. Author/)
+    end
+  end
+
+  context 'Corporate Author' do
+    let(:target) { :corporate_author }
+
+    it 'does not render the label' do
+      expect(rendered).not_to match(/Corporate Author/)
+    end
+
+    it 'renders link, search, and post_text correctly' do
+      expect(rendered).to have_css('li a', text: 'Ecuador. Procuraduría General del Estado, A Title')
+      expect(rendered).to have_css('li a @href', text: /q=%22Ecuador.\+Procuradur%C3%ADa\+General\+del\+Estado%2C\+%22/)
+      expect(rendered).to have_css('li a @href', text: /search_field=search_author/)
+      expect(rendered).not_to have_css('li a @href', text: /A Title/)
+      expect(rendered).not_to have_css('li a @href', text: /issuing body/)
+    end
+
+    it 'included the extra text after the link' do
+      expect(rendered).to match(/author, issuing body\. Art copyist/)
+    end
+  end
+
+  context 'Meeting (with venacular)' do
+    let(:target) { :meeting }
+
+    it 'does not render label' do
+      expect(rendered).not_to match(/Meeting/)
+    end
+
+    it 'renders link, search, and post_text correctly' do
+      expect(rendered).to have_css('li:nth-child(1) a', text: 'Technical Workshop on Organic Agriculture (1st : 2010 : Ogbomoso, Nigeria) A title')
+      expect(rendered).to have_css('li:nth-child(1) a @href', text: /q=%22Technical\+Workshop\+on\+Organic\+Agriculture\+%281st\+%3A\+2010\+%3A\+Ogbomoso%2C\+Nigeria%29\+%22/)
+      expect(rendered).to have_css('li:nth-child(1) a @href', text: /search_field=search_author/)
+      expect(rendered).not_to have_css('li:nth-child(1) a @href', text: /A title/)
+      expect(rendered).not_to have_css('li:nth-child(1) a @href', text: /creator/)
+    end
+
+    it 'renders the venacular correctly' do
+      expect(rendered).to have_css('li:nth-child(2) a', text: 'Vernacular Title Vernacular Uniform Title')
+      expect(rendered).to have_css('li:nth-child(2) a @href', text: /q=%22Vernacular\+Uniform\+Title\+%22/)
+    end
+
+    it 'included the extra text after the link' do
+      expect(rendered).to match(/creator\. Other/)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #1321. It introduces a new `MarcField` class to handled linked "authors" so that we can implement 110 and 111 records. Currently, we're just using data from Solr fields to display and link the record. The linking semantics are more nuanced as described in #1321 so we need to generate them directly from MARC. This PR also ports over the 100 records previously handled by `link_to_author_from_marc`. The changes appear in both search results and show pages.

### Before 110$e

![screen shot 2017-06-07 at 2 16 24 pm](https://user-images.githubusercontent.com/1861171/26901885-20b8ff2a-4b8c-11e7-8405-36d3eef68301.png)

### After 110$e

![screen shot 2017-06-07 at 2 16 56 pm](https://user-images.githubusercontent.com/1861171/26901891-2247fdc8-4b8c-11e7-8897-7489743c1218.png)

### Before 111$j

![screen shot 2017-06-07 at 2 19 46 pm](https://user-images.githubusercontent.com/1861171/26901963-6a4e7dd6-4b8c-11e7-96c9-be2d17f46255.png)

### After 111$j

![screen shot 2017-06-07 at 2 20 25 pm](https://user-images.githubusercontent.com/1861171/26901984-7d866116-4b8c-11e7-8575-76257c65a827.png)

### Before 711$j

![screen shot 2017-06-07 at 2 21 14 pm](https://user-images.githubusercontent.com/1861171/26902013-9664dbcc-4b8c-11e7-9d35-d30dfac1c12a.png)

### After 711$j

![screen shot 2017-06-07 at 2 25 57 pm](https://user-images.githubusercontent.com/1861171/26902214-43bc4d64-4b8d-11e7-9780-bce942d6a8a0.png)

### Before in search results

![screen shot 2017-06-08 at 11 28 58 am](https://user-images.githubusercontent.com/1861171/26944508-c2c82ca8-4c3d-11e7-83f1-d5778263c830.png)

### After in search results

![screen shot 2017-06-08 at 11 29 20 am](https://user-images.githubusercontent.com/1861171/26944514-cab8e1aa-4c3d-11e7-8de5-b804d8b64def.png)
