### PR TITLE
Fix sul-toolbar height in record view

### DIFF
--- a/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
+++ b/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
@@ -1,5 +1,5 @@
 #sortAndPerPage {
-  padding-bottom: 4px;
+  padding: 4px 0;
   margin-top: .8em;
   border-bottom: none;
 

--- a/app/assets/stylesheets/modules/sul-toolbar.scss
+++ b/app/assets/stylesheets/modules/sul-toolbar.scss
@@ -1,7 +1,8 @@
 .sul-toolbar {
   @include sul-toolbar-bg-border;
-  padding: 5px 0px;
+  padding: 0;
   margin: 35px 0px;
+  min-height: 40px;
   height: 40px;
   color: $sul-toolbar-color;
 


### PR DESCRIPTION
Closes #1475 

This PR ensures that `.sul-toolbar` appears 40px in the record view. 

## Before
![after](https://user-images.githubusercontent.com/5402927/28345092-9e719f24-6bdc-11e7-9521-28b502edab48.png)

## After
![after](https://user-images.githubusercontent.com/5402927/28345018-271718a0-6bdc-11e7-8038-4b49cf6f1e4a.png)
