### PR TITLE
Remove catalog-related subnav menus from article search context

### DIFF
--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -16,15 +16,17 @@
           <%= render :partial => 'shared/search_navbar_top_menu' %>
         </li>
       </ul>
-      <ul class="nav navbar-nav navbar-right">
-        <li class="navbar-link">
-          <%= render_search_bar_advanced_widget %>
-        </li>
-        <li class="navbar-link">
-          <%= link_to "Course reserves", course_reserves_path %>
-        </li>
-        <%= render_search_bar_selections_widget %>
-      </ul>
+      <% unless article_search? %>
+        <ul class="nav navbar-nav navbar-right">
+          <li class="navbar-link">
+            <%= render_search_bar_advanced_widget %>
+          </li>
+          <li class="navbar-link">
+            <%= link_to "Course reserves", course_reserves_path %>
+          </li>
+          <%= render_search_bar_selections_widget %>
+        </ul>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -30,6 +30,18 @@ feature 'Article Searching' do
     end
   end
 
+  describe 'subnavbar' do
+    scenario 'catalog-specific sub-menus are not rendered' do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+      visit article_index_path
+
+      expect(page).to have_css('a', text: /Library services/)
+      expect(page).not_to have_css('a', text: /Advanced search/)
+      expect(page).not_to have_css('a', text: /Course reserves/)
+      expect(page).not_to have_css('a', text: /Selections/)
+    end
+  end
+
   describe 'articles index page' do
     scenario 'renders home page if no search parameters are present' do
       stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)


### PR DESCRIPTION
Closes #1456 

This PR removes Advanced search, Course reserves, and Selections from the subnavbar when using article search. Advanced search and Selections may be re-introduced later, per discussion in #1456 

>- do not show Course reserves in Article search
>- do not show Advanced search in Article search until we have that specific feature
>- suppress Selections until we know how to handle Article bookmarks

## Article controller
![screen shot 2017-07-18 at 5 44 00 pm](https://user-images.githubusercontent.com/5402927/28345792-4a3874f0-6be1-11e7-8e65-f5f6f88e76c4.png)

![screen shot 2017-07-18 at 5 44 52 pm](https://user-images.githubusercontent.com/5402927/28345803-5b78931c-6be1-11e7-851e-d349b6a5bfaa.png)


## Catalog controller
![screen shot 2017-07-18 at 5 44 21 pm](https://user-images.githubusercontent.com/5402927/28345794-4c5a3340-6be1-11e7-8443-452aa757dfe5.png)

![screen shot 2017-07-18 at 5 44 36 pm](https://user-images.githubusercontent.com/5402927/28345799-55469926-6be1-11e7-8047-f089a45bb67c.png)
