### PR TITLE
add Research Starters to page 1 of results and as a show page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.2.7.pre)
+    ebsco-eds (0.2.8.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)
@@ -529,4 +529,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/app/assets/javascripts/article.js
+++ b/app/assets/javascripts/article.js
@@ -1,10 +1,18 @@
 Blacklight.onLoad(function(){
-
   $('#toggleFulltext').on('show.bs.collapse', function(){
     $('#fulltextToggleBar').html('<h2>Hide full text</h2>')
   });
 
   $('#toggleFulltext').on('hide.bs.collapse', function(){
     $('#fulltextToggleBar').html('<h2>Show full text</h2>')
+  });
+
+  // toggles close icon from plus to X and vice versa
+  $('#research-starter-body').on('hide.bs.collapse', function () {
+    $('#research-starter-close-icon').removeClass('fa-times-circle').addClass('fa-plus-circle');
+  });
+
+  $('#research-starter-body').on('show.bs.collapse', function () {
+    $('#research-starter-close-icon').removeClass('fa-plus-circle').addClass('fa-times-circle');
   });
 })

--- a/app/assets/stylesheets/modules/research-starter.scss
+++ b/app/assets/stylesheets/modules/research-starter.scss
@@ -4,14 +4,14 @@
   left: 10px;
   font-size: 16px;
   font-weight: 400;
-  color: #8c1515;
+  color: $sul-research-starter-color;
   text-transform: uppercase;
   letter-spacing: 1px;
   content: "Research Starter";
 }
 
 .research-starter {
-  border: 1px solid #8c1515;
+  border: 1px solid $sul-research-starter-color;
   box-shadow: 0 4px 8px -2px rgba(0,0,0,0.2);
 
   h3, p {
@@ -27,7 +27,7 @@
     margin-bottom: 10px;
   }
 
-  #research-starter-close-icon {
+  .research-starter-close-icon {
     border: none;
     position: relative;
     top: -15px;
@@ -35,7 +35,7 @@
     float: right;
     font-size: 2em;
     font-weight: 400;
-    color: #8c1515;
+    color: $sul-research-starter-color;
   }
 }
 
@@ -44,7 +44,7 @@
     margin-left: 10px;
     font-size: 16px;
     font-weight: 400;
-    color: #8c1515;
+    color: $sul-research-starter-color;
     text-transform: uppercase;
     letter-spacing: 1px;
   }
