### PR TITLE
add Brief index view

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -102,6 +102,12 @@ class ArticleController < ApplicationController
     # config.add_facet_field 'eds_library_location_facet', label: 'Library'
     # config.add_facet_field 'eds_library_collection_facet', label: 'Location'
     # config.add_facet_field 'eds_author_university_facet', label: 'University'
+
+    # View type group config
+    config.view.list.icon_class = "fa-th-list"
+    config.view.brief ||= OpenStruct.new
+    config.view.brief.partials = %i[index]
+    config.view.brief.icon_class = "fa-align-justify"
   end
 
   def index

--- a/app/views/article/_index_brief_default.html.erb
+++ b/app/views/article/_index_brief_default.html.erb
@@ -1,0 +1,20 @@
+<% doc_presenter = presenter(document) %>
+<% # header bar for doc items in index view %>
+<div class="documentHeader row">
+  <h3 class="index_title col-sm-9 col-lg-10">
+    <% counter = document_counter_with_offset(document_counter) %>
+    <%= render_resource_icon doc_presenter.formats %>
+    <span class="document-counter">
+      <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+    </span>
+    <%= link_to_document document, get_main_title(document), :counter => counter %>
+    <span class="main-title-date"><%= get_main_title_date(document) %></span>
+    <%= document.online_label %>
+  </h3>
+</div>
+
+<% if document['eds_fulltext_links'].present? && !article_restricted?(document) %>
+  <ul class='document-metadata dl-horizontal dl-invert'>
+    <%= safe_join(doc_presenter.fulltext_links) %>
+  </ul>
+<% end %>

--- a/app/views/article/_search_header.html.erb
+++ b/app/views/article/_search_header.html.erb
@@ -2,6 +2,7 @@
   <div class="container-fluid">
     <%= render partial: "catalog/paginate_compact", object: @response %>
     <div id="search-results-toolbar" class="search-widgets pull-right">
+      <%= render partial: 'catalog/view_type_group' %>
       <%= render partial: 'shared/per_page_widget' %>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes #1424. The View menu is pulled right for now.

### Pulldown
![screen shot 2017-07-05 at 12 39 08 pm](https://user-images.githubusercontent.com/1861171/27881907-4e672e02-617f-11e7-9954-736aa7929c51.png)

### Hit
![screen shot 2017-07-05 at 12 39 24 pm](https://user-images.githubusercontent.com/1861171/27881906-4e664f50-617f-11e7-9047-5456da661cb3.png)

