### PR TITLE
Add article email content for brief records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem "letter_opener"
 end
 
 gem 'ruby-oembed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,8 @@ GEM
       unicode (~> 0.4)
     launchy (2.4.3)
       addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     library_stdnums (1.6.0)
     libv8 (3.16.14.19)
     listen (3.1.5)
@@ -506,6 +508,7 @@ DEPENDENCIES
   jquery-datatables-rails
   jquery-rails
   launchy
+  letter_opener
   listen (>= 3.0.5, < 3.2)
   mods_display (~> 0.4.0)
   mysql2

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -196,9 +196,9 @@ class ArticleController < ApplicationController
     email_addresses.each do |email_address|
       email_params[:to] = email_address
       email = if params[:type] == 'full'
-                SearchWorksRecordMailer.full_email_record(documents, email_params, url_options)
+                SearchWorksRecordMailer.article_full_email_record(documents, email_params, url_options)
               else
-                SearchWorksRecordMailer.email_record(documents, email_params, url_options)
+                SearchWorksRecordMailer.article_email_record(documents, email_params, url_options)
               end
       email.deliver_now
     end

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -5,6 +5,7 @@ class ArticleController < ApplicationController
   include Blacklight::Catalog
   include Blacklight::Configurable
   include EdsPaging
+  include EmailValidation
 
   before_action :set_search_query_modifier, only: :index
 
@@ -169,7 +170,41 @@ class ArticleController < ApplicationController
   # Used by default Blacklight `index` and `show` actions
   delegate :search_results, :fetch, to: :search_service
 
+  def email
+    # TODO: Handle arrays of IDs in future selection work
+    @response, @documents = fetch(params[:id])
+    if request.post? && validate_email_params
+      send_emails_to_all_recipients
+
+      respond_to do |format|
+        format.html { redirect_to solr_document_path(params['id']) }
+        format.js { render 'email_success' }
+      end and return
+    end
+
+    respond_to do |format|
+      format.html
+      format.js { render layout: false }
+    end
+  end
+
   protected
+
+  def send_emails_to_all_recipients
+    documents = Array.wrap(@documents)
+    email_params = { message: params[:message], subject: params[:subject], email_from: params[:email_from] }
+    email_addresses.each do |email_address|
+      email_params[:to] = email_address
+      email = if params[:type] == 'full'
+                SearchWorksRecordMailer.full_email_record(documents, email_params, url_options)
+              else
+                SearchWorksRecordMailer.email_record(documents, email_params, url_options)
+              end
+      email.deliver_now
+    end
+
+    flash[:success] = I18n.t('blacklight.email.success')
+  end
 
   def _prefixes
     @_prefixes ||= super + ['catalog']

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -24,6 +24,8 @@ class CatalogController < ApplicationController
 
   include LocationFacet
 
+  include EmailValidation
+
   before_action :set_search_query_modifier, only: :index
 
   before_action only: :index do
@@ -405,55 +407,6 @@ class CatalogController < ApplicationController
       format: document[document.format_key],
       holdings: document.holdings.as_json(live: live)
     }
-  end
-
-  def send_emails_to_all_recipients
-    email_params = { message: params[:message], subject: params[:subject], email_from: params[:email_from] }
-    email_addresses.each do |email_address|
-      email_params[:to] = email_address
-      email = if params[:type] == 'full'
-                SearchWorksRecordMailer.full_email_record(@documents, email_params, url_options)
-              else
-                SearchWorksRecordMailer.email_record(@documents, email_params, url_options)
-              end
-      email.deliver_now
-    end
-
-    flash[:success] = I18n.t('blacklight.email.success')
-  end
-
-  def validate_email_params
-    case
-    when !%w(full brief).include?(params[:type])
-      flash[:error] = I18n.t('blacklight.email.errors.type')
-    when params[:email_address].present?
-      flash[:error] = I18n.t('blacklight.email.errors.email_address')
-    when params[:message] =~ %r{href|url=|https?://}i
-      flash[:error] = I18n.t('blacklight.email.errors.message.spam')
-    when params[:to].blank?
-      flash[:error] = I18n.t('blacklight.email.errors.to.blank')
-    when too_many_email_addresses?
-      flash[:error] = I18n.t('blacklight.email.errors.to.too_many', max: Settings.EMAIL_THRESHOLD)
-    when !valid_email_addresses?
-      flash[:error] = I18n.t('blacklight.email.errors.to.invalid', to: params[:to])
-    end
-
-    flash[:error].blank?
-  end
-
-  def valid_email_addresses?
-    email_regexp = defined?(Devise) ? Devise.email_regexp : /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/
-    email_addresses.all? do |email|
-      email.match(email_regexp)
-    end
-  end
-
-  def too_many_email_addresses?
-    email_addresses.length > Settings.EMAIL_THRESHOLD.to_i
-  end
-
-  def email_addresses
-    params[:to].split(/,|\s+/).reject(&:blank?)
   end
 
   def modifiable_params_keys

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -409,6 +409,21 @@ class CatalogController < ApplicationController
     }
   end
 
