### PR TITLE
add new LinkedRelatedWorks MarcField to handle 730 related works

### DIFF
--- a/app/models/concerns/marc_metadata.rb
+++ b/app/models/concerns/marc_metadata.rb
@@ -10,6 +10,10 @@ module MarcMetadata
     @linked_author[target] ||= LinkedAuthor.new(self, target)
   end
 
+  def linked_related_works
+    @linked_related_works ||= LinkedRelatedWorks.new(self)
+  end
+
   def physical_medium
     @physical_medium ||= PhysicalMedium.new(self)
   end

--- a/app/models/marc_fields/linked_related_works.rb
+++ b/app/models/marc_fields/linked_related_works.rb
@@ -1,0 +1,95 @@
+##
+# A class to parse MARC related works (730 and others) and link them
+# to a search. Some subfields are not include in the search
+# but they do show up inside the link text, hence the logic in
+# the map/join methods.
+#
+class LinkedRelatedWorks < MarcField
+  LINK_CODES = %w[a d f k l m n o p r s t].freeze
+  TEXT_CODES = %w[h i x 3].freeze
+
+  def to_partial_path
+    'marc_fields/linked_related_works'
+  end
+
+  def tags
+    %w[700 710 711 720 730]
+  end
+
+  # @return [Array<Hash<String>>] output in `:pre_text`, `:link`, `:search`, and `:post_text`
+  def values
+    relevant_fields.map do |field|
+      join_to_view(map_to_sections(field))
+    end
+  end
+
+  def preprocessors
+    super + %i[filter_out_indicator2 filter_out_missing_titles]
+  end
+
+  private
+
+  def filter_out_indicator2
+    relevant_fields.reject! do |field|
+      field.canonical_tag != '730' && field.indicator2 == '2' # are not "included works"
+    end
+  end
+
+  def filter_out_missing_titles
+    relevant_fields.reject! do |field|
+      field.canonical_tag != '730' && field.subfields.none? { |subfield| subfield.code == 't' } # do not have a title
+    end
+  end
+
+  # Divides the subfields into Before, Inside (the link nodes), and After.
+  # @return [Hash<Array<Subfield>>] `:before`, `:inside`, and `:after`
+  def map_to_sections(field)
+    result = {
+      before: [],
+      inside: [],
+      after: []
+    }
+    all = field.subfields.dup
+
+    # grab before text at top of the list
+    all.dup.each do |subfield|
+      break if LINK_CODES.include?(subfield.code)
+      result[:before] << subfield if TEXT_CODES.include?(subfield.code)
+      all.delete(subfield)
+    end
+
+    # grab after text from the back of the list
+    all.reverse.dup.each do |subfield|
+      break if LINK_CODES.include?(subfield.code)
+      result[:after] << subfield if TEXT_CODES.include?(subfield.code)
+      all.delete(subfield)
+    end
+    result[:after].reverse! # restore
+
+    # what's left is the link
+    result[:inside] = all
+    result
+  end
+
+  SECTION_TO_VIEW = {
+    before: %i[pre_text],
+    inside: %i[link search],
+    after:  %i[post_text]
+  }.freeze
+
+  # Organizes the `map` output into output suitable to render in a view and returned by `values`
+  # @return [Hash<String>] output in `:pre_text`, `:link`, `:search`, and `:post_text`
+  def join_to_view(subfields)
+    result = {}
+    SECTION_TO_VIEW.each do |from, destinations|
+      destinations.each do |to|
+        subfields[from].each do |subfield|
+          next if to == :search && TEXT_CODES.include?(subfield.code) # omit text subfields from searches
+          result[to] ||= ''
+          result[to] << subfield.value.to_s + ' '
+        end
+      end
+    end
+    result
+  end
+end

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -291,7 +291,7 @@
   <%= render_field_from_marc(note_592) %>
 <% end %>
 
-<%= link_to_related_works_from_marc(document.to_marc) %>
+<%= render document.linked_related_works %>
 
 <%- new_related_work_740 = get_related_works_from_marc(document.to_marc, "Related Work", '740') -%>
 <%- unless new_related_work_740.nil? -%>

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -293,7 +293,7 @@
 
 <%= render document.linked_related_works %>
 
