### PR TITLE
add IP-based authentication for Article Search

### DIFF
--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -37,8 +37,8 @@ module Eds
 
     def eds_session_options(eds_params = {})
       {
-        guest:          $EDS_GUEST_MODE, # TODO: hardcoded to non-authenticated
-        session_token:  eds_params['session_token'],
+        guest:          eds_params[:guest],
+        session_token:  eds_params[:session_token],
         caller:         eds_params[:caller],
         user:           Settings.EDS_USER,
         pass:           Settings.EDS_PASS,

--- a/app/models/ip_range.rb
+++ b/app/models/ip_range.rb
@@ -1,0 +1,58 @@
+##
+# A class to model a set of IP ranges.  The default IPAddr library in ruby
+# can define broad IP ranges (e.g. 172.12.0.0/16 would define 172.12.*.*)
+# but doesn't handle custom ranges as well (e.g. 172.22.24.* - 172.22.255.*)
+# This class allows you to check if a given IP is in a network of IP ranges.
+#
+# There is a network of IP ranges injected by default, but an object can be
+# injected that provides an array of singleton IP addresses (or ranges defined
+# by the slash prefixes) and an mutli-dimensional array of custom IP ranges.
+# Example network definition:
+# example_network = OpenStruct.new(
+#   singletons: ['172.12.0.0/16'],
+#   ranges: [['172.12.12.0', '172.12.56.255']]
+# )
+#
+# Example Usage:
+# IPRange.includes?('172.12.52.21')
+# => false
+# IPRange.new('172.12.52.21', example_network).includes?
+# => true
+class IPRange
+  attr_reader :ip_to_check, :network
+
+  def initialize(ip, network_definition = self.class.default_network)
+    @ip_to_check = IPAddr.new(ip)
+    @network = network_definition
+  end
+
+  def included?
+    singletons_include_ip? || ranges_include_ip?
+  end
+
+  class << self
+    def includes?(ip_to_check)
+      new(ip_to_check).included?
+    end
+
+    def default_network
+      Settings.STANFORD_NETWORK
+    end
+  end
+
+  private
+
+  delegate :ranges, :singletons, to: :network
+
+  def singletons_include_ip?
+    singletons.any? do |singleton|
+      IPAddr.new(singleton).include?(ip_to_check)
+    end
+  end
+
+  def ranges_include_ip?
+    ranges.any? do |range|
+      (IPAddr.new(range.first)..IPAddr.new(range.last)).cover?(ip_to_check)
+    end
+  end
+end

--- a/config/initializers/eds.rb
+++ b/config/initializers/eds.rb
@@ -3,5 +3,4 @@ require 'ebsco/eds'
 raise ArgumentError, 'EDS API requires user, password, and profile settings' if Settings.EDS_USER.blank? ||
                                                                                 Settings.EDS_PASS.blank? ||
                                                                                 Settings.EDS_PROFILE.blank?
-
-$EDS_GUEST_MODE = true # TODO: hardcoded to non-authenticated
+                                                                                

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,6 @@ EDS_CACHE: true
 EDS_LOGDIR: <%= Rails.root.join('log') %>
 EDS_TIMEOUT: 15
 EDS_OPEN_TIMEOUT: 2
+STANFORD_NETWORK:
+  singletons: []
+  ranges: []

--- a/spec/models/ip_range_spec.rb
+++ b/spec/models/ip_range_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+##
+# Stimple test class to model a
+# network of singleton and IP ranges
+class TestIPNetwork
+  def singletons
+    ['172.22.45.195', '172.35.0.0/16']
+  end
+
+  def ranges
+    [
+      ['171.10.15.7', '171.10.15.35'],
+      ['171.12.0.0', '171.15.255.255']
+    ]
+  end
+end
+
+describe IPRange do
+  let(:test_network) { TestIPNetwork.new }
+
+  context 'singletons' do
+    it 'IP addresses configured as a single address are properly identified' do
+      expect(described_class.new('172.22.45.195', test_network)).to be_included
+      expect(described_class.new('172.22.45.196', test_network)).not_to be_included
+    end
+
+    it 'IP addresses configured in a range with a slash suffix are properly identified' do
+      expect(described_class.new('172.34.255.255', test_network)).not_to be_included
+      expect(described_class.new('172.35.0.0', test_network)).to be_included
+      expect(described_class.new('172.35.100.100', test_network)).to be_included
+      expect(described_class.new('172.35.255.255', test_network)).to be_included
+      expect(described_class.new('172.36.0.0', test_network)).not_to be_included
+    end
+  end
+
+  context 'ranges' do
+    it 'IP addresses configured as custom ranges are properly identified' do
+      expect(described_class.new('171.10.15.6', test_network)).not_to be_included
+      expect(described_class.new('171.10.15.7', test_network)).to be_included
+      expect(described_class.new('171.10.15.20', test_network)).to be_included
+      expect(described_class.new('171.10.15.35', test_network)).to be_included
+      expect(described_class.new('171.10.15.36', test_network)).not_to be_included
+
+      expect(described_class.new('171.11.255.255', test_network)).not_to be_included
+      expect(described_class.new('171.12.0.0', test_network)).to be_included
+      expect(described_class.new('171.14.100.100', test_network)).to be_included
+      expect(described_class.new('171.15.255.255', test_network)).to be_included
+      expect(described_class.new('171.16.0.0', test_network)).not_to be_included
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #1529. It implements simple IP-based authentication which toggles the EDS API's `guest` mode parameter. The `IPRange` class and its specs comes from the sul-requests application.

I've put a `production.local.yml` on the sandbox that has the IP ranges. We need to do further testing on these ranges (which is why this PR does not close the ticket). The set is pretty different than sul-requests' production values.

For local testing, make sure you clear your browser cookies and add this to your `development.local.yml` to authenticate yourself:

```yml
STANFORD_NETWORK:
  singletons:
    - 127.0.0.1
  ranges: []
```

Note we may need to rework this when we integrate Shibboleth workgroup-based authentication, but for now this PR takes a simple approach.