### PR TITLE
allow configuration of the EDS cache directory

### DIFF
--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -44,6 +44,7 @@ module Eds
         pass:           Settings.EDS_PASS,
         profile:        Settings.EDS_PROFILE,
         use_cache:      Settings.EDS_CACHE,
+        eds_cache_dir:  Settings.EDS_CACHE_DIR,
         timeout:        Settings.EDS_TIMEOUT,
         open_timeout:   Settings.EDS_OPEN_TIMEOUT,
         debug:          Settings.EDS_DEBUG,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ EDS_PASS: the-eds-password
 EDS_PROFILE: the-eds-profile
 EDS_DEBUG: false
 EDS_CACHE: true
+EDS_CACHE_DIR: /tmp
 EDS_LOGDIR: <%= Rails.root.join('log') %>
 EDS_TIMEOUT: 15
 EDS_OPEN_TIMEOUT: 2


### PR DESCRIPTION
This PR allows us to override the EDS cache location (which defaults to `/tmp`) via `Settings.EDS_CACHE_DIR`