@@ -55,8 +55,8 @@
 
 .research-starter-figure {
   padding: 12px;
-  background-color: #fff;
-  border: 1px solid #e3dfd5;
+  background-color: $white;
+  border: 1px solid $beige-30-percent;
   margin-bottom: 20px;
 
   img {

--- a/app/assets/stylesheets/modules/research-starter.scss
+++ b/app/assets/stylesheets/modules/research-starter.scss
@@ -1,0 +1,72 @@
+.research-starter:before {
+  position: relative;
+  top: 10px;
+  left: 10px;
+  font-size: 16px;
+  font-weight: 400;
+  color: #8c1515;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  content: "Research Starter";
+}
+
+.research-starter {
+  border: 1px solid #8c1515;
+  box-shadow: 0 4px 8px -2px rgba(0,0,0,0.2);
+
+  h3, p {
+    margin: 10px 20px;
+  }
+
+  img {
+    max-height: 100px;
+    width: auto;
+    float: right;
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-bottom: 10px;
+  }
+
+  #research-starter-close-icon {
+    border: none;
+    position: relative;
+    top: -15px;
+    right: 10px;
+    float: right;
+    font-size: 2em;
+    font-weight: 400;
+    color: #8c1515;
+  }
+}
+
+.research-starter-show {
+  .research-starter-label {
+    margin-left: 10px;
+    font-size: 16px;
+    font-weight: 400;
+    color: #8c1515;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .research-starter-source-title {
+    margin-left: 30px;
+  }
+}
+
+.research-starter-figure {
+  padding: 12px;
+  background-color: #fff;
+  border: 1px solid #e3dfd5;
+  margin-bottom: 20px;
+
+  img {
+    max-height: 200px;
+    width: auto;
+  }
+
+  span {
+    position: absolute;
+    margin-right: 10px;
+    padding: 12px;
+  }
+}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -51,6 +51,7 @@
 @import 'modules/side-nav-minimap';
 @import 'modules/record-toolbar';
 @import 'modules/requests-modal';
+@import 'modules/research-starter';
 @import 'modules/results-documents';
 @import 'modules/search-bar';
 @import 'modules/subnavbar';

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -130,6 +130,7 @@ $sul-location-panel-btn-background: #007cbc;
 $sul-location-panel-btn-border: #006ba3;
 $sul-location-panel-btn-background-hover: #005a89;
 $sul-location-panel-btn-border-hover: #001723;
+$sul-research-starter-color: #8c1515;
 
 // Sizes
 $gallery-document-width: 176px;

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -81,7 +81,7 @@ class ArticleController < ApplicationController
     config.show.document_presenter_class = ShowDocumentPresenter
     config.show.html_title = 'eds_title'
     config.show.heading = 'eds_title'
-    config.show.display_type = 'format'
+    config.show.display_type_field = 'eds_publication_type'
     config.show.pub_date = 'eds_publication_date'
     config.show.pub_info = 'eds_publisher_info'
     config.show.abstract = 'eds_abstract'

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -6,16 +6,6 @@ module ArticleHelper
     controller_name == 'article'
   end
 
-  def article_research_starter?(document)
-    # TODO: we probably need a better place to put this...
-    document['eds_database_name'] == 'Research Starters' if document
-  end
-
-  def article_restricted?(document)
-    # TODO: we probably need a better way to determine this
-    document['eds_title'] =~ /^This title is unavailable for guests, please login to see more information./
-  end
-
   def link_subjects(options = {})
     return unless options[:value]
     separators = options.dig(:config, :separator_options) || {}
@@ -59,7 +49,7 @@ module ArticleHelper
 
   def sanitize_fulltext(options = {})
     return unless options[:value].present?
-    return safe_join(options[:value]) if article_research_starter?(@document)
+    return safe_join(options[:value]) if @document && @document.research_starter?
     separators = options.dig(:config, :separator_options) || {}
     textblock = options[:value].map(&:to_s).to_sentence(separators)
     textblock = Nokogiri::HTML.fragment(CGI.unescapeHTML(textblock))

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -67,37 +67,6 @@ module ArticleHelper
     end.flatten
   end
 
-  #
-  def transform_research_starter_text(options = {})
-    return if options[:value].blank?
-    doc = Nokogiri::HTML.fragment(CGI.unescapeHTML(options[:value]))
-    doc.search('anid', 'title').remove # remove EDS header content
-
-    # Translate EDS elements into regular HTML
-    element_rename(doc, 'bold', 'b')
-    element_rename(doc, 'emph', 'i')
-    element_rename(doc, 'ulist', 'ul')
-    element_rename(doc, 'item', 'li')
-    element_rename(doc, 'subs', 'sub')
-    element_rename(doc, 'sups', 'sup')
-
-    # Rewrite EDS eplinks into actual hyperlinks to other research starters
-    doc.search('eplink').each do |node|
-      node.name = 'a'
-      node['href'] = article_path(id: "#{@document['eds_database_id']}__#{node['linkkey']}")
-    end
-
-    # Wrap images into figures with captions
-    doc.search('img').each do |node|
-      figure = Nokogiri::HTML.fragment("
-      <div class=\"research-starter-figure clearfix\">
-        #{node.to_html}<span>#{node['title']}</span>
-      </div>")
-      node.replace(figure)
-    end
-    sanitize(doc.to_html, tags: %w[p a b i ul li img div span sub sup])
-  end
-
   private
 
   RELATOR_TERMS = %w[Author Originator]
@@ -111,11 +80,5 @@ module ArticleHelper
       value.gsub!(/, #{relator}$/i, '')
     end
     [value, label]
-  end
-
-  def element_rename(doc, from, to)
-    doc.search(from).each do |node|
-      node.name = to
-    end
   end
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -10,9 +10,11 @@ module BlacklightHelper
 
     display_type ||= document.display_type
 
+    display_type ||= document['eds_publication_type']
+
     display_type ||= 'default'
 
-    type = type_field_to_partial_name(document, display_type)
+    type = type_field_to_partial_name(document, display_type.downcase)
 
     type
   end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -10,11 +10,11 @@ module BlacklightHelper
 
     display_type ||= document.display_type
 
-    display_type ||= document['eds_publication_type']
+    display_type ||= document[view_config.display_type_field]
 
     display_type ||= 'default'
 
-    type = type_field_to_partial_name(document, display_type.downcase)
+    type = type_field_to_partial_name(document, display_type)
 
     type
   end

--- a/app/models/article_search_builder.rb
+++ b/app/models/article_search_builder.rb
@@ -11,7 +11,7 @@ class ArticleSearchBuilder < Blacklight::SearchBuilder
     eds_params.except!('start', 'rows', 'page', 'per_page') # avoid the Solr-like EDS API parameters
     eds_params[:page_number] = page
     eds_params[:results_per_page] = rows
-    eds_params[:highlight] = false # TODO: make highlighting configurable
+    eds_params[:highlight] = 'y' # TODO: must be true in order to workaround EDS bug with missing research starter abstracts. See https://github.com/ebsco/edsapi-ruby/issues/55
     eds_params['search_field'] = 'descriptor' if eds_params['search_field'] == 'subject'
   end
 end

--- a/app/models/concerns/eds_document.rb
+++ b/app/models/concerns/eds_document.rb
@@ -2,4 +2,14 @@ module EdsDocument
   def html_fulltext_available?
     self[:eds_html_fulltext].present?
   end
+
+  def research_starter?
+    # TODO: we probably need a better way to determine this
+    self['eds_database_name'] == 'Research Starters'
+  end
+
+  def eds_restricted?
+    # TODO: we probably need a better way to determine this
+    self['eds_title'] =~ /^This title is unavailable for guests, please login to see more information./
+  end
 end

--- a/app/presenters/concerns/presenter_research_starter.rb
+++ b/app/presenters/concerns/presenter_research_starter.rb
@@ -1,0 +1,41 @@
+module PresenterResearchStarter
+  # TODO: maybe this should go in the pipeline and only run on document.research_starter?
+  def transform_research_starter_text
+    value = document['eds_html_fulltext']
+    return if value.blank?
+    doc = Nokogiri::HTML.fragment(CGI.unescapeHTML(value))
+    doc.search('anid', 'title').remove # remove EDS header content
+
+    # Translate EDS elements into regular HTML
+    element_rename(doc, 'bold', 'b')
+    element_rename(doc, 'emph', 'i')
+    element_rename(doc, 'ulist', 'ul')
+    element_rename(doc, 'item', 'li')
+    element_rename(doc, 'subs', 'sub')
+    element_rename(doc, 'sups', 'sup')
+
+    # Rewrite EDS eplinks into actual hyperlinks to other research starters
+    doc.search('eplink').each do |node|
+      node.name = 'a'
+      node['href'] = view_context.article_path(id: "#{document['eds_database_id']}__#{node['linkkey']}")
+    end
+
+    # Wrap images into figures with captions
+    doc.search('img').each do |node|
+      figure = Nokogiri::HTML.fragment("
+      <div class=\"research-starter-figure clearfix\">
+        #{node.to_html}<span>#{node['title']}</span>
+      </div>")
+      node.replace(figure)
+    end
+    document['eds_html_fulltext'] = view_context.sanitize(doc.to_html, tags: %w[p a b i ul li img div span sub sup])
+  end
+
+  private
+
+  def element_rename(doc, from, to)
+    doc.search(from).each do |node|
+      node.name = to
+    end
+  end
+end

--- a/app/presenters/show_document_presenter.rb
+++ b/app/presenters/show_document_presenter.rb
@@ -1,4 +1,5 @@
 class ShowDocumentPresenter < Blacklight::ShowPresenter
   include PresenterFormat
   include PresenterFulltextLinks
+  include PresenterResearchStarter
 end

--- a/app/views/article/_index.html.erb
+++ b/app/views/article/_index.html.erb
@@ -26,6 +26,7 @@
           </div>
         </div>
         <%= render 'search_header' %>
+        <%= render 'research_starters' %>
         <%= render @response.documents, as: :document %>
 
         <%- unless @response.empty? %>

--- a/app/views/article/_index_brief_default.html.erb
+++ b/app/views/article/_index_brief_default.html.erb
@@ -13,7 +13,7 @@
   </h3>
 </div>
 
-<% if document['eds_fulltext_links'].present? && !article_restricted?(document) %>
+<% if document['eds_fulltext_links'].present? && !document.eds_restricted? %>
   <ul class='document-metadata dl-horizontal dl-invert'>
     <%= safe_join(doc_presenter.fulltext_links) %>
   </ul>

--- a/app/views/article/_index_default.html.erb
+++ b/app/views/article/_index_default.html.erb
@@ -18,7 +18,7 @@
     <li><%= doc_presenter.field_value('eds_abstract') %></li>
   </ul>
 <% end %>
-<% if document['eds_fulltext_links'].present? && !article_restricted?(document) %>
+<% if document['eds_fulltext_links'].present? && !document.eds_restricted? %>
   <ul class='document-metadata dl-horizontal dl-invert'>
     <%= safe_join(doc_presenter.fulltext_links) %>
   </ul>

--- a/app/views/article/_research_starters.html.erb
+++ b/app/views/article/_research_starters.html.erb
@@ -1,0 +1,24 @@
+<% if params[:page].blank? || params[:page] == '1' -%>
+  <% research_starters = @response['research_starters'] -%>
+  <% if research_starters.present? -%>
+    <% starter = research_starters.first -%>
+    <div class='research-starter clearfix'>
+      <a class="research-starter-close" role="button" data-toggle="collapse" href="#research-starter-body" aria-expanded="true" aria-controls="research-starter-body">
+        <span id='research-starter-close-icon' class='fa fa-times-circle'></span>
+        <span class="sr-only">hide research starter</span>
+      </a>
+      <div id='research-starter-body' class='collapse.in'>
+        <h3>
+          <%= link_to starter['eds_title'], article_path(id: "#{starter['eds_database_id']}__#{starter['eds_accession_number']}") -%>
+        </h3>
+        <img src="<%= starter['eds_cover_thumb_url'] -%>"/>
+        <p>
+          <%= truncate(sanitize(starter['eds_abstract']), length: 250, separator: ' ') -%>
+        </p>
+        <p>
+          <%= starter['eds_composed_title'] -%>
+        </p>
+      </div>
+    </div>
+  <% end -%>
+<% end -%>

--- a/app/views/article/_research_starters.html.erb
+++ b/app/views/article/_research_starters.html.erb
@@ -1,7 +1,7 @@
 <% if params[:page].blank? || params[:page] == '1' -%>
   <% research_starters = @response['research_starters'] -%>
   <% if research_starters.present? -%>
-    <% starter = research_starters.first -%>
+    <% starter = research_starters.first # only show first research starter -%>
     <div class='research-starter clearfix'>
       <a class="research-starter-close" role="button" data-toggle="collapse" href="#research-starter-body" aria-expanded="true" aria-controls="research-starter-body">
         <span id='research-starter-close-icon' class='fa fa-times-circle research-starter-close-icon'></span>
@@ -11,7 +11,9 @@
         <h3>
           <%= link_to starter['eds_title'], article_path(id: "#{starter['eds_database_id']}__#{starter['eds_accession_number']}") -%>
         </h3>
-        <img src="<%= starter['eds_cover_thumb_url'] -%>"/>
+        <% if starter['eds_cover_thumb_url'].present? -%>
+          <img src="<%= starter['eds_cover_thumb_url'] -%>"/>
+        <% end -%>
         <p>
           <%= truncate(sanitize(starter['eds_abstract']), length: 250, separator: ' ') -%>
         </p>

--- a/app/views/article/_research_starters.html.erb
+++ b/app/views/article/_research_starters.html.erb
@@ -4,7 +4,7 @@
     <% starter = research_starters.first -%>
     <div class='research-starter clearfix'>
       <a class="research-starter-close" role="button" data-toggle="collapse" href="#research-starter-body" aria-expanded="true" aria-controls="research-starter-body">
-        <span id='research-starter-close-icon' class='fa fa-times-circle'></span>
+        <span id='research-starter-close-icon' class='fa fa-times-circle research-starter-close-icon'></span>
         <span class="sr-only">hide research starter</span>
       </a>
       <div id='research-starter-body' class='collapse.in'>

--- a/app/views/article/_show_header_reference.html.erb
+++ b/app/views/article/_show_header_reference.html.erb
@@ -1,0 +1,5 @@
+<%= render_document_heading(document, :tag => :h1) %>
+<div class="research-starter-show container row">
+  <span class="research-starter-label">Research Starter</span>
+  <span class="research-starter-source-title"><%= document['eds_composed_title'] -%></span>
+</div>

--- a/app/views/article/_show_header_reference.html.erb
+++ b/app/views/article/_show_header_reference.html.erb
@@ -1,4 +1,4 @@
-<%= render_document_heading(document, :tag => :h1) %>
+<%= render_document_heading(document, tag: :h1) %>
 <div class="research-starter-show container row">
   <span class="research-starter-label">Research Starter</span>
   <span class="research-starter-source-title"><%= document['eds_composed_title'] -%></span>

--- a/app/views/article/_show_reference.html.erb
+++ b/app/views/article/_show_reference.html.erb
@@ -1,3 +1,4 @@
+<% doc_presenter = presenter(document) -%>
 <%# we need to transform the EDS HTML Full Text content as it's in pseudo-HTML markup %>
-<% document['eds_html_fulltext'] = transform_research_starter_text(value: document['eds_html_fulltext']) %>
+<% doc_presenter.transform_research_starter_text %>
 <%= render "article/show_default", document: document -%>

--- a/app/views/article/_show_reference.html.erb
+++ b/app/views/article/_show_reference.html.erb
@@ -1,0 +1,3 @@
+<%# we need to transform the EDS HTML Full Text content as it's in pseudo-HTML markup %>
+<% document['eds_html_fulltext'] = transform_research_starter_text(value: document['eds_html_fulltext']) %>
+<%= render "article/show_default", document: document -%>

--- a/app/views/article/record/_html_fulltext.erb
+++ b/app/views/article/record/_html_fulltext.erb
@@ -2,7 +2,7 @@
 <button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="false" aria-controls="toggleFulltext">
   <h2>Full text</h2>
 </button>
-<div class='section-body collapse' id="toggleFulltext">
+<div class='section-body <%= article_research_starter?(document) ? 'collapse.in' : 'collapse' -%>' id="toggleFulltext">
 <% fields.each do |field_name| -%>
   <% field_name = field_name.to_s -%>
   <% value = doc_presenter.field_value field_name -%>

--- a/app/views/article/record/_html_fulltext.erb
+++ b/app/views/article/record/_html_fulltext.erb
@@ -2,7 +2,7 @@
 <button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="false" aria-controls="toggleFulltext">
   <h2>Full text</h2>
 </button>
-<div class='section-body <%= article_research_starter?(document) ? 'collapse.in' : 'collapse' -%>' id="toggleFulltext">
+<div class='section-body <%= document.research_starter? ? 'collapse.in' : 'collapse' -%>' id="toggleFulltext">
 <% fields.each do |field_name| -%>
   <% field_name = field_name.to_s -%>
   <% value = doc_presenter.field_value field_name -%>

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -124,37 +124,4 @@ RSpec.describe ArticleHelper do
       expect(result).to eq '<p>This Journal</p>, 10(1)'
     end
   end
-
-  context '#transform_research_starter_text' do
-    it 'removes anid and title' do
-      result = helper.transform_research_starter_text(value: '<anid>abc</anid><title>123</title>')
-      expect(result).to eq ''
-    end
-    it 'rewrites EDS tags with regular HTML tags' do
-      result = helper.transform_research_starter_text(value: '<bold/><emph/><ulist><item><subs/><sups/></item></ulist>')
-      expect(result).to eq "<b></b><i></i><ul><li>\n<sub></sub><sup></sup>\n</li></ul>"
-    end
-    it 'rewrites EDS eplinks' do
-      assign(:document, { 'eds_database_id' => 'xyz' })
-      result = helper.transform_research_starter_text(value: '<eplink linkkey="abc123">def456</eplink>')
-      expect(result).to eq '<a href="/article/xyz__abc123">def456</a>'
-    end
-    it 'converts images to figures with captions' do
-      result = helper.transform_research_starter_text(value: '<img src="abc.jpg" title="def"/>')
-      result = Capybara.string(result)
-      expect(result).to have_css('.research-starter-figure')
-      expect(result).to have_css('img[src="abc.jpg"]')
-      expect(result).to have_css('span', text: 'def')
-    end
-    it 'removes any unknown elements' do
-      result = helper.transform_research_starter_text(value: '<unknown/>')
-      expect(result).to eq ''
-    end
-    it 'preserves any desired elements' do
-      %w[p a b i ul li div span sub sup].each do |tag|
-        result = helper.transform_research_starter_text(value: "<#{tag}>abc</#{tag}>")
-        expect(result).to eq "<#{tag}>abc</#{tag}>"
-      end
-    end
-  end
 end

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -124,4 +124,37 @@ RSpec.describe ArticleHelper do
       expect(result).to eq '<p>This Journal</p>, 10(1)'
     end
   end
+
+  context '#transform_research_starter_text' do
+    it 'removes anid and title' do
+      result = helper.transform_research_starter_text(value: '<anid>abc</anid><title>123</title>')
+      expect(result).to eq ''
+    end
+    it 'rewrites EDS tags with regular HTML tags' do
+      result = helper.transform_research_starter_text(value: '<bold/><emph/><ulist><item><subs/><sups/></item></ulist>')
+      expect(result).to eq "<b></b><i></i><ul><li>\n<sub></sub><sup></sup>\n</li></ul>"
+    end
+    it 'rewrites EDS eplinks' do
+      assign(:document, { 'eds_database_id' => 'xyz' })
+      result = helper.transform_research_starter_text(value: '<eplink linkkey="abc123">def456</eplink>')
+      expect(result).to eq '<a href="/article/xyz__abc123">def456</a>'
+    end
+    it 'converts images to figures with captions' do
+      result = helper.transform_research_starter_text(value: '<img src="abc.jpg" title="def"/>')
+      result = Capybara.string(result)
+      expect(result).to have_css('.research-starter-figure')
+      expect(result).to have_css('img[src="abc.jpg"]')
+      expect(result).to have_css('span', text: 'def')
+    end
+    it 'removes any unknown elements' do
+      result = helper.transform_research_starter_text(value: '<unknown/>')
+      expect(result).to eq ''
+    end
+    it 'preserves any desired elements' do
+      %w[p a b i ul li div span sub sup].each do |tag|
+        result = helper.transform_research_starter_text(value: "<#{tag}>abc</#{tag}>")
+        expect(result).to eq "<#{tag}>abc</#{tag}>"
+      end
+    end
+  end
 end

--- a/spec/models/article_search_builder_spec.rb
+++ b/spec/models/article_search_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ArticleSearchBuilder do
       expect(search_builder[:q]).to eq 'my search'
       expect(search_builder[:page_number]).to eq 1
       expect(search_builder[:results_per_page]).to eq 10
-      expect(search_builder[:highlight]).to be_falsey
+      expect(search_builder[:highlight]).to eq 'y'
     end
 
     it 'excludes some Solr-like parameters' do

--- a/spec/presenters/presenter_research_starter_spec.rb
+++ b/spec/presenters/presenter_research_starter_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+RSpec.describe PresenterResearchStarter do
+  subject(:presenter) do
+    Class.new do
+      include PresenterResearchStarter
+    end.new
+  end
+
+  let(:view_context) do
+    Class.new do
+      include ActionView::Helpers::UrlHelper
+      include ActionView::Helpers::SanitizeHelper
+      def article_path(id:)
+        "/article/#{id}"
+      end
+    end.new
+  end
+
+  subject(:result) { presenter.transform_research_starter_text }
+
+  before do
+    config = double(Blacklight::Configuration, show: double)
+    allow(presenter).to receive(:configuration).and_return(config)
+    allow(presenter).to receive(:view_context).and_return(view_context)
+    allow(presenter).to receive(:document).and_return(document)
+  end
+
+  context '#transform_research_starter_text' do
+    let(:document) { { 'eds_html_fulltext' => value } }
+    let(:value) { 'abc' }
+
+    context 'removes anid and title' do
+      let(:value) { '<anid>abc</anid><title>123</title>' }
+
+      it do
+        expect(result).to eq ''
+      end
+    end
+
+    context 'rewrites EDS tags with regular HTML tags' do
+      let(:value) { '<bold/><emph/><ulist><item><subs/><sups/></item></ulist>' }
+
+      it do
+        expect(result).to eq "<b></b><i></i><ul><li>\n<sub></sub><sup></sup>\n</li></ul>"
+      end
+    end
+
+    context 'rewrites EDS eplinks' do
+      let(:value) { '<eplink linkkey="abc123">def456</eplink>' }
+      let(:document) { { 'eds_html_fulltext' => value, 'eds_database_id' => 'xyz' } }
+
+      it do
+        expect(result).to eq '<a href="/article/xyz__abc123">def456</a>'
+      end
+    end
+
+    context 'converts images to figures with captions' do
+      let(:value) { '<img src="abc.jpg" title="def"/>' }
+      it do
+        html = Capybara.string(result)
+        expect(html).to have_css('.research-starter-figure')
+        expect(html).to have_css('img[src="abc.jpg"]')
+        expect(html).to have_css('span', text: 'def')
+      end
+    end
+
+    context 'removes any unknown elements' do
+      let(:value) { '<unknown/>' }
+
+      it do
+        expect(result).to eq ''
+      end
+    end
+
+    context 'preserves desired element' do
+      %w[p a b i ul li div span sub sup].each do |tag|
+        context "#{tag}" do
+          let(:value) { "<#{tag}>abc</#{tag}>" }
+
+          it do
+            expect(result).to eq value
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #1504 and fixes #1518. 

- [x] need a bug fix from EDS for the search results Research Starter's abstract metadata (see https://github.com/ebsco/edsapi-ruby/issues/55) (fixed in 0.2.8.pre)
- [x] rebase onto article-search for new full text display changes
- [x] fix hardcoding in blacklight_helper.rb
- [x] addressed comments

Notes:
- If the user is not authenticated, then the show page will not have any full text content. We may need to include some indication for the user to login to see the research starter full text.

### On search page
![screen shot 2017-07-28 at 10 41 24 am](https://user-images.githubusercontent.com/1861171/28729477-6908a1c8-7381-11e7-8aa7-a7727150f0e1.png)

### On show page (when user is authenticated)
![screen shot 2017-07-28 at 10 41 45 am](https://user-images.githubusercontent.com/1861171/28729486-6ef495c4-7381-11e7-96a8-24a2e37df419.png)

### On show page (when user is not authenticated)
![screen shot 2017-07-28 at 10 52 01 am](https://user-images.githubusercontent.com/1861171/28729872-db458070-7382-11e7-87f6-00e34841290d.png)
