### PR TITLE
Add an initializer to silence deprecation warnings in production.

### DIFF
--- a/config/initializers/deprecation_silencer.rb
+++ b/config/initializers/deprecation_silencer.rb
@@ -1,0 +1,2 @@
+# We may want to remove this after the BL6/Rails5.1 upgrade
+Deprecation.default_deprecation_behavior = :silence if Rails.env.production?


### PR DESCRIPTION
Hopefully this will help alleviate the issues we've been seeing w/ our disk filling up in production.