### PR TITLE
update EDS ID spliting logic

### DIFF
--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -25,8 +25,8 @@ module Eds
     end
 
     def eds_find(id, params, eds_params)
-      dbid = id.split('__').first
-      accession = id.split('__').last.tr('_', '.')
+      dbid = id.split('__', 2).first
+      accession = id.split('__', 2).last.tr('_', '.')
       eds_session = EBSCO::EDS::Session.new(eds_session_options(eds_params.update(caller: 'bl-repo-find')))
       record = eds_session.retrieve(dbid: dbid, an: accession)
       blacklight_config.response_model.new(record.to_solr,

--- a/spec/models/eds/repository_spec.rb
+++ b/spec/models/eds/repository_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe Eds::Repository do
         to_solr: instance_double(SolrDocument)
       )
     )
-    expect(EBSCO::EDS::Session).to receive(:new).and_return(session)
+    expect(EBSCO::EDS::Session).to receive(:new).twice.and_return(session)
     expect(instance.find('123__abc')).to be_truthy
+    expect(instance.find('123__abc__def')).to be_truthy
   end
 
   context '#search (normal)' do


### PR DESCRIPTION
This PR allows double underscores to be included in the accession id.