### PR TITLE
add italic style for EDS markup searchLink

### DIFF
--- a/app/assets/stylesheets/modules/article.scss
+++ b/app/assets/stylesheets/modules/article.scss
@@ -9,3 +9,8 @@
     padding-top: 10px;
   }
 }
+
+// EDS markup
+searchLink {
+  font-style: italic;
+}


### PR DESCRIPTION
This PR is connected to #1538. It makes any `<searchLink>` that we mark as HTML safe show in italics.