### PR TITLE
Add a dropdown to switch between Catalog and Article Search

### DIFF
--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -69,6 +69,14 @@
     color: $white;
   }
 
+  .search-dropdown {
+    display: inline-block;
+
+    .dropdown-menu {
+      left: auto;
+    }
+  }
+
   .search-target{
     font-family: 'Crimson Text', serif;
     font-size: 1.6em;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  # This is a path helper that routes the main search
+  # form based on the current search context.
+  def searchworks_search_action_path(opts = {})
+    return article_home_path(opts) if article_search?
+    search_catalog_path(opts)
+  end
 
   def render_search_bar_advanced_widget
     render partial:'catalog/search_bar_advanced_widget'

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -1,2 +1,5 @@
 module ArticleHelper
+  def article_search?
+    controller_name == 'article'
+  end
 end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag search_catalog_path, method: :get, class: 'navbar-forzm', role: 'search' do %>
+<%= form_tag searchworks_search_action_path, method: :get, class: 'navbar-forzm', role: 'search' do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
 
   <div class="input-group">

--- a/app/views/catalog/_search_targets_widget.html.erb
+++ b/app/views/catalog/_search_targets_widget.html.erb
@@ -1,3 +1,24 @@
-<p class="navbar-text search-target">
-  catalog
-</p>
+<div class="search-dropdown">
+  <a href="#" class="dropdown-toggle navbar-text search-target" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+    <span class="sr-only">search</span>
+    <% if article_search?  %>
+      <%= t('searchworks.search_dropdown.articles.label') %>
+    <% else %>
+      <%= t('searchworks.search_dropdown.catalog.label') %>
+    <% end %>
+
+    <span class="caret"></span>
+  </a>
+   <ul class="dropdown-menu" role="menu">
+     <li class="<%= 'active' unless article_search? %>">
+       <%= link_to root_path do %>
+         <%= t('searchworks.search_dropdown.catalog.description_html') %>
+       <% end %>
+     </li>
+     <li class="<%= 'active' if article_search? %>">
+      <%= link_to article_home_path do %>
+        <%= t('searchworks.search_dropdown.articles.description_html') %>
+      <% end %>
+    </li>
+  </ul>
+</div>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -1,5 +1,12 @@
 en:
   searchworks:
+    search_dropdown:
+      articles:
+        label: articles
+        description_html: articles <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
+      catalog:
+        label: catalog
+        description_html: catalog <span class="help-block">books &amp; media in the Stanford Libraries'collections</span>
     marc_fields:
       imprint:
         label: Imprint

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+feature 'Article Searching' do
+  describe 'Search bar dropdown', js: true do
+    scenario 'allows the user to switch to the article search context' do
+      visit root_path
+
+      within '.search-dropdown' do
+        click_link 'search catalog'
+
+        expect(page).to have_css('.dropdown-menu', visible: true)
+
+        expect(page).to have_css('li.active a', text: /catalog/)
+        expect(page).not_to have_css('li.active a', text: /articles/)
+
+        click_link 'articles'
+      end
+
+      expect(page).to have_current_path(article_home_path)
+
+      within '.search-dropdown' do
+        click_link 'search articles'
+
+        expect(page).to have_css('.dropdown-menu', visible: true)
+
+        expect(page).not_to have_css('li.active a', text: /catalog/)
+        expect(page).to have_css('li.active a', text: /articles/)
+      end
+    end
+  end
+end

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -28,4 +28,16 @@ feature 'Article Searching' do
       end
     end
   end
+
+  scenario 'when searching w/i the article context we stay in the articles controller' do
+    visit article_home_path
+
+    within '.search-form' do
+      fill_in 'q', with: 'Kittens'
+
+      click_button 'Search'
+    end
+
+    expect(current_url).to match(%r{/article/home\?.*&q=Kittens})
+  end
 end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -44,7 +44,7 @@ feature "Home Page" do
   end
   scenario "Logo and catalog images should display" do
     expect(page).to have_css("a.navbar-brand")
-    expect(page).to have_css("p.navbar-text.search-target", text: "catalog")
+    expect(page).to have_css(".navbar-text.search-target", text: "catalog")
   end
   scenario "there should be no more link on any facets" do
     expect(page).to_not have_css('a', text: /more/)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,21 @@
 require "spec_helper"
 
 describe ApplicationHelper do
+
+  describe '#searchworks_search_action_path' do
+    context 'when in an article search' do
+      before { expect(helper).to receive_messages(article_search?: true) }
+
+      it { expect(helper.searchworks_search_action_path).to eq article_home_path }
+    end
+
+    context 'everywhere else' do
+      before { expect(helper).to receive_messages(article_search?: false) }
+
+      it { expect(helper.searchworks_search_action_path).to eq search_catalog_path }
+    end
+  end
+
   describe "#data_with_label" do
     let(:temp_doc) {{'key' => 'fudgesicles'}}
     let(:temp_doc_array) {{'key' => ['fudgesicles1','fudgesicles2']}}

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -1,5 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe ArticleHelper do
-  pending 'No methods yet'
+  describe '#article_search?' do
+    context 'when in the ArticlesController' do
+      before { expect(helper).to receive_messages(controller_name: 'article') }
+
+      it { expect(helper.article_search?).to be false }
+    end
+
+    context 'when not in the ArticlesController' do
+      before { expect(helper).to receive_messages(controller_name: 'anything_else') }
+
+      it { expect(helper.article_search?).to be true }
+    end
+  end
 end

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe ArticleHelper do
     context 'when in the ArticlesController' do
       before { expect(helper).to receive_messages(controller_name: 'article') }
 
-      it { expect(helper.article_search?).to be false }
+      it { expect(helper.article_search?).to be true }
     end
 
     context 'when not in the ArticlesController' do
       before { expect(helper).to receive_messages(controller_name: 'anything_else') }
 
-      it { expect(helper.article_search?).to be true }
+      it { expect(helper.article_search?).to be false }
     end
   end
 end


### PR DESCRIPTION
Closes #1378 

There is some left to be desired w/ the styling, but knowing that this search bar area is going to go through some significant changes for article search we figured we shouldn't spend too much time on it.

![search-dropdown](https://user-images.githubusercontent.com/96776/27461633-f8bfedc2-576f-11e7-853a-0ca22215e7e4.gif)