-<%- new_related_work_740 = get_related_works_from_marc(document.to_marc, "Related Work", '740') -%>
+<%- new_related_work_740 = get_740_works_from_marc(document.to_marc, "Related Work") -%>
 <%- unless new_related_work_740.nil? -%>
   <%= render_field_from_marc(new_related_work_740) %>
 <%- end -%>

--- a/app/views/marc_fields/_linked_related_works.html.erb
+++ b/app/views/marc_fields/_linked_related_works.html.erb
@@ -1,0 +1,10 @@
+<% if linked_related_works.present? %>
+  <dt><%= linked_related_works.label %></dt>
+  <% linked_related_works.values.each do |related_work| %>
+    <dd>
+      <%= related_work[:pre_text] %>
+      <%= link_to(related_work[:link], catalog_index_path(q: related_work[:search], search_field: 'search_title')) %>
+      <%= related_work[:post_text] %>
+    </dd>
+  <% end %>
+<% end %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -12,6 +12,8 @@ en:
           label: Author/Creator
         meeting:
           label: Meeting
+      linked_related_works:
+        label: 'Related Work'
       linked_series:
         label: Series
       notation:

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -1133,4 +1133,57 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
+  def linked_related_works_fixture
+    <<-xml
+      <record>
+        <datafield tag="730" ind1="0" ind2=" ">
+          <subfield code="i">i1_subfield_text:</subfield>
+          <subfield code="i">i2_subfield_text:</subfield>
+          <subfield code="a">a_subfield_text.</subfield>
+          <subfield code="d">d_subfield_text.</subfield>
+          <subfield code="f">f_subfield_text.</subfield>
+          <subfield code="k">k_subfield_text.</subfield>
+          <subfield code="l">l_subfield_text.</subfield>
+          <subfield code="h">h_subfield_text.</subfield>
+          <subfield code="m">m_subfield_text.</subfield>
+          <subfield code="n">n_subfield_text.</subfield>
+          <subfield code="o">o_subfield_text.</subfield>
+          <subfield code="p">p_subfield_text.</subfield>
+          <subfield code="r">r_subfield_text.</subfield>
+          <subfield code="s">s_subfield_text.</subfield>
+          <subfield code="t">t_subfield_text.</subfield>
+          <subfield code="x">x1_subfield_text.</subfield>
+          <subfield code="x">x2_subfield_text.</subfield>
+          <subfield code="0">0_subfield_text.</subfield>
+          <subfield code="3">3_subfield_text.</subfield>
+          <subfield code="5">5_subfield_text.</subfield>
+          <subfield code="8">8_subfield_text.</subfield>
+        </datafield>
+        <datafield tag="700" ind1=" " ind2=" ">
+          <subfield code="a">700_a_subfield_text</subfield>
+          <subfield code="t">t_subfield_text.</subfield>
+        </datafield>
+        <datafield tag="700" ind1=" " ind2=" "> <!-- missing title $t -->
+          <subfield code="a">700_a_subfield_text</subfield>
+        </datafield>
+        <datafield tag="710" ind1=" " ind2="1">
+          <subfield code="a">710_with_ind2_1</subfield>
+          <subfield code="t">t_subfield_text.</subfield>
+        </datafield>
+        <datafield tag="710" ind1=" " ind2="2">
+          <subfield code="a">710_with_ind2_2</subfield>
+          <subfield code="t">t_subfield_text.</subfield>
+        </datafield>
+        <datafield tag="711" ind1=" " ind2=" ">
+          <subfield code="a">711_a_subfield_text</subfield>
+          <subfield code="t">t_subfield_text.</subfield>
+        </datafield>
+        <datafield tag="720" ind1=" " ind2=" ">
+          <subfield code="a">720_a_subfield_text</subfield>
+          <subfield code="t">t_subfield_text.</subfield>
+        </datafield>
+      </record>
+    xml
+  end
 end

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -641,10 +641,6 @@ module MarcMetadataFixtures
   def related_works_fixture
     <<-xml
       <record>
