### PR TITLE
italicize the first phrase of composed title

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -41,7 +41,7 @@ class ArticleController < ApplicationController
       isbn:     :isbn_search  # advanced search
     }
     config.add_index_field "eds_authors", label: 'Authors', helper_method: :strip_author_relators
-    config.add_index_field "eds_composed_title", label: 'Source', helper_method: :mark_html_safe
+    config.add_index_field "eds_composed_title", label: 'Source', helper_method: :italicize_composed_title
     config.add_index_field "eds_subjects", label: 'Subjects'
     config.add_index_field "eds_abstract", label: 'Abstract', helper_method: :mark_html_safe
 
@@ -94,7 +94,7 @@ class ArticleController < ApplicationController
       'Summary' => {
         eds_authors:              { label: 'Authors', separator_options: BREAKS, helper_method: :link_authors },
         eds_author_affiliations:  { label: 'Author Affiliations' },
-        eds_composed_title:       { label: 'Source', helper_method: :mark_html_safe },
+        eds_composed_title:       { label: 'Source', helper_method: :italicize_composed_title },
         eds_publication_date:     { label: 'Publication Date' },
         eds_languages:            { label: 'Language', helper_method: :mark_html_safe }
       },

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -41,6 +41,19 @@ module ArticleHelper
     link_to(doi, url)
   end
 
+  ##
+  # EDS returns structured data (as XML) sometimes so use that
+  # but when it's just a string, italicize the first phrase
+  def italicize_composed_title(options = {})
+    composed_title = options[:value].try(:first).to_s # We only compose the first value
+    return if composed_title.blank?
+    return composed_title.html_safe if composed_title =~ /\<\/\w+\>/ # has XML so use as-is
+
+    match = /^([^[:punct:]]+)(.*)$/.match(composed_title)
+    return "<i>#{match[1]}</i>#{match[2]}".html_safe if match # italicize first phrase
+    composed_title.html_safe
+  end
+
   def mark_html_safe(options = {})
     return unless options[:value].present?
     separators = options.dig(:config, :separator_options) || {}

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -124,4 +124,90 @@ RSpec.describe ArticleHelper do
       expect(result).to eq '<p>This Journal</p>, 10(1)'
     end
   end
+
+  context '#italicize_composed_title' do
+    let(:result) { helper.italicize_composed_title(value: Array.wrap(title)) }
+
+    context 'no title' do
+      let(:title) { nil }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'blank title' do
+      let(:title) { '  ' }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'already marked up' do
+      let(:title) { '<i>This Journal</i>. 10(1)' }
+
+      it 'just returns as-is but marked HTML safe' do
+        expect(result).to eq title
+        expect(result).to be_html_safe
+      end
+    end
+
+    context 'already marked up with anchor' do
+      let(:title) { '<searchLink fieldCode="FT">This Journal</searchLink>. 10(1)' }
+
+      it 'just returns as-is' do
+        expect(result).to eq title
+        expect(result).to be_html_safe
+      end
+    end
+
+    context 'even marked up multiple times' do
+      let(:title) { '<searchLink fieldCode="FT">This Journal</searchLink>. <i>10</i>(1)' }
+
+      it 'just returns as-is' do
+        expect(result).to eq title
+        expect(result).to be_html_safe
+      end
+    end
+
+    context 'no markup' do
+      let(:title) { 'This Journal. 10(1)' }
+
+      it 'italicizes first phrase' do
+        expect(result).to eq '<i>This Journal</i>. 10(1)'
+        expect(result).to be_html_safe
+      end
+    end
+
+    context 'no markup but weird punctuation' do
+
+      context 'with []' do
+        let(:title) { 'This Journal [Alternate Name]. 10(1)' }
+
+        it 'italicizes first phrase' do
+          expect(result).to eq '<i>This Journal </i>[Alternate Name]. 10(1)'
+          expect(result).to be_html_safe
+        end
+      end
+
+      context 'with commas' do
+        let(:title) { 'Agriculture, ecosystems & environment. 10(1)' }
+
+        it 'fails to do a good job' do
+          expect(result).to eq '<i>Agriculture</i>, ecosystems & environment. 10(1)'
+          expect(result).to be_html_safe
+        end
+      end
+
+      context 'with &' do
+        let(:title) { 'Ecosystems & environment. 10(1)' }
+
+        it 'fails to do a good job' do
+          expect(result).to eq '<i>Ecosystems </i>& environment. 10(1)'
+          expect(result).to be_html_safe
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is connected to #1538. It tries to italicize the first phrase when there's no markup already given back by EDS. See the spec for various cases.