### PR TITLE
Marks various EDS metadata as HTML-safe and disables unused highlighting

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -32,9 +32,9 @@ class ArticleController < ApplicationController
     config.index.fulltext_links_field = 'eds_fulltext_links'
 
     config.add_index_field "eds_authors", label: 'Authors'
-    config.add_index_field "eds_composed_title", label: 'Composed Title', helper_method: :strip_html_from_solr_field
+    config.add_index_field "eds_composed_title", label: 'Composed Title', helper_method: :mark_html_safe
     config.add_index_field "eds_subjects", label: 'Subjects'
-    config.add_index_field "eds_abstract", label: 'Abstract', helper_method: :strip_html_from_solr_field
+    config.add_index_field "eds_abstract", label: 'Abstract', helper_method: :mark_html_safe
 
     config.add_search_field('search') do |field|
       field.label = 'All fields'
@@ -82,12 +82,12 @@ class ArticleController < ApplicationController
       'Summary' => {
         eds_authors:              { label: 'Authors', separator_options: BREAKS },
         eds_author_affiliations:  { label: 'Author Affiliations' },
-        eds_composed_title:       { label: 'Composed Title', helper_method: :strip_html_from_solr_field },
+        eds_composed_title:       { label: 'Composed Title', helper_method: :mark_html_safe },
         eds_publication_date:     { label: 'Publication Date' },
-        eds_languages:            { label: 'Language' }
+        eds_languages:            { label: 'Language', helper_method: :mark_html_safe }
       },
       'Abstract' => {
-        eds_abstract: { label: 'Abstract', helper_method: :strip_html_from_solr_field },
+        eds_abstract: { label: 'Abstract', helper_method: :mark_html_safe },
         eds_notes:    { label: 'Notes' }
       },
       'Subjects' => {

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -28,12 +28,10 @@ module ArticleHelper
     link_to(doi, url)
   end
 
-  def strip_html_from_solr_field(options = {})
-    return unless options[:value]
+  def mark_html_safe(options = {})
+    return unless options[:value].present?
     separators = options.dig(:config, :separator_options) || {}
-    options[:value].collect do |value|
-      safe_join(render_text_from_html(value))
-    end.to_sentence(separators).html_safe # this is what Blacklight's Join step does
+    options[:value].map(&:to_s).to_sentence(separators).html_safe
   end
 
   def render_text_from_html(values)

--- a/app/models/article_search_builder.rb
+++ b/app/models/article_search_builder.rb
@@ -11,6 +11,6 @@ class ArticleSearchBuilder < Blacklight::SearchBuilder
     eds_params.except!('start', 'rows', 'page', 'per_page') # avoid the Solr-like EDS API parameters
     eds_params[:page_number] = page
     eds_params[:results_per_page] = rows
-    eds_params[:highlight] = true # TODO: make highlighting configurable
+    eds_params[:highlight] = false # TODO: make highlighting configurable
   end
 end

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -45,14 +45,6 @@ RSpec.describe ArticleHelper do
     end
   end
 
-  context '#strip_html_from_solr_field' do
-    it 'uses the render_text_from_html helper to strip html tags from a solr field' do
-      result = helper.strip_html_from_solr_field(value: %w[<a>b</a><c>d</e>f])
-
-      expect(result).to eq 'bdf'
-    end
-  end
-
   context '#render_text_from_html' do
     it 'returns only text from HTML' do
       result = helper.render_text_from_html(%w[ab<c>d</c>])
@@ -67,6 +59,27 @@ RSpec.describe ArticleHelper do
     it 'returns an empty array if missing' do
       result = helper.render_text_from_html(nil)
       expect(result).to eq []
+    end
+  end
+
+  context '#mark_html_safe' do
+    it 'preserves HTML entities to render' do
+      result = helper.mark_html_safe(value: Array.wrap('This &amp; That'))
+      expect(result).to eq 'This &amp; That'
+    end
+    it 'preserves HTML elements to render' do
+      result = helper.mark_html_safe(value: Array.wrap('<i>This Journal</i>, 10(1)'))
+      expect(result).to eq '<i>This Journal</i>, 10(1)'
+    end
+    it 'handles multiple values' do
+      result = helper.mark_html_safe(value: %w[This That])
+      expect(result).to eq 'This and That'
+      result = helper.mark_html_safe(value: %w[This That The\ Other])
+      expect(result).to eq 'This, That, and The Other'
+    end
+    it 'handles multiple values with separators' do
+      result = helper.mark_html_safe(value: %w[This That], config: { separator_options: { two_words_connector: '<br/>' } })
+      expect(result).to eq 'This<br/>That'
     end
   end
 end

--- a/spec/models/article_search_builder_spec.rb
+++ b/spec/models/article_search_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ArticleSearchBuilder do
       expect(search_builder[:q]).to eq 'my search'
       expect(search_builder[:page_number]).to eq 1
       expect(search_builder[:results_per_page]).to eq 10
-      expect(search_builder[:highlight]).to be_truthy
+      expect(search_builder[:highlight]).to be_falsey
     end
 
     it 'excludes some Solr-like parameters' do


### PR DESCRIPTION
This PR is connected to #1466. Instead of stripping out HTML, we're marking them HTML-safe in this PR.

### Before

![screen shot 2017-07-20 at 2 37 38 pm](https://user-images.githubusercontent.com/1861171/28439930-0279fcf0-6d59-11e7-864f-a7b6f9935be1.png)

### After
![screen shot 2017-07-20 at 2 37 03 pm](https://user-images.githubusercontent.com/1861171/28439936-073e7c16-6d59-11e7-8cad-2ce69dade069.png)


### Before
![screen shot 2017-07-20 at 2 41 34 pm](https://user-images.githubusercontent.com/1861171/28440071-a286dea2-6d59-11e7-9ba9-109c12a6786d.png)


### After

![screen shot 2017-07-20 at 2 41 56 pm](https://user-images.githubusercontent.com/1861171/28440065-9dac82ce-6d59-11e7-9a66-1624355a4d1e.png)

It won't close the #1466 ticket until the UTF-8 encoding errors are fixed (see comments in ticket).