### PR TITLE
Update styling of article search results documents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       tins (~> 1.6)
     csl (1.4.5)
       namae (~> 0.7)
-    csl-styles (1.0.1.7)
+    csl-styles (1.0.1.8)
       csl (~> 1.0)
     css_parser (1.5.0)
       addressable
@@ -175,7 +175,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.1.5.pre)
+    ebsco-eds (0.1.6.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -27,9 +27,10 @@ class ArticleController < ApplicationController
     config.repository_class = Eds::Repository
 
     # solr field configuration for search results/index views
+    config.index.document_presenter_class = IndexDocumentPresenter
     config.index.title_field = :eds_title
     config.index.show_link = 'eds_title'
-    config.index.record_display_type = 'format'
+    config.index.display_type_field = 'eds_publication_type'
     config.index.document_actions = [] # Uncomment to add bookmark toggles to results
 
     # Configured index fields not used
@@ -37,6 +38,7 @@ class ArticleController < ApplicationController
     # config.add_index_field 'id'
 
     # solr field configuration for document/show views
+    config.show.document_presenter_class = ShowDocumentPresenter
     config.show.html_title = 'eds_title'
     config.show.heading = 'eds_title'
     config.show.display_type = 'format'

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -26,8 +26,8 @@ class ArticleController < ApplicationController
     config.repository_class = Eds::Repository
 
     # solr field configuration for search results/index views
-    config.index.title_field = :title_display
-    config.index.show_link = 'title_display'
+    config.index.title_field = :eds_title
+    config.index.show_link = 'eds_title'
     config.index.record_display_type = 'format'
 
     config.add_index_field 'author_display', label: 'Author'
@@ -39,26 +39,29 @@ class ArticleController < ApplicationController
     config.add_index_field 'id'
 
     # solr field configuration for document/show views
-    config.show.html_title = 'title_display'
-    config.show.heading = 'title_display'
+    config.show.html_title = 'eds_title'
+    config.show.heading = 'eds_title'
     config.show.display_type = 'format'
-    config.show.pub_date = 'pub_date'
-    config.show.pub_info = 'pub_info'
-    config.show.abstract = 'abstract'
-    config.show.full_text_url = 'full_text_url'
-    config.show.plink = 'plink'
+    config.show.pub_date = 'eds_publication_date'
+    config.show.pub_info = 'eds_publisher_info'
+    config.show.abstract = 'eds_abstract'
+    config.show.plink = 'eds_plink'
     config.show.route = { controller: 'article' }
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'title_display', label: 'Title'
-    config.add_show_field 'academic_journal', label: 'Journal'
-    config.add_show_field 'author_display', label: 'Author'
-    config.add_show_field 'format', label: 'Format'
-    config.add_show_field 'pub_date', label: 'Publication Date'
-    config.add_show_field 'pub_info', label: 'Published'
-    config.add_show_field 'abstract', label: 'Abstract'
-    config.add_show_field 'doi', label: 'DOI', helper_method: :doi_link
+    config.add_show_field 'eds_title', label: 'Title'
+    config.add_show_field 'eds_languages', label: 'Language'
+    config.add_show_field 'eds_physical_description', label: 'Physical Description'
+    config.add_show_field 'eds_source_title', label: 'Journal'
+    config.add_show_field 'eds_database_name', label: 'Database'
+    config.add_show_field 'eds_authors', label: 'Author'
+    config.add_show_field 'eds_publication_type', label: 'Format'
+    config.add_show_field 'eds_publication_date', label: 'Publication Date'
+    config.add_show_field 'eds_publisher_info', label: 'Published'
+    config.add_show_field 'eds_abstract', label: 'Abstract'
+    config.add_show_field 'eds_subjects', label: 'Subjects'
+    config.add_show_field 'eds_document_doi', label: 'DOI', helper_method: :doi_link
   end
 
   def index

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -2,6 +2,7 @@
 
 # ArticleController is the controller for Article Search
 class ArticleController < ApplicationController
+  include Blacklight::Catalog
   include Blacklight::Configurable
 
   before_action :set_search_query_modifier, only: :index
@@ -29,14 +30,11 @@ class ArticleController < ApplicationController
     config.index.title_field = :eds_title
     config.index.show_link = 'eds_title'
     config.index.record_display_type = 'format'
+    config.index.document_actions = [] # Uncomment to add bookmark toggles to results
 
-    config.add_index_field 'author_display', label: 'Author'
-    config.add_index_field 'format', label: 'Format'
-    config.add_index_field 'academic_journal', label: 'Journal'
-    config.add_index_field 'language_facet', label: 'Language'
-    config.add_index_field 'pub_date', label: 'Year'
-    config.add_index_field 'pub_info', label: 'Published'
-    config.add_index_field 'id'
+    # Configured index fields not used
+    # config.add_index_field 'author_display', label: 'Author'
+    # config.add_index_field 'id'
 
     # solr field configuration for document/show views
     config.show.html_title = 'eds_title'
@@ -75,6 +73,10 @@ class ArticleController < ApplicationController
   def new; end
 
   protected
+
+  def _prefixes
+    @_prefixes ||= super + ['catalog']
+  end
 
   def search_service
     eds_params = {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -61,11 +61,13 @@ class CatalogController < ApplicationController
     #}
 
     # solr field configuration for search results/index views
+    config.index.document_presenter_class = IndexDocumentPresenter
     config.index.title_field = 'title_display'
-    config.index.display_type_field = 'format'
+    config.index.display_type_field = 'format_main_ssim'
     config.index.thumbnail_method = :thumbnail
 
     # solr field configuration for document/show views
+    config.show.document_presenter_class = ShowDocumentPresenter
     #config.show.title_field = 'title_display'
     #config.show.display_type_field = 'format'
 

--- a/app/helpers/results_document_helper.rb
+++ b/app/helpers/results_document_helper.rb
@@ -21,6 +21,7 @@ module ResultsDocumentHelper
     production_year     = document["production_year_isi"].to_s
     original_year       = document["original_year_isi"].to_s
     copyright_year      = document["copyright_year_isi"].to_s
+    journal_pub_year    = document['eds_publication_year'].to_s
 
     # single date
     date = publication_year
@@ -46,6 +47,8 @@ module ResultsDocumentHelper
     if date.empty? and (!earliest_poss_year.empty? or !latest_poss_year.empty?)
       date = "#{earliest_poss_year} ... #{latest_poss_year}"
     end
+
+    date = journal_pub_year if journal_pub_year.present?
 
     date = "[#{date}]" unless date.empty?
   end

--- a/app/helpers/results_document_helper.rb
+++ b/app/helpers/results_document_helper.rb
@@ -1,7 +1,8 @@
 module ResultsDocumentHelper
 
   def get_main_title(document)
-    (document['title_display'] || "").html_safe
+    title_field = blacklight_config.index.title_field
+    (document[title_field] || '').html_safe
   end
 
   def get_main_title_date(document)

--- a/app/presenters/concerns/presenter_format.rb
+++ b/app/presenters/concerns/presenter_format.rb
@@ -1,0 +1,6 @@
+module PresenterFormat
+  def formats
+    field_key = configuration.index.display_type_field
+    document[field_key]
+  end
+end

--- a/app/presenters/index_document_presenter.rb
+++ b/app/presenters/index_document_presenter.rb
@@ -1,0 +1,3 @@
+class IndexDocumentPresenter < Blacklight::IndexPresenter
+  include PresenterFormat
+end

--- a/app/presenters/show_document_presenter.rb
+++ b/app/presenters/show_document_presenter.rb
@@ -1,0 +1,3 @@
+class ShowDocumentPresenter < Blacklight::ShowPresenter
+  include PresenterFormat
+end

--- a/app/views/article/_index_default.html.erb
+++ b/app/views/article/_index_default.html.erb
@@ -1,0 +1,19 @@
+<% doc_presenter = presenter(document) %>
+<ul class='document-metadata dl-horizontal dl-invert'>
+  <% if document['eds_authors'].present? %>
+    <li><%= doc_presenter.field_value('eds_authors') %></li>
+  <% end %>
+
+  <% if document['eds_source_title'].present? %>
+    <li><%= doc_presenter.field_value('eds_source_title') %></li>
+  <% end %>
+</ul>
+<ul class='document-metadata dl-horizontal dl-invert'>
+  <% if document['eds_subjects'].present? %>
+    <li><%= doc_presenter.field_value('eds_subjects') %></li>
+  <% end %>
+
+  <% if document['eds_abstract'].present? %>
+    <li><%= doc_presenter.field_value('eds_abstract') %></li>
+  <% end %>
+</ul>

--- a/app/views/article/index.html.erb
+++ b/app/views/article/index.html.erb
@@ -1,21 +1,27 @@
-<div class="article-search-results">
-  <% if @response.empty? %>
-    <div class="search_num_of_results">
-      <div class='results-heading'>
-        <h1 class="sr-only"><%= t('blacklight.search.zero_results.page_heading') %></h1>
-        <%= t('blacklight.search.pagination_info.no_items_found', search_type: 'articles').html_safe %>
-      </div>
+<div class='row'>
+  <div id="sidebar" class="col-md-4 col-sm-5">
+  </div>
+  <div id="content" class="col-md-8 col-sm-7">
+    <div id='documents' class="article-search-results">
+      <% if @response.empty? %>
+        <div class="search_num_of_results">
+          <div class='results-heading'>
+            <h1 class="sr-only"><%= t('blacklight.search.zero_results.page_heading') %></h1>
+            <%= t('blacklight.search.pagination_info.no_items_found', search_type: 'articles').html_safe %>
+          </div>
+        </div>
+        <%= render "shared/zero_results" %>
+      <% else %>
+        <div class="search_num_of_results">
+          <div class='results-heading'>
+            <h1 class="sr-only"><%= t('blacklight.search.page_heading') %></h1>
+            <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'result') %></h2>
+          </div>
+        </div>
+        <%= render 'search_header' %>
+        <%= render @response.documents, as: :document %>
+        <%= render 'search_footer' %>
+      <% end %>
     </div>
-    <%= render "shared/zero_results" %>
-  <% else %>
-    <div class="search_num_of_results">
-      <div class='results-heading'>
-        <h1 class="sr-only"><%= t('blacklight.search.page_heading') %></h1>
-        <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'result') %></h2>
-      </div>
-    </div>
-    <%= render 'search_header' %>
-    <%= render @response.documents, as: :document %>
-    <%= render 'search_footer' %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/browse/_index_header_default.html.erb
+++ b/app/views/browse/_index_header_default.html.erb
@@ -1,9 +1,9 @@
-
+<% doc_presenter = presenter(document) %>
 <% # header bar for doc items in index view %>
 <div class="documentHeader row">
 
   <h3 class="index_title col-sm-9 col-lg-10">
