### PR TITLE
upgrade to ebsco-eds 0.2.7.pre

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.2.3.pre)
+    ebsco-eds (0.2.7.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)
@@ -191,7 +191,7 @@ GEM
       require_all (~> 1.3)
     erubi (1.6.1)
     execjs (2.7.0)
-    faraday (0.12.1)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-detailed_logger (2.1.1)
       faraday (~> 0.8)
@@ -262,7 +262,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
-    minitest (5.10.2)
+    minitest (5.10.3)
     mods (2.1.0)
       iso-639
       nokogiri


### PR DESCRIPTION
The latest ebsco-eds gem adds support for `eds_publication_year_range_facet` and the DE (descriptor) field code.