### PR TITLE
right align the Selections pulldown in the gray bar

### DIFF
--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -31,6 +31,12 @@
     }
   }
 
+  // the last menu item should be right-aligned
+  .navbar-nav > li:last-child > a {
+    margin-right: 0;
+    padding-right: 0;
+  }
+
   // For dropdowns
   .dropdown-menu {
     background-color: $sul-subnavbar-bg-color;


### PR DESCRIPTION
A minor tweak to the gray navbar alignment.

### After 
![screen shot 2017-06-30 at 10 30 47 am](https://user-images.githubusercontent.com/1861171/27747267-57ec1ec8-5d7f-11e7-8e25-8f63e3d0563d.png)

### Before
![screen shot 2017-06-30 at 10 31 11 am](https://user-images.githubusercontent.com/1861171/27747273-5a8ffc12-5d7f-11e7-9562-c3267db467ea.png)
