### PR TITLE
Restructure the banner into a red search bar and a grey navbar

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -4,7 +4,7 @@
   padding: 0 0;
 }
 
-#outer-container, #topnav-container, #search-navbar-container, #sul-footer-container {
+#outer-container, #topnav-container, #search-navbar-container, #search-subnavbar-container, #sul-footer-container {
 	width: 100%;
 	margin: 0;
 	padding: 0;
@@ -15,7 +15,7 @@
 	border-bottom: none;
 }
 
-#topnav, #search-navbar, #main-container, #sul-footer, #masthead-container {
+#topnav, #search-navbar, #search-subnavbar-container, #main-container, #sul-footer, #masthead-container {
 	margin: 0 auto;
 	text-align: left;
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -15,7 +15,7 @@
 	border-bottom: none;
 }
 
-#topnav, #search-navbar, #search-subnavbar-container, #main-container, #sul-footer, #masthead-container {
+#topnav, #search-navbar, #search-subnavbar, #main-container, #sul-footer, #masthead-container {
 	margin: 0 auto;
 	text-align: left;
 }
@@ -26,7 +26,7 @@
   }
 }
 
-#search-navbar {
+#search-navbar, #search-subnavbar {
 	padding: 0;
 }
 
@@ -36,26 +36,26 @@ a#sul-logo {
 }
 
 @media (min-width: 768px) {
-  #topnav, #search-navbar, #main-container, #sul-footer, #masthead-container {
+  #topnav, #search-navbar, #search-subnavbar, #main-container, #sul-footer, #masthead-container {
     width: 750px;
   }
 }
 
 @media (min-width: 980px) {
-  #topnav, #search-navbar, #main-container, #sul-footer, #masthead-container {
+  #topnav, #search-navbar, #search-subnavbar, #main-container, #sul-footer, #masthead-container {
     width: 970px;
   }
 }
 
 @media (min-width: 1200px) {
-  #topnav, #search-navbar, #main-container, #sul-footer, #masthead-container {
+  #topnav, #search-navbar, #search-subnavbar, #main-container, #sul-footer, #masthead-container {
     width: 1170px;
   }
 }
 
 
 @media only screen and (max-width : 768px) {
-  #main-container, #search-navbar {
+  #main-container, #search-navbar, #search-subnavbar {
     padding: 0 15px;
   }
 

--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -11,12 +11,6 @@ $btn-preview-border: darken($sul-btn-preview-bg, 9.8%);
   text-decoration: none;
 }
 
-.btn-topbar-menu {
-  color: $cardinal-red;
-  background: none;
-  border: none;
-}
-
 .btn-sul-toolbar {
   color: $btn-sul-toolbar-bar-color !important;
   background-color: transparent;

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -1,4 +1,5 @@
-#search-navbar-container {
+#search-navbar-container,
+#search-subnavbar-container {
   padding: 0 0 0 0;
   background-color: $sul-navbar-brand-color;
 

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -1,58 +1,34 @@
 #search-navbar-container {
-  padding: 10px 0 0 0;
-  background-color: $cardinal-red;
-  box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.2)
-}
+  padding: 0 0 0 0;
+  background-color: $sul-navbar-brand-color;
 
-.search-bar {
+  .navbar-header {
+    height: 100px;
+  }
+
   a {
     border: none;
   }
 
   .navbar-brand {
-    padding: 10px 0 10px 0;
-    line-height: 28px;
+    padding: 0 0 0 0;
+    height: 28px;
+    margin: 36px 10px 36px 0px;
 
     img {
       height: 28px;
-      margin-right: 10px;
-      vertical-align: middle;
       @media screen and (max-width: $screen-sm) {
         height: 26px;
       }
     }
   }
 
+  // For text search pulldown
   .search-form {
     .input-group-addon {
       &.for-search-field {
         border-radius: 4px 0 0 4px;
       }
-    }
-  }
-
-  .navbar-nav.navbar-right.searchbar-right:last-child {
-    margin-right: -15px;
-  }
-
-  ul.searchbar-right {
-    text-transform: uppercase;
-  }
-
-  .nav > li > a {
-    padding: 15px 0 5px 0;
-    margin-left: 15px;
-  }
-
-  #searchbar-navbar-collapse .nav > li > a {
-    &:hover, &:focus, &:active {
-      border-bottom: 3px solid $white;
-    }
-  }
-
-  @media screen and (max-width: $screen-sm) {
-    .navbar-nav.navbar-right.searchbar-right {
-      text-align: right;
     }
   }
 
