### PR TITLE
prioritize and relabel full text links

### DIFF
--- a/app/presenters/concerns/presenter_fulltext_links.rb
+++ b/app/presenters/concerns/presenter_fulltext_links.rb
@@ -1,8 +1,58 @@
 module PresenterFulltextLinks
   def fulltext_links
-    field_key = configuration.index.fulltext_links_field
-    document[field_key].collect do |link|
-      "<li class=\"article-fulltext-link\">#{view_context.link_to(link['label'] || link['url'], link['url'])}</li>".html_safe
+    links = document[configuration.index.fulltext_links_field]
+    links.collect do |link|
+      if show_link?(links, link)
+        link = relabel_link(link)
+        "<li class=\"article-fulltext-link\">#{view_context.link_to(link['label'], link['url'])}</li>".html_safe
+      end
+    end.compact
+  end
+
+  private
+
+  def relabel_link(link)
+    link = link.dup
+    map = to_link_mapping(link)
+    link['label'] = map[:label] if map.present?
+    link
+  end
+
+  # Link types are prioritized as follows:
+  #
+  # 1 and 2 are preferred, and can coexist
+  # show 3 only if there's no 1 or 2
+  # show 4 only if there's no 1-3
+  def show_link?(links, link)
+    map = to_link_mapping(link)
+    return false if map.blank? # drop links that don't have a mapping
+
+    case map[:priority]
+    when 1, 2
+      true
+    when 3, 4
+      !link_within_priority?(links, map[:priority] - 1)
     end
+  end
+
+  # does this link have a priority <= given priority?
+  def link_within_priority?(links, priority)
+    links.each do |link|
+      map = to_link_mapping(link)
+      return true if map.present? && map[:priority] <= priority
+    end
+    false
+  end
+
+  # Unfortunately we can only do this mapping via the EDS Label
+  LINK_MAPPING = {
+    'HTML full text'.downcase =>           { label: 'View full text', priority: 1 },
+    'PDF full text'.downcase =>            { label: 'View/download full text PDF', priority: 2 },
+    'Check SFX for full text'.downcase =>  { label: 'View full text on content provider\'s site', priority: 3 },
+    'View request options'.downcase =>     { label: 'Find it in print or via interlibrary services', priority: 4 }
+  }.freeze
+
+  def to_link_mapping(link)
+    LINK_MAPPING[link['label'].downcase] if link['label'].present?
   end
 end

--- a/spec/presenters/presenter_fulltext_links_spec.rb
+++ b/spec/presenters/presenter_fulltext_links_spec.rb
@@ -13,29 +13,91 @@ RSpec.describe PresenterFulltextLinks do
     end.new
   end
 
-  let(:document) { { 'eds_fulltext_links' => Array.wrap({ 'label' => 'My label', 'url' => 'http://example.com' }) } }
+  subject(:result) { Capybara.string(presenter.fulltext_links.join) }
 
   before do
     config = double(Blacklight::Configuration, index: double(fulltext_links_field: 'eds_fulltext_links'))
-    expect(presenter).to receive(:configuration).and_return(config)
-    expect(presenter).to receive(:view_context).and_return(view_context)
-    expect(presenter).to receive(:document).and_return(document)
+    allow(presenter).to receive(:configuration).and_return(config)
+    allow(presenter).to receive(:view_context).and_return(view_context)
+    allow(presenter).to receive(:document).and_return(document)
   end
 
   context '#fulltext_links' do
+    let(:document) { { 'eds_fulltext_links' => Array.wrap({ 'label' => 'HTML full text', 'url' => 'http://example.com' }) } }
+
     it 'assumes EDS API returns a hash with label and url'
     it 'renders a list of labeled links' do
-      result = Capybara.string(presenter.fulltext_links.first)
       expect(result).to have_css('li.article-fulltext-link', count: 1)
-      expect(result).to have_css('li a', text: 'My label')
-      expect(result).to have_css('li a @href', text: 'http://example.com')
+      expect(result).to have_link('View full text', href: 'http://example.com')
     end
-    it 'uses the URL as a label when label is missing' do
+    it 'skips using the URL as a label when label is missing' do
       document['eds_fulltext_links'].first.delete('label')
