### PR TITLE
Change Prev/Next from disabled to hidden on search results

### DIFF
--- a/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
+++ b/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
@@ -11,7 +11,7 @@
   }
 
   .page_links {
-    padding: 0 0 0 0;
+    padding: 0px 10px;
   }
 
   .page_entries {

--- a/app/views/kaminari/blacklight_compact/_next_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_next_page.html.erb
@@ -6,8 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<% if current_page.last? %>
-  <%= link_to raw(t 'views.pagination_compact.next'), "#", :rel => 'next', class: 'btn btn-sul-toolbar disabled', role: 'button', :remote => remote %>
-<% else %>
+<% unless current_page.last? %>
   <%= link_to raw(t 'views.pagination_compact.next'), url, :rel => 'next', class: 'btn btn-sul-toolbar', role: 'button', :remote => remote %>
 <% end %>

--- a/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -26,4 +26,11 @@
       <%= next_page_tag %>
     </div>
   <% end -%>
+<% else -%>
+  <%# we still want the "1-n" to show up -%>
+  <div class="page_links pull-left">
+    <span class="page_entries">
+      <%= page_entries_info %>
+    </span>
+  </div>
 <% end -%>

--- a/app/views/kaminari/blacklight_compact/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_prev_page.html.erb
@@ -6,8 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<% if current_page.first? %>
-  <%= link_to raw(t 'views.pagination_compact.previous'), '#', :rel => 'prev', class: 'btn btn-sul-toolbar disabled', role: 'button', :remote => remote %>
-<% else %>
+<% unless current_page.first? %>
   <%= link_to raw(t 'views.pagination_compact.previous'), url, :rel => 'prev', class: 'btn btn-sul-toolbar', role: 'button', :remote => remote %>
 <% end %>

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -10,7 +10,7 @@ feature "Results Toolbar", js: true do
 
     within "#sortAndPerPage" do
       within "div.page_links" do
-        expect(page).to have_css("a.btn.btn-sul-toolbar.disabled", text: /Previous/, visible: true)
+        expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: /Previous/)
         expect(page).to have_css("span.page_entries", text: /1 - 20/, visible: true)
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: /Next/, visible: true)
       end
@@ -28,20 +28,20 @@ feature "Results Toolbar", js: true do
     click_button 'search'
 
     within('.sul-toolbar') do
-      expect(page).to_not have_css('.page_links')
+      expect(page).to have_css('.page_links')
       expect(page).to_not have_content('1 entry')
     end
   end
   scenario "pagination links for multiple items but no pages should not have any number of results info" do
-    visit root_path
-    fill_in "q", with: '34'
-    click_button 'search'
+    visit root_path q: '34'
 
     expect(page).to have_css('h2', text: '4 results')
 
-    within('.sul-toolbar') do
-      expect(page).to_not have_css('.page_links')
-      expect(page).to_not have_content('1 - 4')
+    within('.sul-toolbar .page_links') do
+      expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: /Previous/)
+      expect(page).to have_css("span.page_entries", text: /1 - 4/)
+      expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: /Next/)
+
     end
   end
 end

--- a/spec/features/responsive/results_toolbar_spec.rb
+++ b/spec/features/responsive/results_toolbar_spec.rb
@@ -10,7 +10,7 @@ describe "Responsive results toolbar", js: true, feature: true do
     it "should display correct tools" do
       within "#sortAndPerPage" do
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Next", visible: true)
-        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: true)
+        expect(page).to_not have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar i.fa.fa-th-list", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar", text: "View", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar", text: "Sort by relevance", visible: true)
@@ -24,7 +24,7 @@ describe "Responsive results toolbar", js: true, feature: true do
       within "#sortAndPerPage" do
         page.driver.resize("800", "800")
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Next", visible: true)
-        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: true)
+        expect(page).to_not have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: true)
         expect(page).to_not have_css("button.btn.btn-sul-toolbar i.fa.fa-th-list", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar", text: "View", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar", text: "20", visible: true)
@@ -37,7 +37,7 @@ describe "Responsive results toolbar", js: true, feature: true do
       page.driver.resize("700", "700")
       within "#sortAndPerPage" do
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Next", visible: false)
-        expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: false)
+        expect(page).to_not have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: false)
         expect(page).to_not have_css("button.btn.btn-sul-toolbar i.fa.fa-th-list", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar", text: "View", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar", text: "20", visible: true)


### PR DESCRIPTION
This PR fixes #1423. See screenshots for various cases.

### Normal first page
![screen shot 2017-07-11 at 1 25 23 pm](https://user-images.githubusercontent.com/1861171/28089905-5b0ff43a-663f-11e7-89da-b910ad7280ed.png)

### A single result
![screen shot 2017-07-11 at 1 24 35 pm](https://user-images.githubusercontent.com/1861171/28089915-68dd0ee0-663f-11e7-8bd1-9783a0900cfe.png)

### Single page results
![screen shot 2017-07-11 at 1 24 53 pm](https://user-images.githubusercontent.com/1861171/28089965-93e3642c-663f-11e7-830d-98e48d989173.png)

### Middle page of results
![screen shot 2017-07-11 at 1 27 56 pm](https://user-images.githubusercontent.com/1861171/28089954-883a2b4c-663f-11e7-8e87-44592206eecb.png)

### Last page of results
![screen shot 2017-07-11 at 1 26 34 pm](https://user-images.githubusercontent.com/1861171/28089935-7ab91fdc-663f-11e7-992e-f4b1a98158f2.png)
