### PR TITLE
persist the EDS session token between Blacklight sessions

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -10,7 +10,6 @@ class ArticleController < ApplicationController
   before_action :eds_init, only: %i[index show]
   # TODO: probably need to move this into an Eds::SearchService initializer
   def eds_init
-    session['guest'] = true # TODO: hardcoded to non-authenticated
     setup_eds_session(session)
   end
 
@@ -74,7 +73,7 @@ class ArticleController < ApplicationController
 
   def search_service
     eds_params = {
-      'guest' => session['guest'],
+      'guest' => true, # TODO: hardcoded to non-authenticated
       'session_token' => session['eds_session_token']
     }
     Eds::SearchService.new(blacklight_config, search_state.to_h, eds_params)
@@ -89,7 +88,7 @@ class ArticleController < ApplicationController
   def setup_eds_session(session)
     return if session['eds_session_token'].present?
     session['eds_session_token'] = EBSCO::EDS::Session.new(
-      guest: session['guest'],
+      guest: true, # TODO: hardcoded to non-authenticated
       caller: 'new-session',
       user: Settings.EDS_USER,
       pass: Settings.EDS_PASS,

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -11,15 +11,7 @@ class ArticleController < ApplicationController
   # TODO: probably need to move this into an Eds::SearchService initializer
   def eds_init
     session['guest'] = true # TODO: hardcoded to non-authenticated
-    session['eds_session_token'] =
-      EBSCO::EDS::Session.new(
-        guest: true, # TODO: hardcoded to non-authenticated
-        caller: 'new-session',
-        user: Settings.EDS_USER,
-        pass: Settings.EDS_PASS,
-        profile: Settings.EDS_PROFILE,
-        debug: Settings.EDS_DEBUG
-      ).session_token
+    setup_eds_session(session)
   end
 
   configure_blacklight do |config|
@@ -90,5 +82,19 @@ class ArticleController < ApplicationController
 
   def set_search_query_modifier
     @search_modifier ||= SearchQueryModifier.new(params, blacklight_config)
+  end
+
+  # Reuse the EDS session token if available in the user's session data,
+  # otherwise establish a session
+  def setup_eds_session(session)
+    return if session['eds_session_token'].present?
+    session['eds_session_token'] = EBSCO::EDS::Session.new(
+      guest: session['guest'],
+      caller: 'new-session',
+      user: Settings.EDS_USER,
+      pass: Settings.EDS_PASS,
+      profile: Settings.EDS_PROFILE,
+      debug: Settings.EDS_DEBUG
+    ).session_token
   end
 end

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -30,4 +30,21 @@ RSpec.describe ArticleController do
       get :show, params: { id: 123 }
     end
   end
+
+  context 'EDS Session Management' do
+    let(:user_session) { {} }
+    let(:eds_session) { instance_double(EBSCO::EDS::Session, session_token: 'abc') }
+    before { allow(controller).to receive(:session).and_return(user_session) }
+    it 'will create a new session' do
+      expect(EBSCO::EDS::Session).to receive(:new).with(
+        hash_including(caller: 'new-session')
+      ).and_return(eds_session)
+      controller.eds_init
+    end
+    it 'will reuse the session if in the user session data' do
+      user_session['eds_session_token'] = 'def'
+      expect(EBSCO::EDS::Session).not_to receive(:new)
+      controller.eds_init
+    end
+  end
 end

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ArticleController do
     before { allow(controller).to receive(:session).and_return(user_session) }
     it 'will create a new session' do
       expect(EBSCO::EDS::Session).to receive(:new).with(
-        hash_including(caller: 'new-session')
+        hash_including(caller: 'new-session', guest: true)
       ).and_return(eds_session)
       controller.eds_init
     end


### PR DESCRIPTION
This PR fixes #1412.

Verified that it's working correctly with Bill and Eric on Slack. Basically you can look at the Faraday logs to see the API traffic (set EDS_DEBUG=true in your setteings). It should not issue a CreateSession call unless you clear your browser cookies.