+  def send_emails_to_all_recipients
+    email_params = { message: params[:message], subject: params[:subject], email_from: params[:email_from] }
+    email_addresses.each do |email_address|
+      email_params[:to] = email_address
+      email = if params[:type] == 'full'
+                SearchWorksRecordMailer.full_email_record(@documents, email_params, url_options)
+              else
+                SearchWorksRecordMailer.email_record(@documents, email_params, url_options)
+              end
+      email.deliver_now
+    end
+
+    flash[:success] = I18n.t('blacklight.email.success')
+  end
+
   def modifiable_params_keys
     %w[q search search_author search_title subject_terms series_search pub_search isbn_search]
   end

--- a/app/controllers/concerns/email_validation.rb
+++ b/app/controllers/concerns/email_validation.rb
@@ -1,21 +1,6 @@
 module EmailValidation
   extend ActiveSupport::Concern
 
-  def send_emails_to_all_recipients
-    email_params = { message: params[:message], subject: params[:subject], email_from: params[:email_from] }
-    email_addresses.each do |email_address|
-      email_params[:to] = email_address
-      email = if params[:type] == 'full'
-                SearchWorksRecordMailer.full_email_record(@documents, email_params, url_options)
-              else
-                SearchWorksRecordMailer.email_record(@documents, email_params, url_options)
-              end
-      email.deliver_now
-    end
-
-    flash[:success] = I18n.t('blacklight.email.success')
-  end
-
   def validate_email_params
     case
     when !%w(full brief).include?(params[:type])

