### PR TITLE
Disable search dropdown link for current context

### DIFF
--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -35,9 +35,10 @@
         left: auto;
         top: 70%;
 
-        li.active > a {
+        li.active {
           background-color: $public-note-yellow;
           color: $black; // override bootstrap
+          padding: 3px 20px;
         }
       }
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,8 +89,10 @@ module ApplicationHelper
       mapped_params = { q: params[:q] }
       mapped_params[:search_field] = blacklight_config.index.search_field_mapping[params[:search_field].to_sym] if params[:search_field]
     end
-    link_to t('searchworks.search_dropdown.catalog.description_html'),
-            root_path(mapped_params)
+    link_to_unless_current(
+      t('searchworks.search_dropdown.catalog.description_html'),
+      root_path(mapped_params)
+    )
   end
 
   def link_to_article_search
@@ -98,7 +100,9 @@ module ApplicationHelper
       mapped_params = { q: params[:q] }
       mapped_params[:search_field] = blacklight_config.index.search_field_mapping[params[:search_field].to_sym] if params[:search_field]
     end
-    link_to t('searchworks.search_dropdown.articles.description_html'),
-            article_index_path(mapped_params)
+    link_to_unless_current(
+      t('searchworks.search_dropdown.articles.description_html'),
+      article_index_path(mapped_params)
+    )
   end
 end

--- a/app/views/catalog/_search_targets_widget.html.erb
+++ b/app/views/catalog/_search_targets_widget.html.erb
@@ -17,6 +17,6 @@
      </li>
      <li class="<%= 'active' if article_search? %>">
        <%= link_to_article_search %>
-    </li>
+     </li>
   </ul>
 </div>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -11,7 +11,7 @@ feature 'Article Searching' do
 
         expect(page).to have_css('.dropdown-menu', visible: true)
 
-        expect(page).to have_css('li.active a', text: /catalog/)
+        expect(page).to have_css('li.active', text: /catalog/)
         expect(page).not_to have_css('li.active a', text: /articles/)
 
         click_link 'articles'
@@ -24,7 +24,7 @@ feature 'Article Searching' do
         expect(page).to have_css('.dropdown-menu', visible: true)
 
         expect(page).not_to have_css('li.active a', text: /catalog/)
-        expect(page).to have_css('li.active a', text: /articles/)
+        expect(page).to have_css('li.active', text: /articles/)
       end
     end
   end


### PR DESCRIPTION
Closes #1556 

This PR updates the search dropdown. The active search context is highlighted in yellow and the `<a>` tag is removed. Clicking on the active option (1) closes the dropdown menu (2) keeps the user on the same page.

## Demo

![disabled-menu](https://user-images.githubusercontent.com/5402927/29049926-a3c0c426-7b8d-11e7-962a-d4633cb99a9f.gif)


## Example HTML:
```
<ul class="dropdown-menu" role="menu">
  <li>
    <a href="/?q=kittens&amp;search_field=search"><span class="h3">catalog</span> <span class="help-block">books &amp; media in the Stanford Libraries' collections</span></a>
  </li>
  <li class="active">
    <span class="h3">articles</span> <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
  </li>
</ul>
```