### PR TITLE
Updating to blacklight 6.10.1.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       execjs
     bcrypt (3.1.11)
     bindex (0.5.0)
-    blacklight (6.10.0)
+    blacklight (6.10.1)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid


### PR DESCRIPTION
This addresses the session issues we were seeing when initially pushing to prod yesterday.