-    <%= render_resource_icon document[document.format_key] %>
+    <%= render_resource_icon doc_presenter.formats %>
     <%= link_to_document document, get_main_title(document) %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
     <%= document.online_label %>

--- a/app/views/catalog/_index_brief.html.erb
+++ b/app/views/catalog/_index_brief.html.erb
@@ -2,13 +2,13 @@
   preview_container = 'preview-container-' + document.id
   preview_attrs = preview_data_attrs(true, "preview-brief", document[:id], '.' + preview_container)
 %>
-
+<% doc_presenter = presenter(document) %>
 <div class=" brief-document container-fluid" <%= preview_attrs %>>
   <div class="row row-eq-height brief-container">
     <div class="col-md-10">
       <h3 class="index_title">
         <% counter = document_counter_with_offset(document_counter) %>
-        <%= render_resource_icon document[document.format_key] %>
+        <%= render_resource_icon doc_presenter.formats %>
         <span class="document-counter">
           <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
         </span>

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -1,10 +1,10 @@
-
+<% doc_presenter = presenter(document) %>
 <% # header bar for doc items in index view %>
 <div class="documentHeader row">
 
   <h3 class="index_title col-sm-9 col-lg-10">
     <% counter = document_counter_with_offset(document_counter) %>
-    <%= render_resource_icon document[document.format_key] %>
+    <%= render_resource_icon doc_presenter.formats %>
     <span class="document-counter">
       <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
     </span>