-      result = Capybara.string(presenter.fulltext_links.first)
-      expect(result).to have_css('li.article-fulltext-link', count: 1)
-      expect(result).to have_css('li a', text: 'http://example.com')
-      expect(result).to have_css('li a @href', text: 'http://example.com')
+      expect(result).not_to have_link
+    end
+  end
+
+  context 'rewriting labels' do
+    let(:document) { { 'eds_fulltext_links' => Array.wrap('label' => 'My label', 'url' => 'http://example.com') } }
+
+    it 'handles HTML full text' do
+      document['eds_fulltext_links'].first['label'] = 'HTML full text'
+      expect(result).to have_link('View full text', href: 'http://example.com')
+    end
+
+    it 'handles PDF full text' do
+      document['eds_fulltext_links'].first['label'] = 'PDF full text'
+      expect(result).to have_link('View/download full text PDF', href: 'http://example.com')
+    end
+
+    it 'handles Check SFX for full text' do
+      document['eds_fulltext_links'].first['label'] = 'Check SFX for full text'
+      expect(result).to have_link('View full text on content provider\'s site', href: 'http://example.com')
+    end
+
+    it 'handles View request options' do
+      document['eds_fulltext_links'].first['label'] = 'View request options'
+      expect(result).to have_link('Find it in print or via interlibrary services', href: 'http://example.com')
+    end
+
+    it 'errors on some other label' do
+      expect(result.native.text).to eq ''
+      expect(result).not_to have_link
+    end
+  end
+
+  context 'prioritizing links' do
+    subject(:result) { Capybara.string(presenter.fulltext_links.join) }
+    let(:document) { {
+      'eds_fulltext_links' => Array.wrap([
+        { 'label' => 'HTML FULL TEXT', 'url' => 'http://example.com/1' },
+        { 'label' => 'PDF FULL TEXT', 'url' => 'http://example.com/2' },
+        { 'label' => 'CHECK SFX FOR FULL TEXT', 'url' => 'http://example.com/3' },
+        { 'label' => 'VIEW REQUEST OPTIONS', 'url' => 'http://example.com/4' }
+      ] )
+    } }
+
+    it 'shows 1 and 2 only' do
+      document['eds_fulltext_links'] = document['eds_fulltext_links']
+      expect(result).to have_link(href: 'http://example.com/1')
+      expect(result).to have_link(href: 'http://example.com/2')
+      expect(result).not_to have_link(href: 'http://example.com/3')
+      expect(result).not_to have_link(href: 'http://example.com/4')
+    end
+
+    it 'shows 3 only' do
+      document['eds_fulltext_links'] = document['eds_fulltext_links'].drop(2)
+      expect(result).not_to have_link(href: 'http://example.com/1')
+      expect(result).not_to have_link(href: 'http://example.com/2')
+      expect(result).to have_link(href: 'http://example.com/3')
+      expect(result).not_to have_link(href: 'http://example.com/4')
+    end
+
+    it 'shows 4 only' do
+      document['eds_fulltext_links'] = document['eds_fulltext_links'].drop(3)
+      expect(result).not_to have_link(href: 'http://example.com/1')
+      expect(result).not_to have_link(href: 'http://example.com/2')
+      expect(result).not_to have_link(href: 'http://example.com/3')
+      expect(result).to have_link(href: 'http://example.com/4')
     end
   end
 end

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'article/access_panels/_online.html.erb' do
   let(:document) do
     SolrDocument.new(
-      fulltext_link_field: [{ 'label' => 'Link Label', 'url' => 'http://example.com' }]
+      fulltext_link_field: [{ 'label' => 'HTML full text', 'url' => 'http://example.com' }]
     )
   end
 
@@ -32,6 +32,6 @@ RSpec.describe 'article/access_panels/_online.html.erb' do
   end
 
   it 'includes EDS fulltext links' do
-    expect(rendered).to have_css('.panel-body ul li a', text: 'Link Label')
+    expect(rendered).to have_css('.panel-body ul li a', text: 'View full text')
   end
 end


### PR DESCRIPTION
This PR is connected to #1476. It rewrites the `PresenterFulltextLinks.fulltext_links` to support re-labeling and prioritization.

### Example index page

![screen shot 2017-07-19 at 11 54 18 am](https://user-images.githubusercontent.com/1861171/28384302-09f95f92-6c79-11e7-9396-e5f28c6b6d22.png)

### Example show page
![screen shot 2017-07-19 at 11 53 25 am](https://user-images.githubusercontent.com/1861171/28384253-e5a074fa-6c78-11e7-8c47-c4d50c38bcce.png)
