### PR TITLE
add label/icon to full text links

### DIFF
--- a/app/views/article/_index_brief_default.html.erb
+++ b/app/views/article/_index_brief_default.html.erb
@@ -16,7 +16,14 @@
 <% if document.access_panels.online? && !document.eds_restricted? %>
   <ul class='document-metadata dl-horizontal dl-invert'>
     <% document.access_panels.online.links.each do |link| %>
-      <li><%= link_to(link.text, link.href) %></li>
+      <li>
+        <% if link.ill? -%>
+          <%= link_to(link.text, link.href, class: 'sfx') %>
+        <% else %>
+          <span class="online-label">Full text</span>
+          <%= link_to(link.text, link.href) %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/article/_index_default.html.erb
+++ b/app/views/article/_index_default.html.erb
@@ -34,7 +34,14 @@
 <% if document.access_panels.online? && !document.eds_restricted? %>
   <ul class='document-metadata dl-horizontal dl-invert'>
     <% document.access_panels.online.links.each do |link| %>
-      <li><%= link_to(link.text, link.href) %></li>
+      <li>
+        <% if link.ill? -%>
+          <%= link_to(link.text, link.href, class: 'sfx') %>
+        <% else %>
+          <span class="online-label">Full text</span>
+          <%= link_to(link.text, link.href) %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/article/access_panels/_online.html.erb
+++ b/app/views/article/access_panels/_online.html.erb
@@ -7,7 +7,9 @@
   <div class="panel-body">
     <ul class='document-metadata dl-horizontal dl-invert'>
       <% document.access_panels.online.links.each do |link| %>
-        <li><%= link_to(link.text, link.href) %></li>
+        <li>
+          <%= link_to(link.text, link.href, class: link.ill? ? 'sfx' : '') %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/lib/links.rb
+++ b/lib/links.rb
@@ -30,6 +30,10 @@ module SearchWorks
       all.select(&:managed_purl?)
     end
 
+    def ill
+      all.select(&:ill?)
+    end
+
     class Link
       attr_accessor :html, :text, :href, :file_id, :druid
       def initialize(options={})
@@ -43,6 +47,7 @@ module SearchWorks
         @managed_purl = options[:managed_purl]
         @file_id = options[:file_id]
         @druid = options[:druid]
+        @ill = options[:ill]
       end
 
       def ==(other)
@@ -67,6 +72,10 @@ module SearchWorks
 
       def managed_purl?
         @managed_purl
+      end
+
+      def ill?
+        @ill
       end
     end
   end

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -98,6 +98,14 @@ feature 'Article Searching' do
         expect(page).to have_css('a.responsiveTruncatorToggle', text: 'more...', count: 2)
       end
     end
+
+    scenario 'fulltext links are present and have labels' do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+      article_search_for('Kittens')
+
+      expect(page).to have_css('ul.document-metadata li span.online-label', text: 'Full text')
+      expect(page).to have_css('ul.document-metadata li a.sfx', text: /^Find it in print/)
+    end
   end
 
   describe 'breadcrumbs', js: true do
@@ -130,7 +138,6 @@ feature 'Article Searching' do
       expect(page).to have_button('Bottom')
     end
   end
-
 
   it 'displays the appropriate fields in the search' do
     skip 'we need some EDS fixtures'

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe EdsLinks do
     it 'does not consider links full-text when type is not correct' do
       expect(document.eds_links.fulltext).to be_present
 
-      document['eds_fulltext_links'].first['type'] = 'pdf'
+      document['eds_fulltext_links'].first['type'] = 'unknown'
       expect(document.eds_links.fulltext).not_to be_present
     end
   end
@@ -37,9 +37,20 @@ RSpec.describe EdsLinks do
       expect(document.eds_links.all.first.text).to eq('View full text')
     end
 
-    it 'handles PDF full text' do
+    it 'handles PDF full text variants' do
       document['eds_fulltext_links'].first['label'] = 'PDF full text'
+      document['eds_fulltext_links'].first['type'] = 'pdf'
       expect(document.eds_links.all.first.text).to eq('View/download full text PDF')
