### PR TITLE
Add article HTML full text hide/show in record view

### DIFF
--- a/app/assets/javascripts/article.js
+++ b/app/assets/javascripts/article.js
@@ -1,1 +1,10 @@
-// TODO: intentionally left blank
+Blacklight.onLoad(function(){
+
+  $('#toggleFulltext').on('show.bs.collapse', function(){
+    $('#fulltextToggleBar').html('<h2>Hide full text</h2>')
+  });
+
+  $('#toggleFulltext').on('hide.bs.collapse', function(){
+    $('#fulltextToggleBar').html('<h2>Show full text</h2>')
+  });
+})

--- a/app/assets/stylesheets/modules/access-panel-online.scss
+++ b/app/assets/stylesheets/modules/access-panel-online.scss
@@ -13,3 +13,11 @@
 .visible {
   display: inline;
 }
+
+.article-record-panels {
+  .panel-body {
+    .fa {
+      margin-right: 5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/record-metadata-section.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.scss
@@ -1,9 +1,27 @@
 .record-sections {
+  .section {
+    padding-bottom: 0;
+  }
+}
+
+.record-metadata, .upper-record-metadata {
+  @include show-page-row-layout;
+  dt {
+    width: auto;
+  }
+}
+
+.article-record-sections {
+  .fulltext-toggle-bar {
+    border: 0;
+    text-align: left;
+    width: 100%;
+  }
+
   .section-container-heading {
-    background-color: #009B76;
-    border-bottom: 1px solid $sul-panel-border-bottom;
-    margin-top: 10px;
+    background-color: $pantone-334;
     margin-bottom: 15px;
+    margin-top: 10px;
     padding: 10px 15px;
 
     h2 {
@@ -14,27 +32,6 @@
       font-weight: 400;
     }
   }
-  .section {
-    padding-bottom: 0;
-
-    .section-heading h2 {
-      i.fa {
-        font-size: 15px;
-        margin-right: 5px;
-      }
-    }
-  }
-}
-
-.record-metadata, .upper-record-metadata {
-  @include show-page-row-layout;
-
-  dt {
-    width: auto;
-  }
-}
-
-.article-record-sections {
   dt {
     text-align: right;
   }

--- a/app/models/concerns/eds_document.rb
+++ b/app/models/concerns/eds_document.rb
@@ -1,0 +1,5 @@
+module EdsDocument
+  def html_fulltext_available?
+    self[:eds_html_fulltext].present?
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,6 +28,7 @@ class SolrDocument
   include Citable
   include MarcLinkedSerials
   include MarcMetadata
+  include EdsDocument
 
   include Blacklight::Solr::Document
 

--- a/app/views/article/_show_default.html.erb
+++ b/app/views/article/_show_default.html.erb
@@ -5,17 +5,16 @@
     <%= render "article/record/metadata_panels", document: document -%>
   </div>
   <div class="article-record-sections record-sections col-md-8">
+    <% sections = blacklight_config.show.sections %>
+    <% if document.html_fulltext_available? %>
+      <div class="html-fulltext-container">
+        <%= render('article/record/html_fulltext', document: document, fields: sections["Fulltext"].keys)%>
+      </div>
+    <% end %>
     <dl class="dl-horizontal dl-invert">
-      <% blacklight_config.show.sections.each do |section_name, fields| -%>
+      <% sections.each do |section_name, fields| -%>
         <% if (section = render('article/record/section_fields', document: document, fields: fields.keys)).present? -%>
-          <% if section_name == 'Fulltext' -%>
-            <div class="section-container-heading">
-              <h2>Full Text</h2>
-            </div>
-            <div class='section-body'>
-              <%= section -%>
-            </div>
-          <% else -%>
+          <% unless section_name == 'Fulltext' -%>
             <% if section_name == 'Summary' -%>
               <div class="section-container-heading">
                 <h2>About this article</h2>

--- a/app/views/article/record/_html_fulltext.erb
+++ b/app/views/article/record/_html_fulltext.erb
@@ -1,0 +1,13 @@
+<% doc_presenter = presenter(document) -%>
+<button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="false" aria-controls="toggleFulltext">
+  <h2>Full text</h2>
+</button>
+<div class='section-body collapse' id="toggleFulltext">
+<% fields.each do |field_name| -%>
+  <% field_name = field_name.to_s -%>
+  <% value = doc_presenter.field_value field_name -%>
+  <% if value.present? %>
+    <div class="blacklight-<%= field_name.parameterize %>"><%= value %></div>
+  <% end -%>
+<% end -%>
+</div>

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -18,15 +18,27 @@ feature 'Article Record Display' do
     end
   end
 
-  describe 'Fulltext' do
+  describe 'Fulltext', js: true do
     let(:document) do
       SolrDocument.new(id: '123', eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
     end
 
+    it 'toggled via panel heading' do
+      visit article_path(document[:id])
+      expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: false)
+
+      find('#fulltextToggleBar').click
+      expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
+      expect(page).to have_content('This Journal')
+    end
+
     it 'renders HTML' do
       visit article_path(document[:id])
+      find('#fulltextToggleBar').click
       expect(page).to have_css('.blacklight-eds_html_fulltext')
-      expect(page).not_to have_content('<anid>')
+      within('div.blacklight-eds_html_fulltext') do
+        expect(page).not_to have_content('<anid>')
+      end
     end
   end
 

--- a/spec/models/concerns/eds_document.rb
+++ b/spec/models/concerns/eds_document.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe EdsDocument do
+  let(:document) do
+    SolrDocument.new(id: '123', eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
+  end
+  let(:empty_document) do
+    SolrDocument.new(id: '456', eds_html_fulltext: '')
+  end
+
+  describe '#html_fulltext_available' do
+    it 'should return true when fulltext is present' do
+      expect(document.html_fulltext_available?).to be true
+    end
+
+    it 'returns nil when fulltext is not available' do
+      expect(empty_document.html_fulltext_available?).to be_falsey
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -121,4 +121,10 @@ describe SolrDocument do
       expect(subject).to respond_to :organization_and_arrangement
     end
   end
+
+  describe 'EdsDocument' do
+    it 'is included' do
+      expect(subject).to be_kind_of EdsDocument
+    end
+  end
 end


### PR DESCRIPTION
Closes #1509 

This PR adds hide/show functionality for HTML fulltext in the article record view:
- Hides full text by default
- Clicking on the section header (green bar) toggles fulltext
- `View full text / Show full text` does not appear in records where HTML full text is unavailable
- adds a concern for `EdsDocument`

## Demo
![hide-show-fulltext](https://user-images.githubusercontent.com/5402927/28686780-44a28738-72c1-11e7-97d2-fec219879f84.gif)
