### PR TITLE
Add PlaceName MarcField class

### DIFF
--- a/app/models/concerns/marc_metadata.rb
+++ b/app/models/concerns/marc_metadata.rb
@@ -13,4 +13,8 @@ module MarcMetadata
   def physical_medium
     @physical_medium ||= PhysicalMedium.new(self)
   end
+
+  def place_name
+    @place_name ||= PlaceName.new(self)
+  end
 end

--- a/app/models/marc_fields/place_name.rb
+++ b/app/models/marc_fields/place_name.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+##
+# A class to parse MARC 752 Hierarchical Place Name for display
+# https://www.loc.gov/marc/bibliographic/bd752.html
+# Appears as 'Location' in bibliographic information
+class PlaceName < MarcField
+  private
+
+  def subfield_delimeter
+    ' -- '
+  end
+
+  def tags
+    %w(752)
+  end
+end

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -298,10 +298,7 @@
   <%= render_field_from_marc(new_related_work_740) %>
 <%- end -%>
 
-<%- location = get_data_with_label_from_marc(document.to_marc, "Location", '752') -%>
-<%- unless location.nil? -%>
-  <%= render_field_from_marc(location) %>
-<%- end -%>
+<%= render document.place_name %>
 
 <%- system_reqs = get_data_with_label_from_marc(document.to_marc, "System Reqs", '753') -%>
 <%- unless system_reqs.nil? -%>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -18,6 +18,8 @@ en:
         label: Notation
       organization_and_arrangement:
         label: 'Organization & arrangement'
+      place_name:
+        label: 'Location'
       physical_medium:
         label: 'Medium'
       unlinked_series:

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -471,6 +471,7 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
   def contributed_works_fixture
     <<-xml
       <record>
@@ -534,6 +535,18 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
+  def place_name_fixture
+    <<-xml
+      <record>
+        <datafield tag="752">
+          <subfield code="a">Florida</subfield>
+          <subfield code="d">Tampa</subfield>
+        </datafield>
+      </record>
+    xml
+  end
+
   def bad_toc_fixture
     <<-xml
       <record>

--- a/spec/models/marc_fields/place_name_spec.rb
+++ b/spec/models/marc_fields/place_name_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe PlaceName do
+  include MarcMetadataFixtures
+
+  let(:document) { SolrDocument.new(marcxml: place_name_fixture) }
+  subject(:place_name) { described_class.new(document) }
+
+  it 'returns MARC 752' do
+    expect(place_name.values).to be_present
+  end
+
+  it 'is labeled Location' do
+    expect(place_name.label).to eq 'Location'
+  end
+
+  it 'joins subfields with a --' do
+    expect(place_name.values.length).to eq 1
+    expect(place_name.values.first).to eq 'Florida -- Tampa'
+  end
+end


### PR DESCRIPTION
Closes #1338 

- Changes the 'Location' delimiter to --
- Uses the MarcField class convention

## Before:

![before-752](https://user-images.githubusercontent.com/5402927/26994097-fcc2cf16-4d1a-11e7-83d6-b48afd6efc24.png)

## After:

![after-752](https://user-images.githubusercontent.com/5402927/26994100-fe715774-4d1a-11e7-81e5-892ebba84181.png)
