### PR TITLE
fix deprecation warning about SolrDocument initializer

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,6 +34,7 @@ class SolrDocument
   delegate :empty?, :blank?, to: :to_h
 
   def initialize(source_doc = {}, response = nil)
+    source_doc = source_doc.to_h if source_doc.respond_to?(:to_h)
     source_doc[:marcfield] = (source_doc[:marcxml] || source_doc['marcxml'] || source_doc[:marcbib_xml] || source_doc['marcbib_xml'])
     super
   end


### PR DESCRIPTION
Fixes a deprecation warning:

```
DEPRECATION WARNING: Blacklight::Document#[]= is deprecated; use obj.to_h.[]= instead. (called from initialize at /Users/drh/workspace/SearchWorks/app/models/solr_document.rb:37)
DEPRECATION WARNING: Blacklight::Document#initialize expects a hash-like object, received SolrDocument. (called from initialize at /Users/drh/workspace/SearchWorks/app/models/solr_document.rb:38)
```