### PR TITLE
Display HTML full text in article show page

### DIFF
--- a/app/assets/stylesheets/modules/record-metadata-section.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.scss
@@ -1,4 +1,19 @@
 .record-sections {
+  .section-container-heading {
+    background-color: #009B76;
+    border-bottom: 1px solid $sul-panel-border-bottom;
+    margin-top: 10px;
+    margin-bottom: 15px;
+    padding: 10px 15px;
+
+    h2 {
+      border-bottom: 0;
+      color: white;
+      margin: 0;
+      font-size: 1.125em;
+      font-weight: 400;
+    }
+  }
   .section {
     padding-bottom: 0;
 

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -86,6 +86,9 @@ class ArticleController < ApplicationController
         eds_publication_date:     { label: 'Publication Date' },
         eds_languages:            { label: 'Language', helper_method: :mark_html_safe }
       },
+      'Full Text' => {
+        eds_html_fulltext: { label: 'Full Text', helper_method: :sanitize_fulltext }
+      },
       'Abstract' => {
         eds_abstract: { label: 'Abstract', helper_method: :mark_html_safe },
         eds_notes:    { label: 'Notes' }

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -79,15 +79,15 @@ class ArticleController < ApplicationController
     config.show.plink = 'eds_plink'
     config.show.route = { controller: 'article' }
     config.show.sections = {
+      'Fulltext' => {
+        eds_html_fulltext: { label: 'Full Text', helper_method: :sanitize_fulltext }
+      },
       'Summary' => {
         eds_authors:              { label: 'Authors', separator_options: BREAKS, helper_method: :link_authors },
         eds_author_affiliations:  { label: 'Author Affiliations' },
         eds_composed_title:       { label: 'Source', helper_method: :mark_html_safe },
         eds_publication_date:     { label: 'Publication Date' },
         eds_languages:            { label: 'Language', helper_method: :mark_html_safe }
-      },
-      'Full Text' => {
-        eds_html_fulltext: { label: 'Full Text', helper_method: :sanitize_fulltext }
       },
       'Abstract' => {
         eds_abstract: { label: 'Abstract', helper_method: :mark_html_safe },

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -53,6 +53,16 @@ module ArticleHelper
     options[:value].map(&:to_s).to_sentence(separators).html_safe
   end
 
+  def sanitize_fulltext(options = {})
+    return unless options[:value].present?
+    separators = options.dig(:config, :separator_options) || {}
+    textblock = options[:value].map(&:to_s).to_sentence(separators)
+    textblock = Nokogiri::HTML.fragment(CGI.unescapeHTML(textblock))
+    textblock.search('anid').remove
+    textblock = textblock.to_html
+    sanitize(textblock).html_safe
+  end
+
   def render_text_from_html(values)
     values = Array.wrap(values)
     return [] if values.blank?

--- a/app/views/article/_show_default.html.erb
+++ b/app/views/article/_show_default.html.erb
@@ -8,21 +8,34 @@
     <dl class="dl-horizontal dl-invert">
       <% blacklight_config.show.sections.each do |section_name, fields| -%>
         <% if (section = render('article/record/section_fields', document: document, fields: fields.keys)).present? -%>
-          <div class='section'>
-            <% if section_name != 'Summary' -%>
-              <div class='section-heading'>
-                <% mini_map_sections[section_name.downcase] = true %>
-                <h2 id="<%= section_name.downcase %>">
-                  <%= t("record_side_nav.#{section_name.downcase}.icon").html_safe %>
-                  <%= section_name -%>
-                </h2>
-              </div>
-            <% end -%>
+          <% if section_name == 'Fulltext' -%>
+            <div class="section-container-heading">
+              <h2>Full Text</h2>
+            </div>
             <div class='section-body'>
               <%= section -%>
             </div>
-          </div>
-        <% end -%>
+          <% else -%>
+            <% if section_name == 'Summary' -%>
+              <div class="section-container-heading">
+                <h2>About this article</h2>
+              </div>
+              <div class='section'>
+            <% else -%>
+              <div class='section'>
+                <div class='section-heading'>
+                  <% mini_map_sections[section_name.downcase] = true %>
+                  <h2 id="<%= section_name.downcase %>">
+                    <%= section_name -%>
+                  </h2>
+                </div>
+            <% end -%>
+              <div class='section-body'>
+                <%= section -%>
+              </div>
+            </div>
+          <% end -%>
+        <% end %>
       <% end -%>
     </dl>
   </div>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -135,3 +135,11 @@ en:
       id: "browse-nearby"
       icon: '<span class="sul-icon sul-icon-books-3"></span>'
       label: "Browse"
+    fulltext:
+      id: "full-text"
+      icon: '<i class="fa fa-align-justify"></i>'
+      label: "Full Text"
+    summary:
+      id: "summary"
+      icon: '<i class="fa fa-align-justify"></i>'
+      label: "Summary"

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -18,6 +18,18 @@ feature 'Article Record Display' do
     end
   end
 
+  describe 'Fulltext' do
+    let(:document) do
+      SolrDocument.new(id: '123', eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
+    end
+
+    it 'renders HTML' do
+      visit article_path(document[:id])
+      expect(page).to have_css('.blacklight-eds_html_fulltext')
+      expect(page).not_to have_content('<anid>')
+    end
+  end
+
   describe 'sidenav mini-map' do
     let(:document) do
       SolrDocument.new(

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -107,4 +107,21 @@ RSpec.describe ArticleHelper do
       expect(result).to eq 'This<br/>That'
     end
   end
+
+  context '#sanitize_fulltext' do
+    it 'preserves HTML entities to render' do
+      result = helper.mark_html_safe(value: Array.wrap('This &amp; That'))
+      expect(result).to eq 'This &amp; That'
+    end
+
+    it 'preserves HTML elements to render' do
+      result = helper.sanitize_fulltext(value: Array.wrap('<p>This Journal</p>, 10(1)'))
+      expect(result).to eq '<p>This Journal</p>, 10(1)'
+    end
+
+    it 'removes non-HTML EDS tags' do
+      result = helper.sanitize_fulltext(value: Array.wrap('<anid>09dfa;</anid><p>This Journal</p>, 10(1)'))
+      expect(result).to eq '<p>This Journal</p>, 10(1)'
+    end
+  end
 end


### PR DESCRIPTION
Fixes part of #1482 

Adds HTML full text to the article record view. 

## Notes
- Full text can only be accessed in authenticated mode
- Adds a helper_method, `sanitize_fullltext` that strips out EBSCO's `<anid>` tag
- Full Text and Summary are currently excluded from the sidenav sections
- Full text hide/show behavior has been split off to another ticket #1509 

## Todos
- [x] get EDS response to display
- [x] figure out why `html_safe` isn't working 
- [x] write a concern that strips out non-HTML markup
- [x] restyle sections for `Fulltext` and `About this article`
- [x] fix icon and sidenav display
- [x] unit tests for fulltext sanitizer
- [x] feature test

## Current display
### Full text
<img width="1335" alt="screen shot 2017-07-21 at 4 09 09 pm" src="https://user-images.githubusercontent.com/5402927/28485503-f6326730-6e2e-11e7-876a-29a9520a8001.png">

### About this article
<img width="861" alt="screen shot 2017-07-21 at 4 06 59 pm" src="https://user-images.githubusercontent.com/5402927/28485471-b616e4fa-6e2e-11e7-8a50-9f986ce01d7a.png">