--- a/app/views/catalog/_index_header_gallery.html.erb
+++ b/app/views/catalog/_index_header_gallery.html.erb
@@ -1,3 +1,4 @@
+<% doc_presenter = index_presenter(document) # using index_presenter directly here due to embedded call-number browse %>
 <% # header bar for doc items in index view gallery %>
 <div class="documentHeader">
   <div class="callnumber-bar">
@@ -14,7 +15,7 @@
   </div>
   <h3 class="index_title">
     <% counter = document_counter_with_offset(document_counter) %>
-    <%= render_resource_icon document[document.format_key] %>
+    <%= render_resource_icon doc_presenter.formats %>
     <%= link_to_document document, get_main_title(document), counter: counter %>
     <span class="main-title-date"><%= get_main_title_date(document) %></span>
     <%= document.online_label %>

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,5 +1,6 @@
+<% doc_presenter = presenter(document) %>
 <h1>
-  <%= render_resource_icon document[document.format_key] %>
+  <%= render_resource_icon doc_presenter.formats %>
   <%= render_document_heading(document, :tag => :span) %>
 </h1>
 <% if document[:vern_title_display].present? %>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1176,6 +1176,7 @@ module Constants
   SOURCES = { 'Nielsen' => '(source: Nielsen Book Data)' }
   SUL_ICONS = {
     'Object' => 'cube',
+    'Academic Journal' => 'book-2',
     'Archive/Manuscript' => 'document-box-1',
     'Archived website' => 'network-web',
     'Article' => 'text-wrapping-1',

--- a/spec/helpers/results_document_helper_spec.rb
+++ b/spec/helpers/results_document_helper_spec.rb
@@ -29,6 +29,9 @@ describe ResultsDocumentHelper do
     @document_02 = SolrDocument.new(data_02)
     @document_03 = SolrDocument.new(data_03)
     @document_04 = SolrDocument.new
+    @document_05 = SolrDocument.new(
+      eds_publication_year: '2017'
+    )
   end
 
   describe "Render metadata" do
@@ -38,10 +41,17 @@ describe ResultsDocumentHelper do
     it 'should return a blank title if one does not exist' do
       expect(get_main_title(@document_04)).to eq ""
     end
-    it "should return date and date ranges" do
-      expect(get_main_title_date(@document_01)).to eq "[1999]"
-      expect(get_main_title_date(@document_02)).to eq "[1801 ... 1837]"
-      expect(get_main_title_date(@document_03)).to eq "[199 B.C.]"
+
+    describe '#get_main_title_date' do
+      it "should return date and date ranges" do
+        expect(get_main_title_date(@document_01)).to eq "[1999]"
+        expect(get_main_title_date(@document_02)).to eq "[1801 ... 1837]"
+        expect(get_main_title_date(@document_03)).to eq "[199 B.C.]"
+      end
+
+      it 'returns the eds publication year when present' do
+        expect(get_main_title_date(@document_05)).to eq '[2017]'
+      end
     end
 
     it "should return book ids with prefixes" do

--- a/spec/presenters/presenter_format_spec.rb
+++ b/spec/presenters/presenter_format_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe PresenterFormat do
+  subject(:presenter) do
+    Class.new do
+      include PresenterFormat
+    end.new
+  end
+
+  let(:document) { { format_field: ['ABC'] } }
+
+  before do
+    config = double('BlacklightConfig', index: double(display_type_field: :format_field))
+    expect(presenter).to receive(:configuration).and_return(config)
+    expect(presenter).to receive(:document).and_return(document)
+  end
+
+  context 'when the field is present' do
+    it 'is returned' do
+      expect(presenter.formats).to eq ['ABC']
+    end
+  end
+
+  context 'when the field is not present' do
+    let(:document) { {} }
+    it { expect(presenter.formats).to be_nil }
+  end
+end


### PR DESCRIPTION
Closes #1394 

Things that are not necessarily in this PR, and can prob. be deferred are:
* Allow bookmarks toggle to work (this is going to take some serious consideration)
* Remaining citation details (pending convo w/ EBSCO)


## Search Results View
<img width="1185" alt="search-results" src="https://user-images.githubusercontent.com/96776/27612843-5c20d328-5b4d-11e7-8111-38cfdb647b3f.png">


## Record/Detail View
<img width="893" alt="record-view" src="https://user-images.githubusercontent.com/96776/27612842-5c1fe9d6-5b4d-11e7-882a-c2a067a9dd1a.png">