### PR TITLE
Change label for 555 finding aids

### DIFF
--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -219,7 +219,7 @@
   <%= render_field_from_marc(note_552) %>
 <% end %>
 
-<% finding_aid = get_data_with_label_from_marc(document.to_marc, "Finding Aid", '555') %>
+<% finding_aid = get_data_with_label_from_marc(document.to_marc, "Cumulative index or finding aid", '555') %>
 <% unless finding_aid.nil? %>
   <%= render_field_from_marc(finding_aid) %>
 <% end %>


### PR DESCRIPTION
This PR fixes #1341 by changing the label for 555 content in the bibliographic section.

### Before

![screen shot 2017-06-09 at 10 16 46 am](https://user-images.githubusercontent.com/1861171/26986576-f16631b2-4cfc-11e7-859e-86a99eac4b37.png)

### After

![screen shot 2017-06-09 at 10 16 32 am](https://user-images.githubusercontent.com/1861171/26986572-ead60868-4cfc-11e7-9e94-0e6691f55dd5.png)

