### PR TITLE
Unlink subject terms in article search results

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -30,22 +30,10 @@ class ArticleController < ApplicationController
     config.index.display_type_field = 'eds_publication_type'
     config.index.fulltext_links_field = 'eds_fulltext_links'
 
-    # Configured index fields not used
-    # config.add_index_field 'author_display', label: 'Author'
-    # config.add_index_field 'id'
-
-    # Summary
     config.add_index_field "eds_authors", label: 'Authors'
-    config.add_index_field "eds_author_affiliations", label: 'Author Affiliations'
     config.add_index_field "eds_composed_title", label: 'Composed Title', helper_method: :strip_html_from_solr_field
-    config.add_index_field "eds_publication_date", label: 'Publication Date'
-    config.add_index_field "eds_languages", label: 'Language'
-
-    # Subjects
     config.add_index_field "eds_subjects", label: 'Subjects'
-    config.add_index_field "eds_subjects_geographic", label: 'Geography'
-    config.add_index_field "eds_subjects_person", label: 'Person Subjects'
-    config.add_index_field "eds_author_supplied_keywords", label: 'Author Supplied Keywords'
+    config.add_index_field "eds_abstract", label: 'Abstract', helper_method: :strip_html_from_solr_field
 
     config.add_search_field('search') do |field|
       field.label = 'All fields'

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -34,6 +34,19 @@ class ArticleController < ApplicationController
     # config.add_index_field 'author_display', label: 'Author'
     # config.add_index_field 'id'
 
+    # Summary
+    config.add_index_field "eds_authors", label: 'Authors'
+    config.add_index_field "eds_author_affiliations", label: 'Author Affiliations'
+    config.add_index_field "eds_composed_title", label: 'Composed Title', helper_method: :strip_html_from_solr_field
+    config.add_index_field "eds_publication_date", label: 'Publication Date'
+    config.add_index_field "eds_languages", label: 'Language'
+
+    # Subjects
+    config.add_index_field "eds_subjects", label: 'Subjects'
+    config.add_index_field "eds_subjects_geographic", label: 'Geography'
+    config.add_index_field "eds_subjects_person", label: 'Person Subjects'
+    config.add_index_field "eds_author_supplied_keywords", label: 'Author Supplied Keywords'
+
     config.add_search_field('search') do |field|
       field.label = 'All fields'
     end
@@ -118,7 +131,6 @@ class ArticleController < ApplicationController
     config.show.sections.each do |_section, fields|
       fields.each do |field, options|
         config.add_show_field field.to_s, options
-        config.add_index_field field.to_s, options.except(:separator_options)
       end
     end
 

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -46,17 +46,28 @@ feature 'Article Searching' do
     end
   end
 
-  scenario 'article records are navigable from search results' do
-    stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first]) # just a single document for the record view
-
-    article_search_for('Kittens')
-
-    within(first('.document')) do
-      click_link 'The title of the document'
+  describe 'article search results' do
+    scenario 'subjects are not linked' do
+      stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first])
+      article_search_for('kittens')
+      within '.document-position-0' do
+        expect(page).to have_css('li', text: /Kittens/)
+        expect(page).not_to have_link('Kittens')
+      end
     end
 
-    expect(page).to have_css('h1', text: 'The title of the document')
-    expect(current_url).to match(%r{/article/abc123})
+    scenario 'records are navigable' do
+      stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first]) # just a single document for the record view
+
+      article_search_for('Kittens')
+
+      within(first('.document')) do
+        click_link 'The title of the document'
+      end
+
+      expect(page).to have_css('h1', text: 'The title of the document')
+      expect(current_url).to match(%r{/article/abc123})
+    end
   end
 
   describe 'breadcrumbs', js: true do

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -2,7 +2,7 @@
 # Module included for RSpec tests to stub the article search service
 module StubArticleService
   SAMPLE_RESULTS = [
-      SolrDocument.new(id: 'abc123', eds_title: 'The title of the document'),
+      SolrDocument.new(id: 'abc123', eds_title: 'The title of the document', eds_subjects: %w[Kittens Felines Companions]),
       SolrDocument.new(id: '321cba', eds_title: 'Another title for the document'),
       SolrDocument.new(id: 'wqoeif', eds_title: 'Yet another title for the document')
   ]


### PR DESCRIPTION
Closes #1473

This PR
- adds `eds_subjects` to our first stubbed article
- only unlinks subject terms in the search results
- reorganizes tests in `article_searching_spec.rb`

## Before

![linked_subjects](https://user-images.githubusercontent.com/5402927/28145315-33d49a3c-6726-11e7-9935-027f676941b2.png)

## After

![unlinked_subjects](https://user-images.githubusercontent.com/5402927/28145316-395e7ffe-6726-11e7-839d-deafbe2178c0.png)