-        <datafield tag="730" ind1=" " ind2=" ">
-          <subfield code="i">Includes (expression)</subfield>
-          <subfield code="a">Contributor1</subfield>
-        </datafield>
         <datafield tag="740" ind1=" " ind2="2">
           <subfield code="a">Contributor1</subfield>
         </datafield>

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -198,17 +198,6 @@ describe MarcHelper do
       expect(included_works).to have_css('dd a @href', text: /search_field=search_author/)
       expect(included_works).to have_css('dd', text: /last\./)
     end
-    it "should handle related works correctly" do
-      works = link_to_related_works_from_marc(contributed_works.to_marc)
-      expect(works).to match(/>Related Work</)
-      # should include $i before links but strip ()'s
-      expect(works).to match(/>Includes <a href/)
-      # normal $t punctuation
-      expect(works).to match(/<a href=.*q=%22700\+with\+t\+Title\.%22.*search_field=author_title\">700 with t 700 \$e Title\.<\/a> sub m after \. 700 \$4</)
-      works = link_to_related_works_from_marc(related_works.to_marc) # 730
-      # should include $i before links but strip ()'s
-      expect(works).to match(/>Includes <a href/)
-    end
     it "should handle repeating subfield e" do
        expect(link_to_contributor_from_marc(multi_role_contributor.to_marc)).to match(/\/a> actor\. director\.<\/dd>/)
     end
@@ -369,16 +358,13 @@ describe MarcHelper do
     end
   end
 
-  describe "#get_related_works_from_marc" do
+  describe "#get_740_works_from_marc" do
     let(:related_works) { SolrDocument.new(marcxml: related_works_fixture) }
-    it "should pass on the given label for all indicators except for  when 2 is 2" do
-      expect(get_related_works_from_marc(related_works.to_marc,"Label","730")[:label]).to eq "Label"
-    end
     it "should use Included Work for records with a 2nd indicator of 2" do
-      expect(get_related_works_from_marc(related_works.to_marc,"Label","740")[:label]).to eq "Included Work"
+      expect(get_740_works_from_marc(related_works.to_marc,"Label")[:label]).to eq "Included Work"
     end
     it "should return nil when there is no field" do
-      expect(get_related_works_from_marc(document.to_marc,"Label","740")).to be_nil
+      expect(get_740_works_from_marc(document.to_marc,"Label")).to be_nil
     end
   end
 

--- a/spec/models/marc_fields/linked_related_works_spec.rb
+++ b/spec/models/marc_fields/linked_related_works_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe LinkedRelatedWorks do
+  include MarcMetadataFixtures
+
+  let(:document) { SolrDocument.new(marcxml: linked_related_works_fixture) }
+  subject(:instance) { described_class.new(document) }
+
+  it '#label' do
+    expect(instance.label).to eq 'Related Work'
+  end
+
+  context '#values' do
+    let(:data) { instance.values.first }
+
+    it '#pre_text' do
+      expect(data[:pre_text]).to include 'i1_subfield_text: i2_subfield_text:' # in order
+    end
+
+    it '#link' do
+      %w[a d f k l h m n o p r s t].each do |code|
+        expect(data[:link]).to include "#{code}_subfield_text"
+      end
+      %w[i1 i2 x1 x2].each do |code|
+        expect(data[:link]).not_to include "#{code}_subfield_text"
+      end
+    end
+
+    it '#search' do
+      %w[a d f k l m n o p r s t].each do |code|
+        expect(data[:search]).to include "#{code}_subfield_text"
+      end
+    end
+
+    it '#post_text' do
+      text = 'x1_subfield_text. x2_subfield_text. 3_subfield_text' # in order
+      expect(data[:post_text]).to include text
+      %w[0 5 8].each do |code| # always excluded
+        expect(data[:post_text]).not_to include "#{code}_subfield_text"
+      end
+    end
+  end
+end

--- a/spec/views/marc_fields/_linked_related_works.html.erb_spec.rb
+++ b/spec/views/marc_fields/_linked_related_works.html.erb_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'marc_fields/_linked_related_works.html.erb', type: :view do
+  include MarcMetadataFixtures
+  let(:document) { SolrDocument.new(marcxml: linked_related_works_fixture) }
+
+  before do
+    allow(view).to receive_messages(linked_related_works: LinkedRelatedWorks.new(document))
+    render
+  end
+
+  context 'base' do
+    it 'renders the label in a dt' do
+      expect(rendered).to have_css('dt', text: 'Related Work')
+    end
+
+    it 'renders 5 related works in dd elements' do
+      expect(rendered).to have_css('dd', count: 5)
+    end
+
+    it 'renders pre_text' do
+      text = /i1_subfield_text:\s+i2_subfield_text:/ # in order
+      expect(rendered).to have_css('dd', text: text)
+      expect(rendered).not_to have_css('dd a', text: text)
+    end
+
+    it 'renders link' do
+      %w[a d f k l h m n o p r s t].each do |subfield_code|
+        expect(rendered).to have_css('dd:nth-of-type(1) a', text: "#{subfield_code}_subfield_text")
+      end
+    end
+
+    it 'renders search' do
+      expect(rendered).to have_css('dd:nth-of-type(1) a @href', text: 'q=')
+      expect(rendered).not_to have_css('dd:nth-of-type(1) a @href', text: 'q=%22') # not quoted
+
+      expect(rendered).to have_css('dd:nth-of-type(1) a @href', text: 'search_field=search_title')
+
+      %w[a d f k l m n o p r s t].each do |subfield_code|
+        expect(rendered).to have_css('dd:nth-of-type(1) a @href', text: "#{subfield_code}_subfield_text")
+      end
+      expect(rendered).not_to have_css('dd:nth-of-type(1) a @href', text: 'h_subfield_text') # inner text
+    end
+
+    it 'renders post_text' do
+      text = 'x1_subfield_text. x2_subfield_text. 3_subfield_text' # in order
+      expect(rendered).to have_css('dd:nth-of-type(1)', text: text)
+      expect(rendered).not_to have_css('dd:nth-of-type(1) a', text: text)
+      %w[0 5 8].each do |subfield_code|
+        expect(rendered).not_to have_css('dd:nth-of-type(1) a', text: "#{subfield_code}_subfield_text")
+      end
+    end
+
+    it 'renders 700 fields' do
+      expect(rendered).to have_css('dd:nth-of-type(2) a', text: '700_a_subfield_text')
+    end
+
+    it 'renders 710 fields' do
+      expect(rendered).to have_css('dd:nth-of-type(3) a', text: '710_with_ind2_1')
+      expect(rendered).not_to have_css(text: '710_with_ind2_2')
+    end
+
+    it 'renders 711 fields' do
+      expect(rendered).to have_css('dd:nth-of-type(4) a', text: '711_a_subfield_text')
+    end
+
+    it 'renders 720 fields' do
+      expect(rendered).to have_css('dd:nth-of-type(5) a', text: '720_a_subfield_text')
+    end
+  end
+
+  context 'contributed works' do
+    let(:document) { SolrDocument.new(marcxml: contributed_works_fixture) }
+
+    it 'renders the only field that matches a related work criteria' do
+      expect(rendered).to have_css('dd', count: 1)
+      expect(rendered).to have_css('dd a', text: '700 with t 700 $e Title. sub m after .')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #1340. This code extracts the logic from the marc_helper methods which is non-trivial, and I deleted the (newly) unused code from marc_helper.

### Before

![screen shot 2017-06-12 at 3 55 21 pm](https://user-images.githubusercontent.com/1861171/27058679-9bd3694e-4f87-11e7-9700-7c5115bdc1e7.png)

### After

![screen shot 2017-06-12 at 3 55 03 pm](https://user-images.githubusercontent.com/1861171/27058683-a17996b6-4f87-11e7-8b8a-7ffecbc605b5.png)

### Before

![screen shot 2017-06-12 at 4 10 47 pm](https://user-images.githubusercontent.com/1861171/27059131-c9e0da68-4f89-11e7-809e-b28f57a55315.png)

### After

![screen shot 2017-06-12 at 4 10 24 pm](https://user-images.githubusercontent.com/1861171/27059127-c700d65e-4f89-11e7-9877-b28a03919f15.png)

