### PR TITLE
fix missing public/500 template for bad requests

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -361,7 +361,7 @@ class CatalogController < ApplicationController
                                                    facets_from_request,
                                                    blacklight_config)
       end
-      format.html { render 'public/500', layout: false, status: 400 }
+      format.html { render status: :bad_request, layout: false, file: Rails.root.join('public', '500.html') }
     end
   end
 
@@ -372,7 +372,7 @@ class CatalogController < ApplicationController
         live = params[:live].nil? || params[:live] == 'true'
         render json: render_document_with_availability_as_json(document, live)
       end
-      format.html { render 'public/500', layout: false, status: 400 }
+      format.html { render status: :bad_request, layout: false, file: Rails.root.join('public', '500.html') }
     end
   end
 

--- a/app/controllers/hours_controller.rb
+++ b/app/controllers/hours_controller.rb
@@ -3,7 +3,7 @@ class HoursController < ApplicationController
     response = HoursRequest.new(params[:id]).get
     respond_to do |format|
       format.json { render json: response }
-      format.html { render 'public/500', layout: false, status: 400 }
+      format.html { render status: :bad_request, layout: false, file: Rails.root.join('public', '500.html') }
     end
   end
 end


### PR DESCRIPTION
This PR fixes missing template 500 errors for bad requests to json apis.