### PR TITLE
add Sort dropdown for Article search

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -143,6 +143,11 @@ class ArticleController < ApplicationController
     config.view.brief ||= OpenStruct.new
     config.view.brief.partials = %i[index]
     config.view.brief.icon_class = "fa-align-justify"
+
+    # Sorting, using EDS sort keys
+    config.add_sort_field 'relevance', sort: 'score desc', label: 'relevance'
+    config.add_sort_field 'newest', sort: 'newest', label: 'date (most recent)'
+    config.add_sort_field 'oldest', sort: 'oldest', label: 'date (oldest)'
   end
 
   def index

--- a/app/views/article/_search_header.html.erb
+++ b/app/views/article/_search_header.html.erb
@@ -3,6 +3,7 @@
     <%= render partial: "catalog/paginate_compact", object: @response %>
     <div id="search-results-toolbar" class="search-widgets pull-right">
       <%= render partial: 'catalog/view_type_group' %>
+      <%= render partial: 'sort_widget' %>
       <%= render partial: 'shared/per_page_widget' %>
     </div>
   </div>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Article Searching' do
   describe 'Search bar dropdown', js: true do
     scenario 'allows the user to switch to the article search context' do
-      stub_article_service(docs: [SolrDocument.new(id: 'abc123')])
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit root_path
 
       within '.search-dropdown' do
@@ -32,14 +32,14 @@ feature 'Article Searching' do
 
   describe 'articles index page' do
     scenario 'renders home page if no search parameters are present' do
-      stub_article_service(docs: [SolrDocument.new(id: 'abc123')])
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit article_index_path
       expect(page).to have_css('.home-page-column', count: 3)
       expect(page).to have_css('h1', text: /Find journal articles/)
     end
 
     scenario 'renders results page if search parameters are present' do
-      stub_article_service(docs: [SolrDocument.new(id: 'abc123')])
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit article_index_path
       within '.search-form' do
         fill_in 'q', with: 'Kittens'
@@ -52,12 +52,8 @@ feature 'Article Searching' do
   end
 
   scenario 'article records are navigable from search results' do
-    results = [
-      SolrDocument.new(id: 'abc123', eds_title: 'The title of the document'),
-      SolrDocument.new(id: '321cba', eds_title: 'Another title for the document')
-    ]
-    stub_article_service(docs: results)
-    stub_article_service(type: :single, docs: [results.first]) # just a single document for the record view
+    stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+    stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first]) # just a single document for the record view
 
     visit article_index_path
 
@@ -77,7 +73,7 @@ feature 'Article Searching' do
 
   describe 'breadcrumbs', js: true do
     scenario 'start over button returns users to articles home page' do
-      stub_article_service(docs: [SolrDocument.new(id: 'abc123')])
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit article_index_path
 
       within '.search-form' do
@@ -93,7 +89,7 @@ feature 'Article Searching' do
     end
 
     scenario 'removing last breadcrumb redirects to articles home' do
-      stub_article_service(docs: [SolrDocument.new(id: 'abc123')])
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit article_index_path
 
       within '.search-form' do

--- a/spec/features/sort_and_per_page_dropdown_spec.rb
+++ b/spec/features/sort_and_per_page_dropdown_spec.rb
@@ -84,4 +84,38 @@ describe 'Sort and per page toolbar', js: true, feature: true do
       end
     end
   end
+
+  describe 'Article search' do
+    before do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+      visit article_index_path q: 'my search'
+    end
+    it 'has a sort dropdown' do
+      within '#sort-dropdown' do
+        expect(page).to have_css('button.btn.btn-sul-toolbar', text: 'Sort by relevance')
+      end
+    end
+    it 'sort dropdown brings up options' do
+      within '#sort-dropdown' do
+        page.find('button.btn.btn-sul-toolbar').click
+        expect(page).to have_css('a', text: 'relevance', visible: true)
+        expect(page).to have_css('a', text: 'date (most recent)', visible: true)
+        expect(page).to have_css('a', text: 'date (oldest)', visible: true)
+      end
+    end
+    it 'has a per page dropdown' do
+      within '#per_page-dropdown' do
+        expect(page).to have_css('button.btn.btn-sul-toolbar', text: 'per page')
+      end
+    end
+    it 'per page dropdown brings up options' do
+      within '#per_page-dropdown' do
+        page.find('button.btn.btn-sul-toolbar').click
+        expect(page).to have_css('a', text: '10 per page', visible: true)
+        expect(page).to have_css('a', text: '20 per page', visible: true)
+        expect(page).to have_css('a', text: '50 per page', visible: true)
+        expect(page).to have_css('a', text: '100 per page', visible: true)
+      end
+    end
+  end
 end

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -57,6 +57,10 @@ module StubArticleService
     def rows
       documents.count
     end
+
+    def sort
+      'score desc'
+    end
   end
 end
 

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -1,6 +1,12 @@
 ##
 # Module included for RSpec tests to stub the article search service
 module StubArticleService
+  SAMPLE_RESULTS = [
+      SolrDocument.new(id: 'abc123', eds_title: 'The title of the document'),
+      SolrDocument.new(id: '321cba', eds_title: 'Another title for the document'),
+      SolrDocument.new(id: 'wqoeif', eds_title: 'Yet another title for the document')
+  ]
+
   def stub_article_service(type: :multiple, docs:)
     raise 'Article search service stubbed without any documents.' if docs.blank?
 


### PR DESCRIPTION
This PR fixes #1449. Note in the screenshot the styling is done in another PR. It also relocates some sample Article search results into the `StubArticleService` class for reuse.

![screen shot 2017-07-11 at 11 22 29 am](https://user-images.githubusercontent.com/1861171/28084148-94c74dee-662c-11e7-8485-88a34e2095b7.png)