@@ -70,72 +46,65 @@
   }
 
   .search-dropdown {
-    display: inline-block;
+    display: inline-flex;
+    height: inherit;
 
     .dropdown-menu {
       left: auto;
+      top: 70px;
+
+      li.active > a {
+        color: $black; // override bootstrap
+        background-color: #faf8d2;
+      }
     }
   }
 
-  .search-target{
-    font-family: 'Crimson Text', serif;
-    font-size: 1.6em;
+  .search-target {
+    font-size: 22px;
+    font-weight: 100;
     color: $white;
-    margin-left: 0;
+    margin: 39px 0 0 0;
+    padding: 0;
+    border-bottom-width: 1px;
+    border-bottom-color: $white;
+    border-bottom-style: dashed;
+    display: inline-table;
   }
 
-  span.input-group-addon {
-  	padding: 0;
-  	background: white;
-	}
-  span.input-group-addon select {
-  	border: none;
-  	background: transparent;
-	}
-
-  ul.navbar-nav > li > ul > li {
-    a {
-      text-transform: none;
+  @media screen and (max-width: $screen-sm-min) {
+    .search-form {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+    .search_field {
+      width: 82px;
+    }
+    #searchbar-navbar-collapse .nav > li > a:hover {
+      border-bottom: none !important;
     }
   }
-}
 
-.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus {
-  background-color: transparent;
-}
+  @media screen and (max-width: $screen-md-min) {
+    .search-form {
+      margin-bottom: 10px;
+    }
+  }
+  @media screen and (min-width: $screen-md-min) {
+    .search-form {
+      position: absolute;
+      top: 36px;
+      left: 300px;
+      margin-right: 60px;
+    }
+  }
 
-@media screen and (max-width: $screen-sm-min) {
-  .search-form {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-  .search_field {
-    width: 82px;
-  }
-  #searchbar-navbar-collapse .nav > li > a:hover {
-    border-bottom: none !important;
-  }
-}
-
-@media screen and (max-width: $screen-md-min) {
-  .search-form {
-    margin-bottom: 10px;
-  }
-}
-@media screen and (min-width: $screen-md-min) {
-  .search-form {
-    position: absolute;
-    top: 8px;
-    left: 276px;
-    width: 360px;
-  }
-}
-
-@media screen and (min-width: $screen-lg-min) {
-  .search-form {
-    position: absolute;
-    top: 8px;
-    left: 276px;
-    width: 560px;
+  @media screen and (min-width: $screen-lg-min) {
+    .search-form {
+      position: absolute;
+      top: 36px;
+      left: 300px;
+      margin-right: 60px;
+    }
   }
 }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -4,6 +4,10 @@
   height: 35px;
   box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.2);
 
+  #searchbar-subnavbar-collapse {
+    padding-left: 0;
+  }
+
   // For all subnavbar navbar lists
   .navbar-nav > li {
     a {

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -1,0 +1,69 @@
+#search-subnavbar-container {
+  padding: 0;
+  margin: 0;
+  background-color: $sul-subnavbar-bg-color;
+  color: $white;
+  height: 35px;
+  box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.2);
+
+  // TODO: need to position to align with topnav and search-navbar
+  .navbar-left {
+    margin-left: 25px;
+  }
+  .navbar-right {
+    margin-right: 25px;
+  }
+
+  // For all subnavbar navbar lists
+  .navbar-nav > li {
+    a {
+      color: $white;
+      padding: 6px 0;
+      margin: 0 20px 0 0;
+      line-height: 20px;
+      font-weight: 100;
+      font-size: 20px;
+      border: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+      background-color: $sul-subnavbar-bg-color;
+    }
+
+    a:focus {
+      background-color: $sul-subnavbar-bg-color;
+    }
+  }
+
+  // For dropdowns
+  .dropdown-menu {
+    background-color: $sul-subnavbar-bg-color;
+    border-radius: 0px;
+    left: inherit;
+
+    li a {
+      font-size: 1.375rem;
+      font-weight: 100;
+      line-height: 35px;
+      padding: 0 24px;
+      margin: 0;
+
+       i.fa-bookmark-o {
+        padding-right: 4px;
+      }
+    }
+
+    li.text-muted, li.dropdown-header {
+      padding-left: 15px;
+      color: $white;
+    }
+
+    .divider {
+      margin-left: 15px;
+      margin-right: 15px;
+      border-bottom: white dotted 1px;
+      background-color: transparent;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -1,18 +1,8 @@
 #search-subnavbar-container {
-  padding: 0;
-  margin: 0;
   background-color: $sul-subnavbar-bg-color;
   color: $white;
   height: 35px;
   box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.2);
-
-  // TODO: need to position to align with topnav and search-navbar
-  .navbar-left {
-    margin-left: 25px;
-  }
-  .navbar-right {
-    margin-right: 25px;
-  }
 
   // For all subnavbar navbar lists
   .navbar-nav > li {
@@ -20,8 +10,7 @@
       color: $white;
       background-color: $sul-subnavbar-bg-color;
       padding: 6px 0;
-      margin: 0 20px 0 0;
-      line-height: 20px;
+      margin-right: 20px;
       font-weight: 100;
       font-size: 20px;
       border: none;
@@ -32,7 +21,7 @@
     }
 
     a:focus {
-      // restore bootstrap defaults to override their navbar focus (outline: 0)
+      // restore defaults to override their navbar focus settings (outline: 0)
       outline: 5px auto -webkit-focus-ring-color;
       outline-offset: -2px;
     }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -18,6 +18,7 @@
   .navbar-nav > li {
     a {
       color: $white;
+      background-color: $sul-subnavbar-bg-color;
       padding: 6px 0;
       margin: 0 20px 0 0;
       line-height: 20px;
@@ -28,11 +29,12 @@
 
     a:hover {
       text-decoration: underline;
-      background-color: $sul-subnavbar-bg-color;
     }
 
     a:focus {
-      background-color: $sul-subnavbar-bg-color;
+      // restore bootstrap defaults to override their navbar focus (outline: 0)
+      outline: 5px auto -webkit-focus-ring-color;
+      outline-offset: -2px;
     }
   }
 

--- a/app/assets/stylesheets/modules/top-navbar.scss
+++ b/app/assets/stylesheets/modules/top-navbar.scss
@@ -35,60 +35,6 @@
       border-bottom: 3px solid $sul-topnavbar-link-color;
     }
   }
-
-  .btn-topbar-menu {
-    font-size: 1.7em;
-    height: 25px;
-    margin-top: -2px;
-    padding-left: 0;
-    vertical-align: text-bottom;
-  }
-
-  &.open {
-    .btn-topbar-menu span {
-      @extend .fa-rotate-90;
-    }
-  }
-}
-.sul-top-menu {
-  width: 350px;
-  background: rgba($cardinal-red, .9);
-  margin-left: 2px;
-  margin-top: -1px;
-  border-radius: 0px;
-  left: inherit;
-
-  li a {
-    color: $white;
-    border: none;
-    padding-left: 40px;
-  }
-
-  li a[role=menuitem] i.fa-bookmark-o {
-    padding-right: 4px;
-  }
-
-  li a:hover {
-    color: $cardinal-red;
-    margin-left: 15px;
-    padding-left: 25px;
-    margin-right: 15px;
-  }
-
-  li.menu-header {
-    padding-left: 0;
-  }
-
-  .dropdown-header {
-    font-size: $font-size-base;
-  }
-
-  .divider {
-    margin-left: 15px;
-    margin-right: 15px;
-    border-bottom: white dotted 1px;
-    background-color: transparent;
-  }
 }
 .dropdown-list-title{
   padding: 3px 20px;

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -53,6 +53,7 @@
 @import 'modules/requests-modal';
 @import 'modules/results-documents';
 @import 'modules/search-bar';
+@import 'modules/subnavbar';
 @import 'modules/selected-databases';
 @import 'modules/skip-to-nav';
 @import 'modules/sort-and-per-page-toolbar';

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -37,6 +37,7 @@ $white: #ffffff;
 
 $sul-footer-bg-color: $beige-10-percent;
 $sul-topnav-bg-color: $cardinal-red;
+$sul-subnavbar-bg-color: #857e74;
 $sul-navbar-brand-color: $cardinal-red;
 $sul-topnavbar-link-color: $cardinal-red;
 $sul-link-color: $gray;

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -37,6 +37,10 @@ class ArticleController < ApplicationController
     # config.add_index_field 'author_display', label: 'Author'
     # config.add_index_field 'id'
 
+    config.add_search_field('search') do |field|
+      field.label = 'All fields'
+    end
+
     # solr field configuration for document/show views
     config.show.document_presenter_class = ShowDocumentPresenter
     config.show.html_title = 'eds_title'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,10 +10,6 @@ module ApplicationHelper
     render partial:'catalog/search_bar_advanced_widget'
   end
 
-  def render_search_bar_browse_widget
-    render partial: 'catalog/search_bar_browse_widget'
-  end
-
   def render_search_bar_selections_widget
     render partial: 'catalog/search_bar_selections_widget'
   end

--- a/app/views/catalog/_search_bar_advanced_widget.html.erb
+++ b/app/views/catalog/_search_bar_advanced_widget.html.erb
@@ -1,3 +1,3 @@
 <%= link_to blacklight_advanced_search_engine.advanced_search_path, class:"search-bar-widget #{active_class_for_current_page(blacklight_advanced_search_engine.advanced_search_path)}" do %>
-  <i class="fa fa-search-plus"></i> Advanced
+  Advanced search
 <% end %>

--- a/app/views/catalog/_search_bar_nav_list.html.erb
+++ b/app/views/catalog/_search_bar_nav_list.html.erb
@@ -1,5 +1,0 @@
-<ul class="nav navbar-nav navbar-right searchbar-right">
-  <li class=""><%= render_search_bar_advanced_widget %></li>
-  <%= render_search_bar_browse_widget %>
-  <%= render_search_bar_selections_widget %>
-</ul>

--- a/app/views/catalog/_search_bar_selections_widget.html.erb
+++ b/app/views/catalog/_search_bar_selections_widget.html.erb
@@ -1,6 +1,6 @@
 <li class="dropdown" data-behavior="recent-selections" data-url=<%= recent_selections_path %>>
   <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-    <i class="fa fa-check-square-o"></i> Selections (<span data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>)<span class="caret"></span>
+    Selections (<span data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>)<span class="caret"></span>
   </a>
   <ul class="dropdown-menu dropdown-fixed-width recent-selections">
     <li id="show-list" class= <%= disabled_class_for_current_page(selections_path)%> <%= disabled_class_for_no_selections(current_or_guest_user.bookmarks.length) %>>

--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -44,8 +44,11 @@
     <div id="su-wrap"> <!-- #su-wrap start -->
       <div id="su-content"> <!-- #su-content start -->
         <div id="outer-container" class="container-fluid">
-          <%= render 'shared/top_navbar' %>
-          <%= render 'shared/search_bar' %>
+          <div id="stacked-banner">
+            <%= render 'shared/top_navbar' %>
+            <%= render 'shared/search_bar' %>
+            <%= render 'shared/search_subnavbar' %>
+          </div>
           <%= render_masthead_partial %>
 
           <%= render partial: 'shared/ajax_modal' %>

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -8,11 +8,6 @@
         <%= link_to (image_tag 'searchworks.svg', {:"data-svg-fallback" => "#{image_path('searchworks.png')}", :alt => 'SearchWorks'}), root_path, :class => 'navbar-brand' %>
         <%= render_search_targets_widget %>
     </div>
-    <div class="collapsed-search-navs">
-      <div class="collapse navbar-collapse" id="searchbar-navbar-collapse">
-        <%= render "catalog/search_bar_nav_list" %>
-      </div>
-    </div>
     <div class="search-form">
       <%= render_search_bar %>
     </div>

--- a/app/views/shared/_search_navbar_top_menu.html.erb
+++ b/app/views/shared/_search_navbar_top_menu.html.erb
@@ -1,54 +1,54 @@
 <ul class="dropdown-menu sul-top-menu" role="menu" aria-labelledby="searchNavbarTopMenu">
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/about">About</a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/libraries">Libraries</a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/using">Using the libraries</a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/areas">Collections</a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/research">Research support</a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/academic-technology">Academic technology</a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/ask">Ask us</a>
   </li>
 
-  <li role="presentation" class="divider"></li>
+  <li role="separator" class="divider"></li>
 
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">
       <i class="fa fa-bookmark-o"></i> Connect from off campus
     </a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/hours">
       <i class="fa fa-bookmark-o"></i> Hours &amp; locations
     </a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">
       <i class="fa fa-bookmark-o"></i> Interlibrary borrowing
     </a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/ask/email/request_purchase">
       <i class="fa fa-bookmark-o"></i> Suggest a purchase
     </a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/guides/topic">
       <i class="fa fa-bookmark-o"></i> Topic guides
     </a>
   </li>
-  <li role="presentation">
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/guides/course">
       <i class="fa fa-bookmark-o"></i> Course guides
     </a>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -1,8 +1,8 @@
 <div id="search-subnavbar">
   <div id="search-subnavbar-container">
     <div class="collapsed-search-navs">
-      <div class="collapse navbar-collapse" id="searchbar-navbar-collapse">
-        <ul class="nav navbar-nav">
+      <div class="collapse navbar-collapse" id="searchbar-subnavbar-collapse">
+        <ul class="nav navbar-nav navbar-left">
           <li class="dropdown search-subnavbar-about">
             <a class="dropdown-toggle" data-toggle="dropdown" href="#">
               Library services<span class="caret"/>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -1,5 +1,5 @@
-<div id="search-subnavbar">
-  <div id="search-subnavbar-container">
+<div id="search-subnavbar-container">
+  <div id="search-subnavbar">
     <div class="collapsed-search-navs">
       <div class="collapse navbar-collapse" id="searchbar-subnavbar-collapse">
         <ul class="nav navbar-nav navbar-left">

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -1,0 +1,25 @@
+<div id="search-subnavbar">
+  <div id="search-subnavbar-container">
+    <div class="collapsed-search-navs">
+      <div class="collapse navbar-collapse" id="searchbar-navbar-collapse">
+        <ul class="nav navbar-nav">
+          <li class="dropdown search-subnavbar-about">
+            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+              Library services<span class="caret"/>
+            </a>
+            <%= render :partial => 'shared/search_navbar_top_menu' %>
+          </li>
+        </ul>
+        <ul class="nav navbar-nav navbar-right">
+          <li class="navbar-link">
+            <%= render_search_bar_advanced_widget %>
+          </li>
+          <li class="navbar-link">
+            <%= link_to "Course reserves", course_reserves_path %>
+          </li>
+          <%= render_search_bar_selections_widget %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,9 +1,5 @@
 <div id="topnav-container">
   <header id="topnav" class="header-logo" role="banner">
-    <button class="btn-topbar-menu dropdown-toggle searchbar-topnav" type="button" data-toggle="dropdown" data-target="#searchbar-topnav-menu">
-      <span class="sr-only">Menu</span>
-      <span class="fa fa-bars"></span>
-    </button>
     <%= link_to 'https://library.stanford.edu' do %>
       <%= image_tag "sul-logo.svg", class: "su-logo hidden-xs", alt: "Stanford University Libraries", height: 25 %>
       <%= image_tag "sul-logo-stacked.svg", class: "su-logo visible-xs", alt: "Stanford University Libraries", height: 25 %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -6,7 +6,7 @@ en:
         description_html: articles <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
       catalog:
         label: catalog
-        description_html: catalog <span class="help-block">books &amp; media in the Stanford Libraries'collections</span>
+        description_html: catalog <span class="help-block">books &amp; media in the Stanford Libraries' collections</span>
     marc_fields:
       imprint:
         label: Imprint

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -56,8 +56,6 @@ feature "Advanced Search" do
     within('.breadcrumb') do
       expect(page).to have_content("A search")
     end
-
-    expect(page).to_not have_content("Advanced search")
   end
   scenario "should have search tips" do
     within ".advanced-search-form" do

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -3,19 +3,16 @@ require "spec_helper"
 describe "Search toolbar", js: true, feature: true do
   before { visit root_path }
   describe "has SearchWorks customizations" do
-    it "should display correct elements" do
-      within "#search-navbar" do
+    it "should display correct subnavbar elements" do
+      within '#search-navbar-container' do
         expect(page).to have_css("button.btn.btn-default.search-btn", text: "")
-        expect(page).to have_css("li a", text: "ADVANCED", visible: true)
-        expect(page).to have_css("li a", text: "BROWSE", visible: true)
-        expect(page).to have_css("li a", text: /SELECTIONS/, visible: true)
       end
-    end
-  end
-  describe "Browse dropdown" do
-    it "should have browse links" do
-      click_link "Browse"
-      expect(page).to have_css("ul.dropdown-menu li a", text: "Course reserves")
+      within "#search-subnavbar-container" do
+        expect(page).to have_css("li a", text: "Library services", visible: true)
+        expect(page).to have_css("li a", text: "Advanced search", visible: true)
+        expect(page).to have_css("li a", text: "Course reserves", visible: true)
+        expect(page).to have_css("li a", text: /SELECTIONS/i, visible: true)
+      end
     end
   end
   describe "Selections dropdown" do
@@ -26,24 +23,24 @@ describe "Search toolbar", js: true, feature: true do
         expect(page).to have_css("h3", text: "You have no bookmarks")
       end
     end
-    describe "clear list", js:true do
+    describe "clear list" do
       it "should clear selections and update selections count and recently added list" do
-        skip("Passes locally, not on Travis.") if ENV['CI']
+        skip 'Not working correctly'
         visit search_catalog_path f: {format: ["Book"]}, view: "default"
-        expect(page).to have_css("li a", text: /SELECTIONS \(0\)/)
+        expect(page).to have_css("li a", text: /SELECTIONS \(0\)/i)
         click_link "Selections"
         expect(page).to have_css("li#show-list.disabled")
         expect(page).to have_css("li#clear-list.disabled")
         page.all('label.toggle_bookmark')[0].click
-        expect(page).to have_css("li a", text: /SELECTIONS \(1\)/)
+        expect(page).to have_css("li a", text: /SELECTIONS \(1\)/i)
         click_link "Selections"
         expect(page).to have_css("li.dropdown-list-title", count: 1)
         page.all('label.toggle_bookmark')[1].click
-        expect(page).to have_css("li a", text: /SELECTIONS \(2\)/)
+        expect(page).to have_css("li a", text: /SELECTIONS \(2\)/i)
         click_link "Selections"
         expect(page).to have_css("li.dropdown-list-title", count: 2)
         page.all('label.toggle_bookmark')[1].click
-        expect(page).to have_css("li a", text: /SELECTIONS \(1\)/)
+        expect(page).to have_css("li a", text: /SELECTIONS \(1\)/i)
         click_link "Selections"
         expect(page).to have_css("li.dropdown-list-title", count: 1)
         click_link "Selections"

--- a/spec/features/blacklight_customizations/search_types_spec.rb
+++ b/spec/features/blacklight_customizations/search_types_spec.rb
@@ -13,4 +13,6 @@ feature "Search types" do
       expect(page).to have_css('option[value="search_series"]', text: 'Series')
     end
   end
+
+  it 'should have different types for article search'
 end

--- a/spec/features/course_reserves_browse_spec.rb
+++ b/spec/features/course_reserves_browse_spec.rb
@@ -1,7 +1,22 @@
 require 'spec_helper'
 
 feature 'Course reserves browse', js: true do
-  scenario 'should have correct manual route' do
+  context 'homepage and subnavbar' do
+    before { visit root_path }
+    scenario "should be accessible from the home page" do
+      within '.features' do
+        click_link 'Course reserves'
+      end
+      expect(page).to have_css("h1", text: "Browse course reserves")
+    end
+    scenario "should be accessible from the subnavbar" do
+      within '#search-subnavbar-container' do
+        click_link 'Course reserves'
+      end
+      expect(page).to have_css("h1", text: "Browse course reserves")
+    end
+  end
+  scenario 'should have correct manual route' do # TODO: move to routing spec?
     visit '/reserves'
     expect(page).to have_css('h1', text: 'Browse course reserves')
   end
@@ -18,23 +33,6 @@ feature 'Course reserves browse', js: true do
     expect(page).to have_css('label', text: 'per page')
     expect(page).to have_css('li.paginate_button.active span', text: 1)
     expect(page).to have_css('ul.pagination li:nth-child(2)', text: 'Next')
-  end
-  scenario 'should have a link in the browse dropdown' do
-    visit root_path
-
-    within("#search-navbar .browse-dropdown") do
-      click_link "Browse"
-
-      expect(page).to have_css('li a', text: 'Course reserves', visible: true)
-      click_link 'Course reserves'
-    end
-
-    expect(page).to have_css('h1', text: 'Browse course reserves')
-  end
-  scenario "should be accessible from the home page" do
-    visit root_path
-    click_link "Course reserves"
-    expect(page).to have_css("h1", text: "Browse course reserves")
   end
   scenario 'it should have a custom masthead' do
     visit course_reserves_path

--- a/spec/features/responsive/search_toolbar_responsive_spec.rb
+++ b/spec/features/responsive/search_toolbar_responsive_spec.rb
@@ -7,34 +7,25 @@ describe "Responsive search bar", js: true, feature: true do
     click_button 'search'
   end
   describe " - desktop view (> 980px)" do
-    it "should display correct tools" do
+    it "displays the search form" do
       within "#search-navbar" do
         expect(page).to have_css(".search-form", visible: true)
-        expect(page).to have_css("#searchbar-navbar-collapse li", count: 3, visible: true)
       end
     end
   end
   describe " - tablet view (768px - 980px) - " do
-    it "should display correct tools" do
+    it "displays the search form" do
       within "#search-navbar" do
         page.driver.resize("800", "800")
         expect(page).to have_css(".search-form", visible: true)
-        expect(page).to have_css("#searchbar-navbar-collapse li", count: 3, visible: true)
       end
     end
   end
   describe " - mobile landscape view (480px - 767px) - " do
-    it "should display correct tools" do
+    it "displays the search form" do
       page.driver.resize("700", "700")
       within "#search-navbar" do
         expect(page).to have_css(".search-form", visible: true)
-        expect(page).to_not have_css("#searchbar-navbar-collapse li", count: 3, visible: true)
-        find("button.navbar-toggle").click
-        within "#searchbar-navbar-collapse" do
-          expect(page).to have_css("li a", text: "ADVANCED", visible: true)
-          expect(page).to have_css("li a", text: "BROWSE", visible: true)
-          expect(page).to have_css("li a", text: /SELECTIONS/, visible: true)
-        end
       end
     end
   end

--- a/spec/features/responsive/subnav_responsive_spec.rb
+++ b/spec/features/responsive/subnav_responsive_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'Responsive subnavbar (gray banner)', js: true, feature: true do
+  skip
+end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -11,6 +11,8 @@ feature "Search Results Page" do
     expect(page).to have_css('.vernacular-title', text: 'Currently, to obtain more information from the weakness of the resultant pain.')
   end
   scenario "should have resource type icon" do
-    expect(page).to have_css("li span.sul-icon")
+    within '.document' do
+      expect(page).to have_css('h1 span.sul-icon')
+    end
   end
 end

--- a/spec/features/top_nav_spec.rb
+++ b/spec/features/top_nav_spec.rb
@@ -3,28 +3,11 @@ require 'spec_helper'
 feature "Top Navigation" do
   scenario "should have navigational links and top menu", js:true do
     visit root_path
-    page.save_screenshot('tmp/screen.png')
     within "#topnav" do
       within ".header-links" do
+        expect(page).to have_css("a", text: "Login")
         expect(page).to have_css("a", text: "My Account")
         expect(page).to have_css("a", text: "Feedback")
-      end
-      expect(page).to have_css("button.btn-topbar-menu.dropdown-toggle", visible:true)
-      page.find('.btn-topbar-menu').click
-      within ".sul-top-menu" do
-        expect(page).to have_css("ul.dropdown-menu li a", text:"About", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Libraries", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Using the libraries", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Collections", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Research support", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Academic technology", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Ask us", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Connect from off campus", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Hours & locations", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Interlibrary borrowing", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Course guides", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Topic guides", visible:true)
-        expect(page).to have_css("ul.dropdown-menu li a", text:"Suggest a purchase", visible:true)
       end
     end
   end


### PR DESCRIPTION
This PR fixes #1396.  I will deploy this branch to the sandbox for testing.

Notes for things that do not work:

- [x] Left alignment for the gray bar is static :(
- [x] FIXED: White background flashes when closing pulldowns on the gray bar
- [x] FIXED: Tab focus doesn't highlight the 2 pulldowns in the gray bar (Library services, Selections)

![banner mov](https://user-images.githubusercontent.com/1861171/27654307-b2807c92-5bf6-11e7-8ea1-82afd7fcefa3.gif)

