### PR TITLE
Show fulltext links on results and show pages

### DIFF
--- a/app/assets/stylesheets/modules/article.scss
+++ b/app/assets/stylesheets/modules/article.scss
@@ -9,3 +9,7 @@
     padding-top: 10px;
   }
 }
+
+li.article-fulltext-link {
+  list-style-type: none;
+}

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -31,6 +31,7 @@ class ArticleController < ApplicationController
     config.index.title_field = :eds_title
     config.index.show_link = 'eds_title'
     config.index.display_type_field = 'eds_publication_type'
+    config.index.fulltext_links_field = 'eds_fulltext_links'
     config.index.document_actions = [] # Uncomment to add bookmark toggles to results
 
     # Configured index fields not used

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -17,4 +17,9 @@ module ArticleHelper
     url = 'https://doi.org/' + doi.to_s
     link_to(doi, url)
   end
+
+  def article_restricted?(document)
+    # TODO: we probably need a better way to determine this
+    document['eds_title'] =~ /^This title is unavailable for guests, please login to see more information./
+  end
 end

--- a/app/presenters/concerns/presenter_fulltext_links.rb
+++ b/app/presenters/concerns/presenter_fulltext_links.rb
@@ -1,0 +1,8 @@
+module PresenterFulltextLinks
+  def fulltext_links
+    field_key = configuration.index.fulltext_links_field
+    document[field_key].collect do |link|
+      "<li class=\"article-fulltext-link\">#{view_context.link_to(link['label'] || link['url'], link['url'])}</li>".html_safe
+    end
+  end
+end

--- a/app/presenters/index_document_presenter.rb
+++ b/app/presenters/index_document_presenter.rb
@@ -1,3 +1,4 @@
 class IndexDocumentPresenter < Blacklight::IndexPresenter
   include PresenterFormat
+  include PresenterFulltextLinks
 end

--- a/app/presenters/show_document_presenter.rb
+++ b/app/presenters/show_document_presenter.rb
@@ -1,3 +1,4 @@
 class ShowDocumentPresenter < Blacklight::ShowPresenter
   include PresenterFormat
+  include PresenterFulltextLinks
 end

--- a/app/views/article/_index_default.html.erb
+++ b/app/views/article/_index_default.html.erb
@@ -17,3 +17,8 @@
     <li><%= doc_presenter.field_value('eds_abstract') %></li>
   <% end %>
 </ul>
+<% if document['eds_fulltext_links'].present? && !article_restricted?(document) %>
+  <ul class='document-metadata dl-horizontal dl-invert'>
+    <%= safe_join(doc_presenter.fulltext_links) %>
+  </ul>
+<% end %>

--- a/app/views/article/show.html.erb
+++ b/app/views/article/show.html.erb
@@ -2,5 +2,12 @@
   <div id="doc_<%= @document.id.to_s.parameterize %>">
     <% # bookmark/folder functions -%>
     <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+    <% if @document['eds_fulltext_links'].present? && !article_restricted?(@document) %>
+    <dl class="dl-horizontal dl-invert"><dt>Links:</dt><dd>
+      <ul class='document-metadata dl-horizontal dl-invert'>
+        <%= safe_join(presenter(@document).fulltext_links) %>
+      </ul>
+    </dd></dl>
+    <% end %>
   </div>
 </div>

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe ArticleHelper do
-  let(:field) { { value: Array.wrap('abc') } }
-
   describe '#article_search?' do
     context 'when in the ArticlesController' do
       before { expect(helper).to receive_messages(controller_name: 'article') }
@@ -17,9 +15,11 @@ RSpec.describe ArticleHelper do
     end
   end
 
-  it '#doi_link' do
-    result = helper.doi_link(field)
-    expect(result).to have_css('a @href', text: 'https://doi.org/abc')
-    expect(result).to have_css('a', text: 'abc')
+  context '#doi_link' do
+    it 'renders a link by appending the value to the DOI resolver' do
+      result = helper.doi_link(value: Array.wrap('abc'))
+      expect(result).to have_css('a @href', text: 'https://doi.org/abc')
+      expect(result).to have_css('a', text: 'abc')
+    end
   end
 end

--- a/spec/presenters/presenter_fulltext_links_spec.rb
+++ b/spec/presenters/presenter_fulltext_links_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe PresenterFulltextLinks do
+  subject(:presenter) do
+    Class.new do
+      include PresenterFulltextLinks
+    end.new
+  end
+
+  let(:view_context) do
+    Class.new do
+      include ActionView::Helpers::UrlHelper
+    end.new
+  end
+
+  let(:document) { { 'eds_fulltext_links' => Array.wrap({ 'label' => 'My label', 'url' => 'http://example.com' }) } }
+
+  before do
+    config = double(Blacklight::Configuration, index: double(fulltext_links_field: 'eds_fulltext_links'))
+    expect(presenter).to receive(:configuration).and_return(config)
+    expect(presenter).to receive(:view_context).and_return(view_context)
+    expect(presenter).to receive(:document).and_return(document)
+  end
+
+  context '#fulltext_links' do
+    it 'assumes EDS API returns a hash with label and url'
+    it 'renders a list of labeled links' do
+      result = Capybara.string(presenter.fulltext_links.first)
+      expect(result).to have_css('li.article-fulltext-link', count: 1)
+      expect(result).to have_css('li a', text: 'My label')
+      expect(result).to have_css('li a @href', text: 'http://example.com')
+    end
+    it 'uses the URL as a label when label is missing' do
+      document['eds_fulltext_links'].first.delete('label')
+      result = Capybara.string(presenter.fulltext_links.first)
+      expect(result).to have_css('li.article-fulltext-link', count: 1)
+      expect(result).to have_css('li a', text: 'http://example.com')
+      expect(result).to have_css('li a @href', text: 'http://example.com')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #1399.

### On shows page
![screen shot 2017-06-28 at 1 19 18 pm](https://user-images.githubusercontent.com/1861171/27658766-ef2f4128-5c05-11e7-8e06-da738cd1ead6.png)

### On results page
![screen shot 2017-06-28 at 1 19 32 pm](https://user-images.githubusercontent.com/1861171/27658767-f0db701e-5c05-11e7-8496-def126ab3186.png)
