### PR TITLE
Update the bookmark email path per BL6.

### DIFF
--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -5,7 +5,7 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>
-      <%= link_to t('blacklight.tools.email_html'), email_solr_document_path(sort: params[:sort], per_page: params[:per_page], id: @response.documents.map {|doc| doc.id}), id: "emailLink", data: {ajax_modal: "trigger"} %>
+      <%= link_to t('blacklight.tools.email_html'), email_bookmarks_path(sort: params[:sort], per_page: params[:per_page], id: @response.documents.map {|doc| doc.id}), id: "emailLink", data: {ajax_modal: "trigger"} %>
     </li>
 
     <% if @response.documents.any? {|d| d.exports_as? :refworks_marc_txt } %>


### PR DESCRIPTION
Fixes #1387 

This appears to only be failing at the apache level, which is why we never got this locally or in tests.

This is currently deployed to stage if anybody wants to test it out.