+
+      document['eds_fulltext_links'].first['label'] = 'PDF eBook Full Text'
+      document['eds_fulltext_links'].first['type'] = 'ebook-pdf'
+      expect(document.eds_links.all.first.text).to eq('View/download full text PDF')
+    end
+
+    it 'retains label for ebook-epub links' do
+      document['eds_fulltext_links'].first['label'] = 'ePub eBook Full Text'
+      document['eds_fulltext_links'].first['type'] = 'ebook-epub'
+      expect(document.eds_links.all.first.text).to eq('ePub eBook Full Text')
     end
 
     it 'handles Check SFX for full text' do
@@ -72,7 +83,7 @@ RSpec.describe EdsLinks do
 
   context 'non customlink-fulltext links' do
     it 'ignores other link types' do
-      document['eds_fulltext_links'].first['type'] = 'pdf'
+      document['eds_fulltext_links'].first['type'] = 'unknown'
       expect(document.eds_links.fulltext).to be_blank
     end
   end
@@ -130,6 +141,7 @@ RSpec.describe EdsLinks do
       it 'shows 5 only' do
         expect(document.eds_links.fulltext.length).to eq 1
         expect(document.eds_links.fulltext.first.href).to eq('http://example.com/5')
+        expect(document.eds_links.fulltext.first.ill?).to be_truthy
       end
     end
   end

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -3,8 +3,8 @@
 module StubArticleService
   SAMPLE_RESULTS = [
       SolrDocument.new(id: 'abc123', eds_title: 'The title of the document', eds_subjects: %w[Kittens Felines Companions]),
-      SolrDocument.new(id: '321cba', eds_title: 'Another title for the document'),
-      SolrDocument.new(id: 'wqoeif', eds_title: 'Yet another title for the document')
+      SolrDocument.new(id: '321cba', eds_title: 'Another title for the document', eds_fulltext_links: [{ 'label' => 'HTML full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]),
+      SolrDocument.new(id: 'wqoeif', eds_title: 'Yet another title for the document', eds_fulltext_links: [{ 'label' => 'View request options', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }])
   ]
 
   def stub_article_service(type: :multiple, docs:)

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe 'article/access_panels/_online.html.erb' do
   it 'includes EDS fulltext links' do
     expect(rendered).to have_css('.panel-body ul li a', text: 'View full text')
   end
+
+  context 'ILL links' do
+    let(:document) do
+      SolrDocument.new(
+        eds_fulltext_links: [{ 'label' => 'View request options', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]
+      )
+    end
+
+    it 'includes label icon' do
+      expect(rendered).to have_css('.panel-body ul li a.sfx', text: /^Find it in print/)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #1530 by adding a label/icon to fulltext links on the search and show pages. It modifies the SearchWorks `Link` class to support "ILL" links. Also, permits PDF eBook links to show the same as regular PDF links.

### SFX link in default search results
![screen shot 2017-07-31 at 12 32 22 pm](https://user-images.githubusercontent.com/1861171/28796178-77f5115e-75f1-11e7-84b0-fe4e4c3e0d81.png)

### Full text link in default search results
![screen shot 2017-07-31 at 12 32 37 pm](https://user-images.githubusercontent.com/1861171/28796179-77f9bc7c-75f1-11e7-87af-850b01e005e5.png)

### SFX link in brief search results
![screen shot 2017-07-31 at 12 34 55 pm](https://user-images.githubusercontent.com/1861171/28796181-77ff833c-75f1-11e7-9e89-d7d0e513699d.png)

### Full text link in brief search results (PDF/eBook link)
![screen shot 2017-07-31 at 12 35 02 pm](https://user-images.githubusercontent.com/1861171/28796182-78016d96-75f1-11e7-94ba-d633c1c50d69.png)

### SFX link on show page
![screen shot 2017-07-31 at 12 37 07 pm](https://user-images.githubusercontent.com/1861171/28796183-7810f7d4-75f1-11e7-9446-6d060cf361bd.png)

### Full text link on show page (no change)
![screen shot 2017-07-31 at 12 37 23 pm](https://user-images.githubusercontent.com/1861171/28796180-77fbabcc-75f1-11e7-81ee-b5e9ea8cd062.png)
