### PR TITLE
Configure and render facets.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.1.6.pre)
+    ebsco-eds (0.1.7.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -67,6 +67,23 @@ class ArticleController < ApplicationController
     config.add_show_field 'eds_abstract', label: 'Abstract'
     config.add_show_field 'eds_subjects', label: 'Subjects'
     config.add_show_field 'eds_document_doi', label: 'DOI', helper_method: :doi_link
+
+    # Facet field configuration
+    config.add_facet_field 'eds_publication_type_facet', label: 'Source type'
+    config.add_facet_field 'eds_language_facet', label: 'Language' # , limit: 20 TODO: Need to handle facet limiting
+    config.add_facet_field 'eds_subject_topic_facet', label: 'Topic'
+    config.add_facet_field 'eds_subjects_geographic_facet', label: 'Geography'
+    config.add_facet_field 'eds_journal_facet', label: 'Journal title'
+    config.add_facet_field 'eds_publisher_facet', label: 'Publisher'
+    config.add_facet_field 'eds_content_provider_facet', label: 'Database'
+
+    # Other available facets
+    # config.add_facet_field 'eds_search_limiters_facet', label: 'Limiters'
+    # config.add_facet_field 'eds_publication_year_facet', label: 'Publication Year'
+    # config.add_facet_field 'eds_category_facet', label: 'Category'
+    # config.add_facet_field 'eds_library_location_facet', label: 'Library'
+    # config.add_facet_field 'eds_library_collection_facet', label: 'Location'
+    # config.add_facet_field 'eds_author_university_facet', label: 'University'
   end
 
   def index

--- a/app/views/article/index.html.erb
+++ b/app/views/article/index.html.erb
@@ -1,5 +1,6 @@
 <div class='row'>
   <div id="sidebar" class="col-md-4 col-sm-5">
+    <%= render 'search_sidebar' %>
   </div>
   <div id="content" class="col-md-8 col-sm-7">
     <div id='documents' class="article-search-results">


### PR DESCRIPTION
Closes #1398 

Consideration for pulling into a separate ticket: More facet modal

A few notes on behavior (not sure if these things are configureable on the ebsco side):
* The facets appear to be `OR` not `AND` like our catalog search facets are
* Some facets appear to not return the selected value in the facet response (e.g. Language), so the only way to remove the facet would be by the breadcrumb.
* Some facets appear to not be returned at all once a value is selected (e.g. Publisher), which might just be a symptom of the issue above.

![article-facets](https://user-images.githubusercontent.com/96776/27617098-0a1b3430-5b69-11e7-8f6f-cffe26bf94bb.gif)