### PR TITLE
permit tildes in the EDS identifiers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
 
   resources :course_reserves, only: :index, path: "reserves"
 
-  constraints(id: /[-\w]+/) do # EDS identifier rules (e.g., db__id)
+  constraints(id: /[-~\w]+/) do # EDS identifier rules (e.g., db__id)
     resources :article, only: %i[index show]
     post "article/:id/track" => 'article#track', as: :track_article
   end

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe 'Article Routing', type: :routing do
     expect(get('/article/1')).to route_to(controller: 'article', action: 'show', id: '1')
     expect(get('/article/eds__style1')).to route_to(controller: 'article', action: 'show', id: 'eds__style1')
     expect(get('/article/eds__Style2-with-hyphens')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with-hyphens')
+    expect(get('/article/eds__Style2-with~tildes')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with~tildes')
   end
   it '#track' do
     expect(post('/article/1/track')).to route_to(controller: 'article', action: 'track', id: '1')
     expect(post('/article/eds__style1/track')).to route_to(controller: 'article', action: 'track', id: 'eds__style1')
     expect(post('/article/eds__Style2-with-hyphens/track')).to route_to(controller: 'article', action: 'track', id: 'eds__Style2-with-hyphens')
+    expect(post('/article/eds__Style2-with~tildes/track')).to route_to(controller: 'article', action: 'track', id: 'eds__Style2-with~tildes')
   end
   it 'other actions are not routable' do
     expect(post('/article')).not_to be_routable


### PR DESCRIPTION
This PR permits tildes `~` to be used in the EDS `id` parameter