### PR TITLE
Update emailing record spec button trigger

### DIFF
--- a/spec/features/blacklight_customizations/emailing_records_spec.rb
+++ b/spec/features/blacklight_customizations/emailing_records_spec.rb
@@ -38,7 +38,7 @@ describe "Emailing Records", type: :feature, js: true do
         fill_in 'to', with: 'email@example.com'
         choose 'Full record'
 
-        find('button[type="submit"]').click
+        find('button[type="submit"]').trigger('click')
       end
 
       # triggers capybara to wait until email is sent


### PR DESCRIPTION
This PR updates how `submit` is triggered in `emailing_records_spec.rb`. Once we rebase these changes into `article-search`, this will hopefully address our failing Travis builds.