### PR TITLE
add support for "Open Access" fulltext links

### DIFF
--- a/spec/lib/access_panels/online_spec.rb
+++ b/spec/lib/access_panels/online_spec.rb
@@ -9,7 +9,7 @@ describe AccessPanels::Online do
   let(:eds_links) do
     described_class.new(
       SolrDocument.new(
-        eds_fulltext_links: [{ 'label' => 'HTML full text', 'url' => 'http://example.com' }]
+        eds_fulltext_links: [{ 'label' => 'HTML full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]
       )
     )
   end

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'article/access_panels/_online.html.erb' do
   let(:document) do
     SolrDocument.new(
-      eds_fulltext_links: [{ 'label' => 'HTML full text', 'url' => 'http://example.com' }]
+      eds_fulltext_links: [{ 'label' => 'HTML full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]
     )
   end
 


### PR DESCRIPTION
This PR closes #1532.  This PR refactors the EdsLinks code (again), which hopefully simplifies it. Due to the application logic changes for #1532, we've introduced `type` as a filter (so it's both `type` and `label` now that triggers the filters).

### Show page with open access link
![screen shot 2017-08-01 at 11 03 51 am](https://user-images.githubusercontent.com/1861171/28839754-8e71bd20-76a9-11e7-9aed-b6f3190476f8.png)

### Search results with open access link
![screen shot 2017-08-01 at 11 04 00 am](https://user-images.githubusercontent.com/1861171/28839756-8e7c0e42-76a9-11e7-903a-effbf2fd56e6.png)

### Search results with a different type of open access link (arXiv)
![screen shot 2017-08-01 at 11 04 43 am](https://user-images.githubusercontent.com/1861171/28839757-8e8b387c-76a9-11e7-8e86-2414e971c36d.png)

### Note that only the open access link is shown for that record (sfx is dropped and non-customlink-fulltext is dropped)
![screen shot 2017-08-01 at 11 05 33 am](https://user-images.githubusercontent.com/1861171/28839755-8e790f62-76a9-11e7-897b-fb40b55cb65b.png)
