### PR TITLE
Add responsive behavior to search dropdown options

### DIFF
--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -101,10 +101,13 @@
       margin-top: 5px;
       text-align: center;
       width: 100%;
-      
+
       .search-dropdown {
         .dropdown-menu {
+          left: 0;
           top: 45%;
+          width: 100%;
+          z-index: 10001;
         }
       }
     }

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -3,10 +3,10 @@ en:
     search_dropdown:
       articles:
         label: articles
-        description_html: articles <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
+        description_html: <span class="h3">articles</span> <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
       catalog:
         label: catalog
-        description_html: catalog <span class="help-block">books &amp; media in the Stanford Libraries' collections</span>
+        description_html: <span class="h3">catalog</span> <span class="help-block">books &amp; media in the Stanford Libraries' collections</span>
     marc_fields:
       imprint:
         label: Imprint


### PR DESCRIPTION
Closes #1442

This PR fixes the alignment of our search dropdown in smaller view sizes. @jvine Let me know your thoughts on the `width: 100%` . I did a quick attempt at trying to keep the dropdown its original width, but keeping things right aligned was a little finicky. 

I also restored the `h3` spans on the dropdown...I think they disappeared during rebasing the other day.

## Demo
![responsive_aligned_dropdown](https://user-images.githubusercontent.com/5402927/28334706-d4833766-6bb0-11e7-9be1-c7abe0fd5764.gif)

