### PR TITLE
Searchbar dropdown UI updates

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -15,10 +15,8 @@ a, a:hover, a:focus {
 }
 
 h1 {
-  font-family: 'dejavu_sansextralight';
   color: $sul-h1-font-color;
   padding: 10px 0;
-  letter-spacing: -.05em;
 }
 
 h2 {

--- a/app/assets/stylesheets/modules/record-view.scss
+++ b/app/assets/stylesheets/modules/record-view.scss
@@ -17,6 +17,10 @@ $show-title-left-margin: 40px;
 }
 
 .document {
+  h1 {
+    @include h1-show-title-font;
+  }
+
   .metadata-panels {
     margin-top: 10px;
   }

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -33,6 +33,7 @@
 
       .dropdown-menu {
         left: auto;
+        top: 70%;
 
         li.active > a {
           background-color: $public-note-yellow;
@@ -100,6 +101,12 @@
       margin-top: 5px;
       text-align: center;
       width: 100%;
+      
+      .search-dropdown {
+        .dropdown-menu {
+          top: 45%;
+        }
+      }
     }
 
     .search-target {

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -54,13 +54,17 @@
   }
 
   .search-target {
-    border-bottom: $white dashed 1px;
+    border-bottom: $white dashed 2px;
     color: $white;
-    display: inline-table;
-    font-size: 22px;
-    font-weight: 100;
-    margin: 39px 0 0;
+    margin: 3px 0;
     padding: 0;
+
+    h1 {
+      color: $white;
+      display: inline-block;
+      margin: 30px 0 0;
+      padding: 0;
+    }
   }
 
   @media screen and (max-width: $screen-md-min) {
@@ -101,7 +105,11 @@
     .search-target {
       float: none;
       margin-top: 5px;
-      vertical-align: middle;
+      vertical-align: baseline;
+
+      h1 {
+        margin-top: 0;
+      }
     }
 
     #searchworks-logo {
@@ -109,7 +117,7 @@
 
       img {
         display: inline-block;
-        height: 24px;
+        vertical-align: baseline;
       }
     }
   }

--- a/app/assets/stylesheets/searchworks-mixins.scss
+++ b/app/assets/stylesheets/searchworks-mixins.scss
@@ -21,6 +21,11 @@
   }
 }
 
+@mixin h1-show-title-font {
+  font-family: 'dejavu_sansextralight';
+  letter-spacing: -.03em;
+}
+
 @mixin h3-index-title-indent {
   text-indent: -12px;
 }

--- a/app/views/catalog/_search_targets_widget.html.erb
+++ b/app/views/catalog/_search_targets_widget.html.erb
@@ -1,13 +1,15 @@
 <div class="search-dropdown">
   <a href="#" class="dropdown-toggle navbar-text search-target" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <span class="sr-only">search</span>
-    <% if article_search?  %>
-      <%= t('searchworks.search_dropdown.articles.label') %>
-    <% else %>
-      <%= t('searchworks.search_dropdown.catalog.label') %>
-    <% end %>
+    <h1>
+      <span class="sr-only">search</span>
+      <% if article_search?  %>
+        <%= t('searchworks.search_dropdown.articles.label') %>
+      <% else %>
+        <%= t('searchworks.search_dropdown.catalog.label') %>
+      <% end %>
 
-    <span class="caret"></span>
+      <span class="caret"></span>
+    </h1>
   </a>
    <ul class="dropdown-menu" role="menu">
      <li class="<%= 'active' unless article_search? %>">


### PR DESCRIPTION
This PR makes updates to the search bar UI. 

- Restricts dejavu font to record titles and uses Source Sans Pro for other h1s
- Adds `<h1>` to the search context dropdown for accessibility purposes
- Adds spans for styling dropdown labels
- Adjusts positioning of the search context dropdown

## Demo

![restyled_searchbar](https://user-images.githubusercontent.com/5402927/28143559-0cea016a-671b-11e7-8808-98734cacf35f.gif)