--- a/app/controllers/concerns/email_validation.rb
+++ b/app/controllers/concerns/email_validation.rb
@@ -1,0 +1,53 @@
+module EmailValidation
+  extend ActiveSupport::Concern
+
+  def send_emails_to_all_recipients
+    email_params = { message: params[:message], subject: params[:subject], email_from: params[:email_from] }
+    email_addresses.each do |email_address|
+      email_params[:to] = email_address
+      email = if params[:type] == 'full'
+                SearchWorksRecordMailer.full_email_record(@documents, email_params, url_options)
+              else
+                SearchWorksRecordMailer.email_record(@documents, email_params, url_options)
+              end
+      email.deliver_now
+    end
+
+    flash[:success] = I18n.t('blacklight.email.success')
+  end
+
+  def validate_email_params
+    case
+    when !%w(full brief).include?(params[:type])
+      flash[:error] = I18n.t('blacklight.email.errors.type')
+    when params[:email_address].present?
+      flash[:error] = I18n.t('blacklight.email.errors.email_address')
+    when params[:message] =~ %r{href|url=|https?://}i
+      flash[:error] = I18n.t('blacklight.email.errors.message.spam')
+    when params[:to].blank?
+      flash[:error] = I18n.t('blacklight.email.errors.to.blank')
+    when too_many_email_addresses?
+      flash[:error] = I18n.t('blacklight.email.errors.to.too_many', max: Settings.EMAIL_THRESHOLD)
+    when !valid_email_addresses?
+      flash[:error] = I18n.t('blacklight.email.errors.to.invalid', to: params[:to])
+    end
+
+    flash[:error].blank?
+  end
+
+  def valid_email_addresses?
+    email_regexp = defined?(Devise) ? Devise.email_regexp : /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/
+    email_addresses.all? do |email|
+      email.match(email_regexp)
+    end
+  end
+
+  def too_many_email_addresses?
+    email_addresses.length > Settings.EMAIL_THRESHOLD.to_i
+  end
+
+  def email_addresses
+    params[:to].split(/,|\s+/).reject(&:blank?)
+  end
+
+end

--- a/app/mailers/search_works_record_mailer.rb
+++ b/app/mailers/search_works_record_mailer.rb
@@ -13,7 +13,19 @@ class SearchWorksRecordMailer < ActionMailer::Base
     mail(to: details[:to], subject: subject_from_details(details, documents))
   end
 
+  def article_email_record(documents, details, url_gen_params)
+    setup_email_defaults(documents, details, url_gen_params)
+
+    mail(to: details[:to], subject: subject_from_details(details, documents))
+  end
+
   def full_email_record(documents, details, url_gen_params)
+    setup_email_defaults(documents, details, url_gen_params)
+
+    mail(to: details[:to], subject: subject_from_details(details, documents))
+  end
+
+  def article_full_email_record(documents, details, url_gen_params)
     setup_email_defaults(documents, details, url_gen_params)
 
     mail(to: details[:to], subject: subject_from_details(details, documents))

--- a/app/models/concerns/searchworks/document/email.rb
+++ b/app/models/concerns/searchworks/document/email.rb
@@ -1,30 +1,5 @@
 # -*- encoding : utf-8 -*-
-# Overridding Blacklight's module to provide our own breif email text
+# Overridding Blacklight's module to provide our own brief email text
 module Searchworks::Document::Email
   include Blacklight::Document::Email
-
-  # Return a text string that will be the body of the email
-  def to_email_text
-    semantics = self.to_semantic_values
-    body = []
-    body << I18n.t('blacklight.email.text.title', :value => semantics[:title].join(" ")) if semantics[:title].present?
-    body << I18n.t('blacklight.email.text.author', :value => semantics[:author].join(" ")) if semantics[:author].present?
-    if self.holdings.present?
-      holdings.libraries.each do |library|
-        library.locations.each do |location|
-          body << "#{library.name} - #{location.name}"
-          location.items.each do |item|
-            body << "\t#{item.callnumber}"
-          end
-        end
-      end
-    end
-    if self.access_panels.online?
-      body << "Online:"
-      self.access_panels.online.links.each do |link|
-        body << "\t#{link.href}"
-      end
-    end
-    return body.join("\n") unless body.empty?
-  end
 end

--- a/app/views/article/_email_form.html.erb
+++ b/app/views/article/_email_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_tag url_for(:controller => "article", :action => "email"), :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
+  <%= render :partial=>'shared/email_form' %>
+
+  <%=hidden_field_tag :type, 'brief' %>
+  <!-- TODO: update after article selections  -->
+  <%=hidden_field_tag "id[]", @documents.id %>
+  <%- if params[:sort] -%>
+    <%= hidden_field_tag "sort", params[:sort] %>
+  <%- end -%>
+  <%- if params[:per_page] -%>
+    <%= hidden_field_tag "per_page", params[:per_page] %>
+  <%- end -%>
+  </div>
+  <div class="modal-footer">
+  <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
+  </div>
+<% end %>

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -1,54 +1,5 @@
 <%= form_tag url_for(:controller => "catalog", :action => "email"), :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
-
-  <div class="modal-body">
-    <%= render :partial=>'/flash_msg' %>
-    <div class="form-group">
-      <div class="col-sm-10 col-sm-offset-2">
-        <%= radio_button_tag :type, 'brief', true %> <%= label_tag(:type_brief,  "<strong>Brief record</strong> (title & author, library & call number, links, bookmark)".html_safe) %><br/>
-        <%= radio_button_tag :type, 'full' %> <%= label_tag(:type_full, "<strong>Full record</strong>".html_safe) %>
-      </div>
-    </div>
-    <div style="display:none; visibility: hidden;">
-      <%= label_tag(:email_address, "Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.")%>
-      <%= text_field_tag :email_address, "" %>
-    </div>
-    <div class="form-group">
-      <label class="control-label col-sm-2" for="to">
-        <%= t('blacklight.email.form.to') %>
-      </label>
-      <div class="col-sm-10">
-        <%= email_field_tag :to, params[:to], multiple: true, class: 'form-control' %>
-        <span class='help-block'>Separate multiple addresses with a comma.</span>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-2" for="email_from">
-        <%= t('blacklight.email.form.email_from.label') %>
-      </label>
-      <div class="col-sm-10">
-        <%= text_field_tag :email_from, params[:email_from], placeholder: t('blacklight.email.form.email_from.placeholder'), class: 'form-control' %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-2" for="subject">
-        Subject:
-      </label>
-      <div class="col-sm-10">
-        <%= text_field_tag :subject, I18n.t('blacklight.email.text.subject', :count => @documents.length, :title => (@documents.first.to_semantic_values[:title].first rescue 'N/A') ), class: 'form-control' %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-2" for="message">
-        <%= t('blacklight.email.form.message') %>
-      </label>
-      <div class="col-sm-10">
-        <%= text_area_tag :message, params[:message], class: 'form-control' %>
-      </div>
-    </div>
-
+  <%= render :partial=>'shared/email_form' %>
     <% @documents.each do |doc| %>
       <%=hidden_field_tag "id[]", doc.id %>
     <% end %>
@@ -60,6 +11,6 @@
     <%- end -%>
   </div>
   <div class="modal-footer">
-  <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
+    <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
   </div>
 <% end %>

--- a/app/views/search_works_record_mailer/article_email_record.html.erb
+++ b/app/views/search_works_record_mailer/article_email_record.html.erb
@@ -1,0 +1,26 @@
+<%= "Email from: #{@email_from}" if @email_from.present? %>
+<p><%= @message.html_safe unless @message.nil? %></p>
+
+<html>
+  <head>
+    <style>
+      .side-nav-minimap { display: none; }
+    </style>
+  </head>
+  <body>
+    <ol>
+      <% @documents.each do |document| %>
+        <li>
+          <strong><a href="<%= article_url(document, {:only_path => false}.merge(@url_gen_params)) %>"><%= document[:eds_title] if document[:eds_title].present? %></a></strong>
+          <div><%= document[:eds_authors].to_sentence if document[:eds_authors].present? %></div>
+          <div><%= document[:eds_composed_title].html_safe  if document[:eds_composed_title].present? %></div>
+          <% if document.eds_links.present? %>
+            <% link = document.eds_links.all.first %>
+            <div><a href="<%= link.href %>"><%= link.text %></a></div>
+          <% end %>
+        </li>
+        <hr>
+      <% end %>
+    </ol>
+  </body>
+</html>

--- a/app/views/search_works_record_mailer/article_full_email_record.html.erb
+++ b/app/views/search_works_record_mailer/article_full_email_record.html.erb
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <style>
+      .side-nav-minimap { display: none; }
+    </style>
+  </head>
+  <body>
+    <% if @message.present? || @email_from.present? %>
+      <dl>
+        <% if @email_from.present? %>
+          <dt>Email from</dt>
+          <dd><%= @email_from %></dd>
+        <% end %>
+        <% if @message.present? %>
+          <dt>Message</dt>
+          <dd><%= @message %></dd>
+        <% end %>
+      </dl>
+    <% end %>
+    <% @documents.each do |document| %>
+      <h1><a href="<%= polymorphic_url(document, {:only_path => false}.merge(@url_gen_params)) %>"><%= document[:title_display] %></a></h1>
+      <% if document.access_panels.online? %>
+        <h2>Online</h2>
+        <% document.access_panels.online.links.each do |link| %>
+          <%= link.html.html_safe %><br/>
+        <% end %>
+      <% end %>
+      <hr/>
+    <% end %>
+  </body>
+</html>

--- a/app/views/search_works_record_mailer/email_record.html.erb
+++ b/app/views/search_works_record_mailer/email_record.html.erb
@@ -1,0 +1,41 @@
+<%= "Email from: #{@email_from}" if @email_from.present? %>
+<p><%= @message.html_safe unless @message.nil? %></p>
+
+<html>
+  <head>
+    <style>
+      .side-nav-minimap { display: none; }
+    </style>
+  </head>
+  <body>
+    <ol>
+      <% @documents.each do |document| %>
+        <% semantics = document.to_semantic_values %>
+        <li>
+          <strong><a href="<%= polymorphic_url(document, {:only_path => false}.merge(@url_gen_params)) %>"><%= semantics[:title].join(" ") if semantics[:title].present? %></a></strong>
+          <div>
+            <% if document.holdings.present? %>
+              <% document.holdings.libraries.each do |library| %>
+                <% library.locations.each do |location| %>
+                  <ul><li><%= library.name %> - <%= location.name %>
+                  <% location.items.each do |item| %>
+                    <ul><li><%= item.callnumber %></li></ul>
+                  <% end %>
+                </li>
+                <% end %>
+              </ul>
+              <% end %>
+            <% end %>
+          </div>
+          <div>
+            <% if document.access_panels.online? %>
+            <% document.access_panels.online.links.each do |link| %>
+              Online: <a href="<%= link.href %>"><%= link.text.html_safe %></a>
+            <% end %>
+          <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ol>
+  </body>
+</html>

--- a/app/views/search_works_record_mailer/email_record.text.erb
+++ b/app/views/search_works_record_mailer/email_record.text.erb
@@ -1,8 +1,0 @@
-<%= "Email from: #{@email_from}" if @email_from.present? %>
-Message: <%= @message.html_safe unless @message.nil? %>
-______________________________________________________________
-<% @documents.each do |document| %>
-<%= document.to_email_text %>
-Bookmark: <%= polymorphic_url(document, {:only_path => false}.merge(@url_gen_params)) %>
-______________________________________________________________
-<% end %>

--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -1,0 +1,50 @@
+<div class="modal-body">
+  <%= render :partial=>'/flash_msg' %>
+  <div class="form-group">
+    <% unless controller.controller_name == 'article' # TODO: full record for articles %>
+      <div class="col-sm-10 col-sm-offset-2">
+        <%= radio_button_tag :type, 'brief', true %> <%= label_tag(:type_brief,  "<strong>Brief record</strong> (title & author, library & call number, links, bookmark)".html_safe) %><br/>
+        <%= radio_button_tag :type, 'full' %> <%= label_tag(:type_full, "<strong>Full record</strong>".html_safe) %>
+      </div>
+    <% end %>
+  </div>
+  <div style="display:none; visibility: hidden;">
+    <%= label_tag(:email_address, "Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.")%>
+    <%= text_field_tag :email_address, "" %>
+  </div>
+  <div class="form-group">
+    <label class="control-label col-sm-2" for="to">
+      <%= t('blacklight.email.form.to') %>
+    </label>
+    <div class="col-sm-10">
+      <%= email_field_tag :to, params[:to], multiple: true, class: 'form-control' %>
+      <span class='help-block'>Separate multiple addresses with a comma.</span>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label col-sm-2" for="email_from">
+      <%= t('blacklight.email.form.email_from.label') %>
+    </label>
+    <div class="col-sm-10">
+      <%= text_field_tag :email_from, params[:email_from], placeholder: t('blacklight.email.form.email_from.placeholder'), class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label col-sm-2" for="subject">
+      Subject:
+    </label>
+    <div class="col-sm-10">
+      <%= text_field_tag :subject, I18n.t('blacklight.email.text.subject', :count => @documents.length, :title => (@documents.first.to_semantic_values[:title].first rescue 'N/A') ), class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label col-sm-2" for="message">
+      <%= t('blacklight.email.form.message') %>
+    </label>
+    <div class="col-sm-10">
+      <%= text_area_tag :message, params[:message], class: 'form-control' %>
+    </div>
+  </div>

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <% if @document.respond_to?( :to_email_text ) %>
   <li class="email" role="presentation">
-    <% if @document[:eds_result_id].present? %>
+    <% if @document[:eds_title].present? %>
       <%= link_to t('blacklight.tools.email_html'), email_article_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
     <% else %>
       <%= link_to t('blacklight.tools.email_html'), email_solr_document_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -5,7 +5,11 @@
 <% end %>
 <% if @document.respond_to?( :to_email_text ) %>
   <li class="email" role="presentation">
-    <%= link_to t('blacklight.tools.email_html'), email_solr_document_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
+    <% if @document[:eds_result_id].present? %>
+      <%= link_to t('blacklight.tools.email_html'), email_article_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
+    <% else %>
+      <%= link_to t('blacklight.tools.email_html'), email_solr_document_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
+    <% end %>
   </li>
 <% end %>
 <% if @document.export_formats.keys.include?( :refworks_marc_txt ) %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Open emails in the browser
+  config.action_mailer.delivery_method = :letter_opener
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,9 @@ Rails.application.routes.draw do
   resources :course_reserves, only: :index, path: "reserves"
 
   constraints(id: /[-~\+\w]+/) do # EDS identifier rules (e.g., db__id)
-    resources :article, only: %i[index show]
+    resources :article, only: %i[index show] do
+      concerns :exportable
+    end
     post "article/:id/track" => 'article#track', as: :track_article
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -16,6 +16,10 @@ describe CatalogController do
   it "should include the ReplaceSpecialQuotes concern" do
     expect(subject).to be_kind_of(ReplaceSpecialQuotes)
   end
+
+  it "should include the EmailValidation concern" do
+    expect(subject).to be_kind_of(EmailValidation)
+  end
   describe "#index" do
     it "should set the search modifier" do
       get :index

--- a/spec/features/blacklight_customizations/emailing_records_spec.rb
+++ b/spec/features/blacklight_customizations/emailing_records_spec.rb
@@ -13,12 +13,49 @@ describe "Emailing Records", type: :feature, js: true do
       end
     end
 
+    expect(URI(find('#email_form')['action']).path).to eq(email_solr_document_path('14'))
+
     within('.modal-dialog') do
       fill_in 'to', with: 'email@example.com'
       find('button[type="submit"]').trigger('click')
     end
 
     expect(page).to have_css('.alert-success', text: 'Email Sent', visible: true)
+  end
+
+  context 'article' do
+    before { stub_article_service(type: :single, docs: [document]) }
+    let(:document) do
+      SolrDocument.new(
+        id: '123',
+        eds_title: 'The title',
+        eds_abstract: 'The Abstract',
+        eds_subjects_person: %w[A Subject],
+        eds_volume: 'The Volumne'
+      )
+    end
+
+    it 'sends a brief record' do
+      visit article_path(document[:id])
+
+      within('.record-toolbar') do
+        within('li.dropdown') do
+          click_button 'Send to'
+          within('.dropdown-menu') do
+            click_link 'email'
+          end
+        end
+      end
+
+      expect(URI(find('#email_form')['action']).path).to eq(email_article_path(document))
+
+      within('.modal-dialog') do
+        fill_in 'to', with: 'email@example.com'
+        find('button[type="submit"]').trigger('click')
+      end
+
+      expect(page).to have_css('.alert-success', text: 'Email Sent', visible: true)
+    end
   end
 
   context 'emailing a full record' do

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -70,66 +70,79 @@ describe SearchWorksRecordMailer do
     end
   end
   describe 'full_email_record' do
-    let(:mail) { SearchWorksRecordMailer.full_email_record(documents, params, url_params) }
-    it 'should send a html email' do
-      expect(mail.content_type).to match /text\/html/
-    end
+    context 'catalog' do
+      let(:mail) { SearchWorksRecordMailer.full_email_record(documents, params, url_params) }
 
-    it 'should include full HTML markup' do
-      expect(mail.body).to have_css('html')
-      expect(mail.body).to have_css('body')
-    end
-
-    it 'includes the Email From text when present' do
-      expect(mail.body).to have_css('dt', text: 'Email from')
-      expect(mail.body).to have_css('dd', text: 'Jane Stanford')
-    end
-
-    it 'should include the titles of all documents as links' do
-      expect(mail.body).to have_css('h1 a', text: 'Title1')
-      expect(mail.body).to have_css('h1 a', text: 'Title2')
-    end
-    it 'should include Subjects and Bibliographic information from both MARC and MODS records' do
-      expect(mail.body).to have_css('h2', text: 'Subjects', count: 2)
-      expect(mail.body).to have_css('h2', text: 'Bibliographic information', count: 2)
-    end
-    it 'should include the HTML markup for MARC records' do
-      expect(mail.body).to have_css('dt', text: 'Related Work')
-      expect(mail.body).to have_css('dd', text: 'A quartely publication.')
-    end
-    it 'should include the HTML markup for MODS records' do
-      expect(mail.body).to have_css('dt', text: 'Contributor')
-      expect(mail.body).to have_css('dd', text: 'B. Smith (Producer)')
-    end
-    it 'should include holdings of all documents' do
-      expect(mail.body).to have_css('h2', text: 'At the library', count: documents.length)
-      expect(mail.body).to have_css('dt', text: 'Green Library - Stacks')
-      expect(mail.body).to have_css('dd', text: 'ABC 123')
-
-      expect(mail.body).to have_css('dt', text: 'SAL3 (off-campus storage) - Stacks')
-      expect(mail.body).to have_css('dd', text: 'ABC 321')
-    end
-    it 'should include links of all the documents' do
-      expect(mail.body).to have_css('h2', text: 'Online')
-      expect(mail.body).to have_css('a', text: 'Find full text', count: documents.length)
-    end
-    it 'should separate records w/ a horizontal rule' do
-      expect(mail.body).to have_css('hr', count: documents.length)
-    end
-
-    context 'when there is bookplate data' do
-      let(:bookplate_document) do
-        SolrDocument.new(
-          id: '123',
-          marcxml: metadata1,
-          bookplates_display: ['FUND-NAME -|- druid:abc123 -|- file-id-abc123.jp2 -|- BOOKPLATE-TEXT']
-        )
+      it 'should send a html email' do
+        expect(mail.content_type).to match(/text\/html/)
       end
-      let(:mail) { SearchWorksRecordMailer.full_email_record([bookplate_document], params, url_params) }
-      it 'renders the bookplate data successfully' do
-        expect(mail.body).to have_css('h2', text: 'Acquired with support from')
-        expect(mail.body).to have_css('.media-body', text: /BOOKPLATE-TEXT/)
+
+      it 'should include full HTML markup' do
+        expect(mail.body).to have_css('html')
+        expect(mail.body).to have_css('body')
       end
+
+      it 'includes the Email From text when present' do
+        expect(mail.body).to have_css('dt', text: 'Email from')
+        expect(mail.body).to have_css('dd', text: 'Jane Stanford')
+      end
+
+      it 'should include the titles of all documents as links' do
+        expect(mail.body).to have_css('h1 a', text: 'Title1')
+        expect(mail.body).to have_css('h1 a', text: 'Title2')
+      end
+
+      it 'should include Subjects and Bibliographic information from both MARC and MODS records' do
+        expect(mail.body).to have_css('h2', text: 'Subjects', count: 2)
+        expect(mail.body).to have_css('h2', text: 'Bibliographic information', count: 2)
+      end
+
+      it 'should include the HTML markup for MARC records' do
+        expect(mail.body).to have_css('dt', text: 'Related Work')
+        expect(mail.body).to have_css('dd', text: 'A quartely publication.')
+      end
+
+      it 'should include the HTML markup for MODS records' do
+        expect(mail.body).to have_css('dt', text: 'Contributor')
+        expect(mail.body).to have_css('dd', text: 'B. Smith (Producer)')
+      end
+
+      it 'should include holdings of all documents' do
+        expect(mail.body).to have_css('h2', text: 'At the library', count: documents.length)
+        expect(mail.body).to have_css('dt', text: 'Green Library - Stacks')
+        expect(mail.body).to have_css('dd', text: 'ABC 123')
+
+        expect(mail.body).to have_css('dt', text: 'SAL3 (off-campus storage) - Stacks')
+        expect(mail.body).to have_css('dd', text: 'ABC 321')
+      end
+
+      it 'should include links of all the documents' do
+        expect(mail.body).to have_css('h2', text: 'Online')
+        expect(mail.body).to have_css('a', text: 'Find full text', count: documents.length)
+      end
+
+      it 'should separate records w/ a horizontal rule' do
+        expect(mail.body).to have_css('hr', count: documents.length)
+      end
+
+      context 'when there is bookplate data' do
+        let(:bookplate_document) do
+          SolrDocument.new(
+            id: '123',
+            marcxml: metadata1,
+            bookplates_display: ['FUND-NAME -|- druid:abc123 -|- file-id-abc123.jp2 -|- BOOKPLATE-TEXT']
+          )
+        end
+        let(:mail) { SearchWorksRecordMailer.full_email_record([bookplate_document], params, url_params) }
+        it 'renders the bookplate data successfully' do
+          expect(mail.body).to have_css('h2', text: 'Acquired with support from')
+          expect(mail.body).to have_css('.media-body', text: /BOOKPLATE-TEXT/)
+        end
+      end
+    end
+
+    context 'article' do
+      skip('Todo: article full record email')
     end
   end
 end

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -25,50 +25,99 @@ describe SearchWorksRecordMailer do
     { to: 'email@example.com', message: 'The message', subject: 'The subject', email_from: 'Jane Stanford' }
   end
   let(:url_params) { {host: 'example.com'} }
+
   describe 'email_record' do
-    let(:mail) { SearchWorksRecordMailer.email_record(documents, params, url_params) }
-    it 'should send a plain-text email' do
-      expect(mail.content_type).to match /text\/plain/
+    context 'article' do
+      let(:documents) {[SolrDocument.new(id: '123', eds_title: 'Title1', eds_authors: ['Author1'],eds_fulltext_links: [{ 'label' => 'View request options', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]
+        )]}
+      let(:mail) { SearchWorksRecordMailer.article_email_record(documents, params, url_params) }
+
+      it 'should send an HTML email' do
+        expect(mail.content_type).to match "text/html; charset=UTF-8"
+      end
+
+      it 'has the subject that was passed in via method params' do
+        expect(mail.subject).to eq 'The subject'
+      end
+
+      it 'has the subject that from the document when none was passed in' do
+        skip('Need to update subject_from_details ')
+        params[:subject] = nil
+        mail = SearchWorksRecordMailer.email_record(documents, params, url_params)
+        expect(mail.subject).to eq 'Item Record: N/A'
+      end
+
+      it 'includes the Email From text when present' do
+        expect(mail.body).to include 'Email from: Jane Stanford'
+      end
+
+      it 'should include the provided message' do
+        expect(mail.body).to include "The message"
+      end
+
+      it 'includes the title' do
+        expect(mail.body).to include "Title1"
+      end
+
+      it 'links to the record' do
+        expect(mail.body).to have_link("Title1", href: "http://example.com/article/123")
+      end
+
+      it 'includes links to fulltext' do
+        expect(mail.body).to have_link('Find it in print', href: "http://example.com")
+      end
     end
 
-    it 'has the subject that was passed in via method params' do
-      expect(mail.subject).to eq 'The subject'
-    end
+    context 'catalog' do
+      let(:mail) { SearchWorksRecordMailer.email_record(documents, params, url_params) }
+      it 'should send an HTML email' do
+        expect(mail.content_type).to match "text/html; charset=UTF-8"
+      end
 
-    it 'has the subject that from the document when none was passed in' do
-      params[:subject] = nil
-      mail = SearchWorksRecordMailer.email_record([documents.first], params, url_params)
-      expect(mail.subject).to eq 'Item Record: Title1'
-    end
+      it 'has the subject that was passed in via method params' do
+        expect(mail.subject).to eq 'The subject'
+      end
 
-    it 'includes the Email From text when present' do
-      expect(mail.body).to include 'Email from: Jane Stanford'
-    end
+      it 'has the subject that from the document when none was passed in' do
+        params[:subject] = nil
+        mail = SearchWorksRecordMailer.email_record([documents.first], params, url_params)
+        expect(mail.subject).to eq 'Item Record: Title1'
+      end
 
-    it 'should include the provided message' do
-      expect(mail.body).to include "Message: The message"
-    end
-    it 'should include the titles of all documents' do
-      expect(mail.body).to include "Title: Title1"
-      expect(mail.body).to include "Title: Title2"
-    end
-    it 'should include the callnumbers' do
-      expect(mail.body).to include "Green Library - Stacks"
-      expect(mail.body).to include "ABC 123"
+      it 'includes the Email From text when present' do
+        expect(mail.body).to include 'Email from: Jane Stanford'
+      end
 
-      expect(mail.body).to include "SAL3 (off-campus storage) - Stacks"
-      expect(mail.body).to include "ABC 321"
-    end
-    it 'should include the URLs' do
-      expect(mail.body).to include "Online:"
-      expect(mail.body).to include "https://library.stanford.edu"
-      expect(mail.body).to include "https://stacks.stanford.edu"
-    end
-    it 'should include the URL to all the documents' do
-      expect(mail.body).to include "Bookmark: http://example.com/view/123"
-      expect(mail.body).to include "Bookmark: http://example.com/view/321"
+      it 'should include the provided message' do
+        expect(mail.body).to include "The message"
+      end
+
+      it 'should include the titles of all documents' do
+        expect(mail.body).to include "Title1"
+        expect(mail.body).to include "Title2"
+      end
+
+      it 'should include the callnumbers' do
+        expect(mail.body).to include "Green Library - Stacks"
+        expect(mail.body).to include "ABC 123"
+
+        expect(mail.body).to include "SAL3 (off-campus storage) - Stacks"
+        expect(mail.body).to include "ABC 321"
+      end
+
+      it 'should include the URLs' do
+        expect(mail.body).to include "Online:"
+        expect(mail.body).to include "https://library.stanford.edu"
+        expect(mail.body).to include "https://stacks.stanford.edu"
+      end
+
+      it 'should include the URL to all the documents' do
+        expect(mail.body).to have_link("Title1", href: "http://example.com/view/123")
+        expect(mail.body).to have_link("Title2", href: "http://example.com/view/321")
+      end
     end
   end
+
   describe 'full_email_record' do
     context 'catalog' do
       let(:mail) { SearchWorksRecordMailer.full_email_record(documents, params, url_params) }


### PR DESCRIPTION
Fixes part of #1448 
Related: #1552, #1553 

## Todo
- [x] add an email action for the article controller
- [x] create a partial for article brief record
- [x] rebase and utilize new EdsLinks module from Jessie's SFX panel work
- [x] get presenters / helper methods working correctly in mailers
- [x] create a partial for article full record
- [x] write tests
- [x] record links should point to `/article` not `/view`

## Requirements
### Brief record
- some cleanup to apply to current SW catalog as well as articles
  - [x]  remove plaintext 
  - [x]  remove "Message:" from the top of the email
  - [x]  create HTML links to avoid exposed URLs
- output is formatted HTML and similar to the results view:
  - [x]  structured as ordered list; sub-elements can be divs
  - [x]  title, bold, linked to SW record 
  - [x]  authors, not linked
  - [x]  composed title (journal, date, issue, etc.)
  - [x]  link to full text, with whatever wording we end up using in the search results

## Examples
### Article 
<img width="814" alt="screen shot 2017-08-04 at 12 31 54 pm" src="https://user-images.githubusercontent.com/5402927/28984081-17b800ee-7911-11e7-9a9f-9bf1c5619592.png">


### Catalog record with holdings info
<img width="436" alt="screen shot 2017-08-04 at 2 29 41 pm" src="https://user-images.githubusercontent.com/5402927/28987895-3425acca-7922-11e7-8d2f-733423b482b5.png">
