### PR TITLE
update to phantomjs 2.1.1 on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,23 @@ env:
 
 sudo: false
 language: ruby
-cache: bundler
 
 script: bundle exec rake ci
+
+# Update to phantomjs 2.1.1 to fix issues with < 2
+# See https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
+# and https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-200965782
+cache:
+  bundler: true
+  directories:
+    - "travis_phantomjs"
+
+before_install:
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "hash -r"
+  - "phantomjs --version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :poltergeist do |app|
 end
 Capybara.javascript_driver = :poltergeist
 
-Capybara.default_wait_time = 10
+Capybara.default_wait_time = ENV['TRAVIS'] ? 60 : 10
 
 if ENV["COVERAGE"] or ENV["CI"]
   require 'simplecov'


### PR DESCRIPTION
I'm seeing spurious errors in the minimap test in the `Emailing Records` feature test (line 49). I noticed that we're not using phantomjs 2.x so this PR upgrades the Travis build to use 2.1.1 (based on ArcLight code) and increases the wait time to a minute on Travis.