### PR TITLE
adds a new Article search landing page at /article/home

### DIFF
--- a/app/assets/javascripts/article.js
+++ b/app/assets/javascripts/article.js
@@ -1,0 +1,1 @@
+// TODO: intentionally left blank

--- a/app/assets/stylesheets/modules/article.scss
+++ b/app/assets/stylesheets/modules/article.scss
@@ -1,0 +1,1 @@
+// TODO: intentionally left blank

--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -41,3 +41,25 @@
 .media-heading {
   font-size: 1.1em;
 }
+
+.article-home-page {
+  .home-page-column {
+    padding-right: 20px;
+  }
+  ul {
+    list-style: none;
+    margin-left: 0;
+    margin-top: 0;
+    padding-left: 0;
+    padding-top: 0;
+    li {
+      font-size: .9em;
+    }
+  }
+  .features-body {
+    padding-bottom: 100px;
+  }
+  .articles-help h2 {
+    text-transform: uppercase;
+  }
+}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -14,6 +14,7 @@
 @import 'modules/availability-table';
 @import 'modules/advanced-search';
 @import 'modules/alert';
+@import 'modules/article';
 @import 'modules/availability';
 @import 'modules/bookmarks';
 @import 'modules/bookplates';

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# ArticleController is the controller for Article Search
+class ArticleController < ApplicationController
+  def new; end
+end

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -1,0 +1,2 @@
+module ArticleHelper
+end

--- a/app/views/article/new.html.erb
+++ b/app/views/article/new.html.erb
@@ -1,0 +1,38 @@
+<div class="article-home-page">
+  <h1>Find journal articles and other e-resources</h1>
+  <div class="col-md-4 home-page-facets home-page-column">
+    <h2>Find materials&hellip;</h2>
+    <div class="home-facet">
+      <p><i>&hellip;Facet(s) go here&hellip;</i></p>
+    </div>
+  </div>
+
+  <div class="col-md-4 features home-page-column">
+    <h2>What's here?</h2>
+    <div class="features-body">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+    <h2>What's not?</h2>
+    <div class="features-body">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+  </div>
+
+  <div class="col-md-4 articles-help home-page-column">
+    <h2>Related</h2>
+    <ul class="media">
+      <li class="media">
+        <div class="media-body">
+          <%= link_to "Example Link", root_path, class: "media-heading" %>
+        </div>
+      </li>
+
+      <li class="media">
+        <div class="media-body">
+          <%= link_to "Example External Link", root_path, class: "media-heading" %>
+          <div class="external-link-icon"/>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,4 +67,7 @@ Rails.application.routes.draw do
   resources :recent_selections, only: :index
 
   resources :course_reserves, only: :index, path: "reserves"
+
+  resources :article, only: :new, defaults: { format: :html }
+  get 'article/home' => 'article#new' # alias for article search home page
 end

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe ArticleController do
+  context '#new' do
+    it 'shows a home page' do
+      get :new
+      expect(response).to render_template('new')
+    end
+  end
+end

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe ArticleHelper do
+  pending 'No methods yet'
+end

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe 'Article Routing' do
+  it '#new' do
+    expect(get new_article_path).to route_to('article#new', format: :html)
+  end
+  it '#home is an alias to #new' do
+    expect(get article_home_path).to route_to('article#new')
+  end
+end

--- a/spec/views/article/new.html.erb_spec.rb
+++ b/spec/views/article/new.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe 'article/new.html.erb' do
+  before { render }
+
+  it 'home page' do
+    expect(rendered).to have_css('h1', text: 'Find journal articles and other e-resources')
+  end
+
+  it '3 column layout' do
+    expect(rendered).to have_css('.home-page-column', count: 3)
+  end
+
+  it 'first column is a facet column' do
+    expect(rendered).to have_css('.home-page-facets h2', text: 'Find materials')
+    expect(rendered).to have_css('.home-facet', count: 1)
+  end
+
+  it 'second column is a features column' do
+    expect(rendered).to have_css('.features h2', text: 'What\'s here?')
+    expect(rendered).to have_css('.features h2', text: 'What\'s not?')
+  end
+
+  it 'third column is a links column' do
+    expect(rendered).to have_css('.articles-help h2', text: 'Related')
+    expect(rendered).to have_css('.articles-help ul li', count: 2) # links
+  end
+end


### PR DESCRIPTION
This PR fixes #1379.

Notes:
- I kept the empty helper/javascript/css that the controller generator -- I'm assuming that we'll need them later
- I wasn't sure if we wanted the "RELATED" links to be configurable or not? They are hardcoded into the view template like the current home page has. If so, I suggest we make a different ticket for that.
- The banner still says "SearchWorks catalog" but that's addressed in another ticket: #1378 
- The styling is not exactly like the screenshot in the #1379 ticket because I'm using the existing styling for the SearchWorks home page, i.e., the underlined headers, etc.
- The rails route is `/article/home` is an alias to a restful route `/article/new` as I'm assuming that we'll want more restful routes

### `/article/home`

<img width="1110" alt="screen shot 2017-06-22 at 10 32 40 am" src="https://user-images.githubusercontent.com/1861171/27447567-451e57ec-5736-11e7-8691-c38d0f7c9e01.png">
