### PR TITLE
Update article record view to have initial layout and…

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -23,7 +23,6 @@ class ArticleController < ApplicationController
     config.index.show_link = 'eds_title'
     config.index.display_type_field = 'eds_publication_type'
     config.index.fulltext_links_field = 'eds_fulltext_links'
-    config.index.document_actions = [] # Uncomment to add bookmark toggles to results
 
     # Configured index fields not used
     # config.add_index_field 'author_display', label: 'Author'
@@ -110,7 +109,7 @@ class ArticleController < ApplicationController
   end
 
   def show
-    _deprecated_response, @document = search_service.fetch(params[:id])
+    @response, @document = search_service.fetch(params[:id])
   end
 
   def new; end

--- a/app/services/eds/search_service.rb
+++ b/app/services/eds/search_service.rb
@@ -39,7 +39,7 @@ module Eds
 
     def fetch_one(id, extra_controller_params)
       solr_response = @repository.find id, extra_controller_params, @eds_params
-      [nil, solr_response.documents.first]
+      [solr_response, solr_response.documents.first]
     end
   end
 end

--- a/app/views/article/_bookmark_control.html.erb
+++ b/app/views/article/_bookmark_control.html.erb
@@ -1,0 +1,4 @@
+<%
+  # intentionally left blank to prevent the bookmark partial from
+  # rendering until we can hook that behavior up for article records
+%>

--- a/app/views/article/_show_default.html.erb
+++ b/app/views/article/_show_default.html.erb
@@ -1,0 +1,9 @@
+<%  %>
+<div class="record-metadata row">
+  <div class="record-panels col-md-4">
+    <%= render "article/record/metadata_panels", document: document %>
+  </div>
+  <div class="record-sections col-md-8">
+    <%= render "catalog/show_default", document: document %>
+  </div>
+</div>

--- a/app/views/article/access_panels/_online.html.erb
+++ b/app/views/article/access_panels/_online.html.erb
@@ -1,0 +1,13 @@
+<% doc_presenter = presenter(document) %>
+<div class="panel panel-default access-panel panel-online">
+  <div class="access-panel-heading panel-heading">
+    <h3>
+      Available online
+    </h3>
+  </div>
+  <div class="panel-body">
+    <ul class='document-metadata dl-horizontal dl-invert'>
+      <%= safe_join(presenter(document).fulltext_links) %>
+    </ul>
+  </div>
+</div>

--- a/app/views/article/record/_metadata_panels.html.erb
+++ b/app/views/article/record/_metadata_panels.html.erb
@@ -1,0 +1,3 @@
+<div class="metadata-panels">
+  <%= render('article/access_panels/online', document: document) if document.access_panels.online? %>
+</div>

--- a/app/views/article/show.html.erb
+++ b/app/views/article/show.html.erb
@@ -1,13 +1,16 @@
-<div id="document" class="document article-search-show <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">
-  <div id="doc_<%= @document.id.to_s.parameterize %>">
-    <% # bookmark/folder functions -%>
-    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
-    <% if @document['eds_fulltext_links'].present? && !article_restricted?(@document) %>
-    <dl class="dl-horizontal dl-invert"><dt>Links:</dt><dd>
-      <ul class='document-metadata dl-horizontal dl-invert'>
-        <%= safe_join(presenter(@document).fulltext_links) %>
-      </ul>
-    </dd></dl>
-    <% end %>
+<div class="row">
+  <div id="content" class="col-md-12 show-document">
+    <%= render "catalog/record/record_toolbar" %>
+
+    <% @page_title = t 'blacklight.search.show.title_html', document_title: document_show_html_title, application_name: application_name %>
+    <% # content_for(:head) { render_link_rel_alternates } Commented out for now %>
+
+    <div id="document" class="document article-search-show <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">
+      <div id="doc_<%= @document.id.to_s.parameterize %>">
+
+        <% # bookmark/folder functions -%>
+        <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/catalog/record/_record_toolbar.html.erb
+++ b/app/views/catalog/record/_record_toolbar.html.erb
@@ -33,7 +33,7 @@
           </ul>
         </li>
         <li>
-          <%= render(:partial => 'catalog/bookmark_control', :locals => {:document=> @document}) %>
+          <%= render(:partial => 'bookmark_control', :locals => {:document=> @document}) %>
         </li>
 
       </ul>

--- a/lib/access_panels/online.rb
+++ b/lib/access_panels/online.rb
@@ -1,8 +1,14 @@
 class AccessPanels
   class Online < ::AccessPanel
-    delegate :present?, to: :links
     def links
       sfx_links || marc_fulltext_links
+    end
+
+    # We are using present? for both marc/solr links but also EDS links
+    # We'll use another method of accessing the EDS links given that they
+    # don't match the same format/behavior as the marc/solr links
+    def present?
+      links.present? || @document['eds_fulltext_links'].present?
     end
 
     private

--- a/spec/lib/access_panels/online_spec.rb
+++ b/spec/lib/access_panels/online_spec.rb
@@ -6,6 +6,7 @@ describe AccessPanels::Online do
 
   let(:fulltext) { described_class.new(SolrDocument.new(marcxml: fulltext_856)) }
   let(:supplemental) { described_class.new(SolrDocument.new(marcxml: supplemental_856)) }
+  let(:eds_links) { described_class.new(SolrDocument.new(eds_fulltext_links: ['link-object'])) }
 
   let(:sfx) do
     described_class.new(
@@ -41,9 +42,18 @@ describe AccessPanels::Online do
     )
   end
 
-  it 'should delegate present? to links' do
-    expect(fulltext).to be_present
-    expect(supplemental).to_not be_present
+  describe '#present?' do
+    it 'is true when there are fulltext links present' do
+      expect(fulltext).to be_present
+    end
+
+    it 'is true when there are eds links present' do
+      expect(eds_links).to be_present
+    end
+
+    it 'is false when there are only supplemental links present' do
+      expect(supplemental).to_not be_present
+    end
   end
 
   describe '#links' do

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe 'article/access_panels/_online.html.erb' do
+  let(:document) do
+    SolrDocument.new(
+      fulltext_link_field: [{ 'label' => 'Link Label', 'url' => 'http://example.com' }]
+    )
+  end
+
+  let(:blacklight_config) do
+    Blacklight::Configuration.new do |config|
+      config.index.fulltext_links_field = :fulltext_link_field
+      config.show.document_presenter_class = ShowDocumentPresenter
+    end
+  end
+
+  before do
+    expect(view).to receive(:presenter).at_least(:once).and_return(
+      ShowDocumentPresenter.new(document, view, blacklight_config)
+    )
+
+    expect(view).to receive_messages(document: document)
+    render
+  end
+
+  it 'renders the panel' do
+    expect(rendered).to have_css('.panel.access-panel.panel-online')
+  end
+
+  it 'has the proper heading' do
+    expect(rendered).to have_css('.panel-heading h3', text: 'Available online')
+  end
+
+  it 'includes EDS fulltext links' do
+    expect(rendered).to have_css('.panel-body ul li a', text: 'Link Label')
+  end
+end


### PR DESCRIPTION
…one online access panel.

Closes #1409 

<img width="972" alt="article-record-view" src="https://user-images.githubusercontent.com/96776/27747897-229d9ae6-5d82-11e7-8235-db69eeeff5ed.png">
