### PR TITLE
Increase EDS open timeout config from 2 to 5 seconds.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,7 +37,7 @@ EDS_CACHE: true
 EDS_CACHE_DIR: /tmp
 EDS_LOGDIR: <%= Rails.root.join('log') %>
 EDS_TIMEOUT: 15
-EDS_OPEN_TIMEOUT: 2
+EDS_OPEN_TIMEOUT: 5
 STANFORD_NETWORK:
   singletons: []
   ranges: []


### PR DESCRIPTION
Closes #1450 

@drh-stanford do you think this is a reasonable number to increase the timeout to?