### PR TITLE
Include a hidden facet field parameter for article search when there …

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_tag searchworks_search_action_path, method: :get, class: 'navbar-form', role: 'search' do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
-
+  <% if article_search? && !has_search_parameters? %>
+    <%= hidden_field_tag('f[eds_search_limiters_facet][]', 'Stanford has it') %>
+  <% end %>
   <div class="input-group">
   <% unless search_fields.empty? %>
     <span class="input-group-addon for-search-field">

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -98,7 +98,7 @@ feature 'Article Searching' do
 
       expect(page).to have_css('.appliedFilter', text: /kittens/)
 
-      find(:css, 'a.remove').trigger('click')
+      first(:css, 'a.remove').trigger('click')
       expect(page).not_to have_css('.appliedFilter', text: /kittens/)
       expect(current_url).not_to match(%r{/article\?.*&q=kittens})
     end

--- a/spec/views/catalog/_search_form.html.erb_spec.rb
+++ b/spec/views/catalog/_search_form.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'catalog/_search_form.html.erb' do
+  before do
+    expect(view).to receive_messages(
+      search_state: double('SearchState', params_for_search: {}),
+      blacklight_config: Blacklight::Configuration.new
+    )
+  end
+
+  context 'article search' do
+    before { expect(view).to receive_messages(article_search?: true) }
+
+    describe 'default options facet params' do
+      context 'when there are no query parameters' do
+        before { expect(view).to receive_messages(has_search_parameters?: false) }
+
+        it 'renders a hidden field for eds_search_limiters_facet' do
+          render
+
+          expect(rendered).to have_css(
+            'input[type="hidden"][name="f[eds_search_limiters_facet][]"][value="Stanford has it"]',
+            visible: false
+          )
+        end
+      end
+
+      context 'when there are query parameters' do
+        before { expect(view).to receive_messages(has_search_parameters?: true) }
+
+        it 'does not render a hidden field for eds_search_limiters_facet' do
+          render
+
+          expect(rendered).not_to have_css(
+            'input[type="hidden"][name="f[eds_search_limiters_facet][]"][value="Stanford has it"]',
+            visible: false
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…are no query params (e.g. on the home page).
Closes #1522 

