### PR TITLE
remove record toolbar navigation temporarily

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -156,6 +156,12 @@ class ArticleController < ApplicationController
   # Used by default Blacklight `index` and `show` actions
   delegate :search_results, :fetch, to: :search_service
 
+  # TODO: remove me when EDS gem supports more efficient Prev/Next functionality
+  #       see https://github.com/sul-dlss/SearchWorks/issues/1493
+  def setup_next_and_previous_documents
+    # do nothing
+  end
+
   protected
 
   def _prefixes

--- a/spec/features/article_record_toolbar_spec.rb
+++ b/spec/features/article_record_toolbar_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Article Record Toolbar', js: true do
     end
   end
   it 'shows both prev and next buttons' do
+    skip 'TODO: disabled temporarily'
     within '.record-toolbar' do
       expect(page).to have_css('.previous', text: 'Previous')
       expect(page).to have_css('.next', text: 'Next')
@@ -32,6 +33,7 @@ RSpec.describe 'Article Record Toolbar', js: true do
   context 'handles the first page (no prev)' do
     let(:previous_document) { nil }
     it 'shows only the Next button' do
+      skip 'TODO: disabled temporarily'
       within '.record-toolbar' do
         expect(page).not_to have_css('.previous', text: 'Previous')
         expect(page).to have_css('.next', text: 'Next')
@@ -42,6 +44,7 @@ RSpec.describe 'Article Record Toolbar', js: true do
   context 'handles the last page (no next)' do
     let(:next_document) { nil }
     it 'shows only the Previous button' do
+      skip 'TODO: disabled temporarily'
       within '.record-toolbar' do
         expect(page).to have_css('.previous', text: 'Previous')
         expect(page).not_to have_css('.next', text: 'Next')
@@ -53,6 +56,7 @@ RSpec.describe 'Article Record Toolbar', js: true do
     let(:previous_document) { nil }
     let(:next_document) { nil }
     it 'does not show any Previous or Next buttons' do
+      skip 'TODO: disabled temporarily'
       within '.record-toolbar' do
         expect(page).not_to have_css('.previous', text: 'Previous')
         expect(page).not_to have_css('.next', text: 'Next')


### PR DESCRIPTION
This PR fixes #1493. The implementation is geared toward making it easy to turn the navigation back on when we get a revised EDS gem. 

So, we don't show the Back to results, Previous, Next buttons or the "1 of n" text.

### Before
![screen shot 2017-07-19 at 1 39 49 pm](https://user-images.githubusercontent.com/1861171/28388490-c37c89cc-6c87-11e7-92f8-37dfdf6bc04b.png)

### After
![screen shot 2017-07-19 at 1 39 11 pm](https://user-images.githubusercontent.com/1861171/28388459-acc791a4-6c87-11e7-960e-10b454861711.png)
