### PR TITLE
Add abstract to search results display and use responsiveTruncator…

### DIFF
--- a/app/assets/javascripts/truncate.js
+++ b/app/assets/javascripts/truncate.js
@@ -1,4 +1,7 @@
 Blacklight.onLoad(function(){
+  $("[data-behavior='article-metadata-truncate']").responsiveTruncate(
+    { height: 40, more: 'more...', less: 'less...' }
+  );
   $("[data-behavior='truncate']").responsiveTruncate({height: 60});
   $("[data-behavior='trunk8']").trunk8({
     tooltip: false

--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -41,6 +41,22 @@
     @include label-items-online;
   }
 
+  &.article-search-results {
+    .article-metadata {
+      border-bottom: 1px solid $beige-30-percent;
+      border-top: 1px solid $beige-30-percent;
+      padding: 8px 0;
+    }
+
+    @media (min-width: $screen-sm-min) {
+      .dl-horizontal {
+        dd {
+          margin-left: 80px; // Get dds working better for article results
+        }
+      }
+    }
+  }
+
 }
 
 .document-metadata {

--- a/app/models/article_search_builder.rb
+++ b/app/models/article_search_builder.rb
@@ -11,6 +11,7 @@ class ArticleSearchBuilder < Blacklight::SearchBuilder
     eds_params.except!('start', 'rows', 'page', 'per_page') # avoid the Solr-like EDS API parameters
     eds_params[:page_number] = page
     eds_params[:results_per_page] = rows
+    eds_params[:view] = 'detailed'
     eds_params[:highlight] = 'y' # TODO: must be true in order to workaround EDS bug with missing research starter abstracts. See https://github.com/ebsco/edsapi-ruby/issues/55
     eds_params['search_field'] = 'descriptor' if eds_params['search_field'] == 'subject'
   end

--- a/app/views/article/_index_default.html.erb
+++ b/app/views/article/_index_default.html.erb
@@ -8,15 +8,27 @@
     <li><%= doc_presenter.field_value('eds_composed_title') %></li>
   <% end %>
 </ul>
-<% if document['eds_subjects'].present? %>
-  <dl class="document-metadata dl-horizontal dl-invert">
-    <dt>Subjects</dt> <dd><%= doc_presenter.field_value('eds_subjects') %></dd>
+
+<% if document['eds_subjects'].present? ||  document['eds_abstract'].present? %>
+  <dl class="document-metadata dl-horizontal dl-invert article-metadata">
+    <% if document['eds_subjects'].present? %>
+      <dt>Subjects</dt>
+      <dd>
+        <div data-behavior='article-metadata-truncate'>
+          <%= doc_presenter.field_value('eds_subjects') %>
+        </div>
+      </dd>
+    <% end %>
+
+    <% if document['eds_abstract'].present? %>
+      <dt>Abstract</dt>
+      <dd>
+        <div data-behavior='article-metadata-truncate'>
+          <%= doc_presenter.field_value('eds_abstract') %>
+        </div>
+      </dd>
+    <% end %>
   </dl>
-<% end %>
-<% if document['eds_abstract'].present? %>
-  <ul class='document-metadata dl-horizontal dl-invert'>
-    <li><%= doc_presenter.field_value('eds_abstract') %></li>
-  </ul>
 <% end %>
 
 <% if document.access_panels.online? && !document.eds_restricted? %>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -80,6 +80,24 @@ feature 'Article Searching' do
       expect(page).to have_css('h1', text: 'The title of the document')
       expect(current_url).to match(%r{/article/abc123})
     end
+
+    scenario 'subject and abstracts are truncated', js: true do
+      long_data = Array.new(100) { |_| 'Lorem ipsum dolor sit amet' }.join(', ')
+      document = SolrDocument.new(
+        id: '1234',
+        eds_abstract: long_data,
+        eds_subjects: long_data
+      )
+      stub_article_service(docs: [document])
+
+      visit article_index_path(q: 'Example Search')
+
+      within(first('.document')) do
+        expect(page).to have_css('dt', text: /subjects/i)
+        expect(page).to have_css('dt', text: /abstract/i)
+        expect(page).to have_css('a.responsiveTruncatorToggle', text: 'more...', count: 2)
+      end
+    end
   end
 
   describe 'breadcrumbs', js: true do


### PR DESCRIPTION
…to truncate data.

Closes #1445 

<img width="792" alt="truncated-metadata" src="https://user-images.githubusercontent.com/96776/28803797-f7623a62-7613-11e7-88ed-3606d57e76f9.png">
