### PR TITLE
Use ArticleSearchBuilder to pass queries onto EDS API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
-faraday.log
 
 config/settings.local.yml
 config/settings/*.local.yml

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -22,6 +22,7 @@ class ArticleController < ApplicationController
   configure_blacklight do |config|
     # Class for sending and receiving requests from a search index
     config.repository_class = Eds::Repository
+    config.search_builder_class = ArticleSearchBuilder
 
     # solr field configuration for search results/index views
     config.index.document_presenter_class = IndexDocumentPresenter
@@ -151,18 +152,8 @@ class ArticleController < ApplicationController
     config.add_sort_field 'oldest', sort: 'oldest', label: 'date (oldest)'
   end
 
-  def index
-    (@response, _deprecated_document_list) = search_service.search_results
-  end
-
-  def show
-    @response, @document = search_service.fetch(params[:id])
-    respond_to do |format|
-      format.html { setup_next_and_previous_documents }
-    end
-  end
-
-  def new; end
+  # Used by default Blacklight `index` and `show` actions
+  delegate :search_results, :fetch, to: :search_service
 
   protected
 
@@ -175,7 +166,7 @@ class ArticleController < ApplicationController
       'guest' => true, # TODO: hardcoded to non-authenticated
       'session_token' => session['eds_session_token']
     }
-    Eds::SearchService.new(blacklight_config, search_state.to_h, eds_params)
+    Eds::SearchService.new(blacklight_config, eds_params)
   end
 
   def set_search_query_modifier

--- a/app/helpers/blacklight_url_helper.rb
+++ b/app/helpers/blacklight_url_helper.rb
@@ -1,24 +1,19 @@
 module BlacklightUrlHelper
   include Blacklight::UrlHelperBehavior
 
-  # Link to the previous document in the current search context
+  # Override from Blacklight::UrlHelperBehavior to provide custom class
   def link_to_previous_document(previous_document)
-    css_class = 'previous btn btn-sul-toolbar ' + (previous_document.nil? ? 'disabled' : '')
-    link_opts = session_tracking_params(previous_document, search_session['counter'].to_i - 1).merge(:class => css_class, :rel => 'prev')
-
-    link_to url_for_document(previous_document), link_opts do
-      t('views.pagination_compact.previous').html_safe
+    link_opts = session_tracking_params(previous_document, search_session['counter'].to_i - 1).merge(:class => 'previous btn btn-sul-toolbar ', :rel => 'prev')
+    link_to_unless previous_document.nil?, raw(t('views.pagination_compact.previous')), url_for_document(previous_document), link_opts do
+      content_tag :span, raw(t('views.pagination_compact.previous')), :class => 'previous'
     end
   end
 
-  # Link to the next document in the current search context
+  # Override from Blacklight::UrlHelperBehavior to provide custom class
   def link_to_next_document(next_document)
-    css_class = 'next btn btn-sul-toolbar ' + (next_document.nil? ? 'disabled' : '')
-    link_opts = session_tracking_params(next_document, search_session['counter'].to_i + 1).merge(:class => css_class, :rel => 'next')
-
-    link_to url_for_document(next_document), link_opts do
-      t('views.pagination_compact.next').html_safe
+    link_opts = session_tracking_params(next_document, search_session['counter'].to_i + 1).merge(:class => 'next btn btn-sul-toolbar ', :rel => 'next')
+    link_to_unless next_document.nil?, raw(t('views.pagination_compact.next')), url_for_document(next_document), link_opts do
+      content_tag :span, raw(t('views.pagination_compact.next')), :class => 'next'
     end
   end
-
 end

--- a/app/models/article_search_builder.rb
+++ b/app/models/article_search_builder.rb
@@ -1,0 +1,16 @@
+# Keep distinct from catalog's SearchBuilder
+class ArticleSearchBuilder < Blacklight::SearchBuilder
+  include Blacklight::Solr::SearchBuilderBehavior
+  self.default_processor_chain = %i[add_eds_params]
+
+  private
+
+  # See EBSCO::EDS::RetrievalCriteria
+  def add_eds_params(eds_params)
+    eds_params.merge!(blacklight_params.to_hash)
+    eds_params.except!('start', 'rows', 'page', 'per_page') # avoid the Solr-like EDS API parameters
+    eds_params[:page_number] = start + 1 # page_number is a misnomer, it's the first hit number
+    eds_params[:results_per_page] = rows
+    eds_params[:highlight] = true # TODO: make highlighting configurable
+  end
+end

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -1,52 +1,54 @@
 module Eds
   class Repository < Blacklight::AbstractRepository
-    ##
-    # Execute a search against EDS
-    #
     def search(search_builder = {}, eds_params = {})
-      send_and_receive(search_builder, eds_params)
-    end
-
-    def send_and_receive(search_builder = {}, eds_params = {})
-      benchmark('EDS fetch', level: :info) do
-
-        # results list passes a full searchbuilder, detailed record only passes params
-        bl_params = search_builder.is_a?(SearchBuilder) ? search_builder.blacklight_params : search_builder
-        # TODO: make highlighting configurable
-        bl_params = bl_params.update('hl' => 'on')
-
-        eds = EBSCO::EDS::Session.new(eds_options(eds_params.update(caller: 'bl-search')))
-        # REGULAR SEARCH
-        results = eds.search(bl_params).to_solr
-        blacklight_config.response_model.new(results, bl_params,
-                                             document_model: blacklight_config.document_model,
-                                             blacklight_config: blacklight_config)
+      benchmark('EDS search', level: :info) do
+        eds_search(search_builder, eds_params)
       end
     end
 
-    # Construct EDS Session options
-    def eds_options(eds_params = {})
-      {
-        guest: eds_params['guest'],
-        session_token: eds_params['session_token'],
-        caller: eds_params[:caller],
-        user: Settings.EDS_USER,
-        pass: Settings.EDS_PASS,
-        profile: Settings.EDS_PROFILE,
-        debug: Settings.EDS_DEBUG
-      }
+    def find(id, params = {}, eds_params = {})
+      benchmark('EDS find', level: :info) do
+        eds_find(id, params, eds_params)
+      end
     end
 
-    def find(id, params = {}, eds_params = {})
-      eds = EBSCO::EDS::Session.new(eds_options(eds_params.update(caller: 'bl-repo-find')))
-      dbid = id.split('__').first
-      accession = id.split('__').last
-      accession.gsub!(/_/, '.')
-      record = eds.retrieve(dbid: dbid, an: accession)
-      solr_result = record.to_solr
-      blacklight_config.response_model.new(solr_result, params,
+    private
+
+    def eds_search(search_builder = {}, eds_params = {})
+      eds_session = EBSCO::EDS::Session.new(eds_session_options(eds_params.update(caller: 'bl-search')))
+      bl_params = search_builder.to_hash
+      results = eds_session.search(bl_params).to_solr
+      blacklight_config.response_model.new(results,
+                                           bl_params,
                                            document_model: blacklight_config.document_model,
                                            blacklight_config: blacklight_config)
+    end
+
+    def eds_find(id, params, eds_params)
+      dbid = id.split('__').first
+      accession = id.split('__').last.tr('_', '.')
+      eds_session = EBSCO::EDS::Session.new(eds_session_options(eds_params.update(caller: 'bl-repo-find')))
+      record = eds_session.retrieve(dbid: dbid, an: accession)
+      blacklight_config.response_model.new(record.to_solr,
+                                           params,
+                                           document_model: blacklight_config.document_model,
+                                           blacklight_config: blacklight_config)
+    end
+
+    def eds_session_options(eds_params = {})
+      {
+        guest:          true, # TODO: hardcoded to non-authenticated
+        session_token:  eds_params['session_token'],
+        caller:         eds_params[:caller],
+        user:           Settings.EDS_USER,
+        pass:           Settings.EDS_PASS,
+        profile:        Settings.EDS_PROFILE,
+        use_cache:      Settings.EDS_CACHE,
+        timeout:        Settings.EDS_TIMEOUT,
+        open_timeout:   Settings.EDS_OPEN_TIMEOUT,
+        debug:          Settings.EDS_DEBUG,
+        log:            File.join(Settings.EDS_LOGDIR, 'faraday.log')
+      }
     end
   end
 end

--- a/app/services/eds/search_service.rb
+++ b/app/services/eds/search_service.rb
@@ -1,40 +1,31 @@
 # frozen_string_literal: true
 
-# SearchService returns search results from the repository
 module Eds
+  # SearchService returns search results and fetches from the repository
   class SearchService
     include Blacklight::RequestBuilders
 
-    def initialize(blacklight_config, user_params = {}, eds_params = {})
+    def initialize(blacklight_config, eds_params = {})
       @blacklight_config = blacklight_config
-      @user_params = user_params
-      @repository = blacklight_config.repository_class.new(blacklight_config)
+      @repository = @blacklight_config.repository_class.new(@blacklight_config)
       @eds_params = eds_params
     end
 
     attr_reader :blacklight_config # used by search_builder
-    attr_reader :repository # used by tests
 
-    def search_results
-      builder = search_builder.with(@user_params)
-      builder.page = @user_params[:page] if @user_params[:page]
-      builder.rows = (@user_params[:per_page] || @user_params[:rows]) if @user_params[:per_page] || @user_params[:rows]
-
+    def search_results(user_params)
+      builder = search_builder.with(user_params)
       builder = yield(builder) if block_given?
       response = @repository.search(builder, @eds_params)
-
-      [response, nil]
+      [response, response.documents]
     end
 
     # retrieve a document, given the doc id
     # @param [Array{#to_s},#to_s] id
     # @return [Blacklight::Solr::Response, Blacklight::SolrDocument] the solr response object and the first document
     def fetch(id = nil, extra_controller_params = {})
-      if id.is_a? Array
-        fetch_many(id, extra_controller_params) # TODO: port me over from EDS example
-      else
-        fetch_one(id, extra_controller_params)
-      end
+      raise NotImplementedError if id.is_a? Array
+      fetch_one(id, extra_controller_params)
     end
 
     def fetch_one(id, extra_controller_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,5 +68,8 @@ Rails.application.routes.draw do
 
   resources :course_reserves, only: :index, path: "reserves"
 
-  resources :article, only: %i[index show]
+  constraints(id: /[-\w]+/) do # EDS identifier rules (e.g., db__id)
+    resources :article, only: %i[index show]
+    post "article/:id/track" => 'article#track', as: :track_article
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,3 +33,7 @@ EDS_USER: the-eds-user
 EDS_PASS: the-eds-password
 EDS_PROFILE: the-eds-profile
 EDS_DEBUG: false
+EDS_CACHE: true
+EDS_LOGDIR: <%= Rails.root.join('log') %>
+EDS_TIMEOUT: 15
+EDS_OPEN_TIMEOUT: 2

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -9,28 +9,16 @@ RSpec.describe ArticleController do
     end
   end
 
-  it 'handles authentication'
-  it 'handles configuration'
-
-  context 'Article Search API (via EDS)' do
-    before do
-      expect(EBSCO::EDS::Session).to receive(:new).and_return(
-        instance_double(EBSCO::EDS::Session, session_token: double)
-      )
-      @search_service = instance_double(Eds::SearchService)
-      expect(Eds::SearchService).to receive(:new).and_return(@search_service)
-    end
-
-    it '#index' do
-      expect(@search_service).to receive(:search_results)
-      get :index
-    end
-
-    it '#show' do
-      expect(@search_service).to receive(:fetch).with('123')
-      get :show, params: { id: 123 }
+  context '#show' do
+    it 'shows a detail page' do
+      stub_article_service(type: :single, docs: [SolrDocument.new(id: '123')])
+      get :show, params: { id: '123' }
+      expect(response).to render_template('show')
     end
   end
+
+  it 'handles authentication'
+  it 'handles configuration'
 
   context 'EDS Session Management' do
     let(:user_session) { {} }

--- a/spec/models/eds/repository_spec.rb
+++ b/spec/models/eds/repository_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Eds::Repository do
   let(:blacklight_config) {
     instance_double(Blacklight::Configuration,
       response_model: Blacklight::Solr::Response,
-      document_model: SolrDocument
+      document_model: SolrDocument,
+      default_per_page: 10
     )
   }
   subject(:instance) { described_class.new(blacklight_config) }
@@ -24,5 +25,29 @@ RSpec.describe Eds::Repository do
     expect(instance.find('123__abc')).to be_truthy
   end
 
-  it '#search'
+  context '#search (normal)' do
+    let(:search_builder) do
+      instance_double(ArticleSearchBuilder, rows: 10, to_hash: { q: 'my query', rows: 10 })
+    end
+    it 'uses a session to execute a search' do
+      session = instance_double(EBSCO::EDS::Session,
+        search: instance_double(EBSCO::EDS::Results, to_solr: {})
+      )
+      expect(EBSCO::EDS::Session).to receive(:new).and_return(session)
+      expect(instance.search(search_builder)).to be_truthy
+    end
+  end
+
+  context '#search (peek query for prev/next)' do
+    let(:search_builder) do
+      instance_double(ArticleSearchBuilder, rows: 3, to_hash: { q: 'my query', start: 11, rows: 3 })
+    end
+    it 'uses a session to run the previous-next search' do
+      session = instance_double(EBSCO::EDS::Session,
+        search: instance_double(EBSCO::EDS::Results, to_solr: double)
+      )
+      expect(EBSCO::EDS::Session).to receive(:new).and_return(session)
+      expect(instance.search(search_builder)).to be_truthy
+    end
+  end
 end

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe 'Article Routing', type: :routing do
   end
   it '#show' do
     expect(get('/article/1')).to route_to(controller: 'article', action: 'show', id: '1')
+    expect(get('/article/eds__style1')).to route_to(controller: 'article', action: 'show', id: 'eds__style1')
+    expect(get('/article/eds__Style2-with-hyphens')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with-hyphens')
+  end
+  it '#track' do
+    expect(post('/article/1/track')).to route_to(controller: 'article', action: 'track', id: '1')
+    expect(post('/article/eds__style1/track')).to route_to(controller: 'article', action: 'track', id: 'eds__style1')
+    expect(post('/article/eds__Style2-with-hyphens/track')).to route_to(controller: 'article', action: 'track', id: 'eds__Style2-with-hyphens')
   end
   it 'other actions are not routable' do
     expect(post('/article')).not_to be_routable

--- a/spec/services/eds/search_service_spec.rb
+++ b/spec/services/eds/search_service_spec.rb
@@ -9,16 +9,24 @@ RSpec.describe Eds::SearchService do
     )
   }
   subject(:instance) { described_class.new(blacklight_config) }
+  subject(:user_params) { {} }
+
+  before do
+    stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+    stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first])
+  end
 
   it '#search_results' do
-    expect(instance.respond_to?(:search_results)).to be_truthy
-    expect(instance.repository).to receive(:search)
-    expect(instance.search_results).to be_truthy
+    results = instance.search_results(user_params)
+    expect(results.length).to eq 2
+    expect(results[0]).to be_an(Blacklight::Solr::Response)
+    expect(results[1]).to eq StubArticleService::SAMPLE_RESULTS
   end
 
   it '#fetch' do
-    expect(instance.respond_to?(:fetch)).to be_truthy
-    expect(instance.repository).to receive(:find).and_return(instance_double(Blacklight::Solr::Response, documents: []))
-    expect(instance.fetch).to be_truthy
+    results = instance.fetch(StubArticleService::SAMPLE_RESULTS.first.id)
+    expect(results.length).to eq 2
+    expect(results[0]).to be_an(Blacklight::Solr::Response)
+    expect(results[1].id).to eq StubArticleService::SAMPLE_RESULTS.first.id
   end
 end


### PR DESCRIPTION
This PR is connected to #1471.

I refactored Eds::SearchService/Repository which allows us to use our own `ArticleSearchBuilder` rather than the existing Catalog's `SearchBuilder` (which has a processing chain that we shouldn't use). 

The core issue is that the Previous/Next buttons weren't working on the show page (and I also believe on the index page too), so this PR mainly cleans up the code path to reduce the potential for problems. I've added support for the `track` action on Articles in the routing, and updated the `id` constraints to match the EDS document id rules.

The refactoring also allows us to use the Blacklight `index`, `show`, and `track` methods as-is in `ArticleController` rather than define them ourselves (and lose features like the `.json` API).

For `link_to_previous_document` and `link_to_next_document`, we don't need the `.disabled` class anymore, so I've re-copied the Blacklight version of these methods and just changed the CSS class we use (it'd be nice to have that be a parameter).

Finally, I added some more configuration values for the EDS gem (timeouts, cache, logging).

Note that there's still a problem with the Prev/Next buttons as reported in #1471 which is why this PR does not close it -- that ticket is blocked on an EDS ticket right now. But this PR is good to go.