### PR TITLE
use page rather than start for page number

### DIFF
--- a/app/models/article_search_builder.rb
+++ b/app/models/article_search_builder.rb
@@ -9,7 +9,7 @@ class ArticleSearchBuilder < Blacklight::SearchBuilder
   def add_eds_params(eds_params)
     eds_params.merge!(blacklight_params.to_hash)
     eds_params.except!('start', 'rows', 'page', 'per_page') # avoid the Solr-like EDS API parameters
-    eds_params[:page_number] = start + 1 # page_number is a misnomer, it's the first hit number
+    eds_params[:page_number] = page
     eds_params[:results_per_page] = rows
     eds_params[:highlight] = true # TODO: make highlighting configurable
   end


### PR DESCRIPTION
This PR uses `page` rather than `start` for the EDS `page_number`. Fixes #1487 

From EBSCO:

> `page_number`: Starting page number for the result set returned from a search (if results per page = 10, and page number = 3 , this implies: I am expecting 10 records starting at page 3).
> `results_per_page`: The number of records retrieved with the search results (between 1-100).