### PR TITLE
add support for redirect-based PDF links

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -174,7 +174,7 @@ class ArticlesController < ApplicationController
     redirect_to url if url.present?
   rescue => e
     Honeybadger.notify(e) if defined? Honeybadger
-    flash[:error] = 'Sorry, the PDF download was not successful.<br/>Alternative route: click the title of the article you want, then try the PDF link on the detail page.'
+    flash[:error] = flash_message_for_link_error
     redirect_back fallback_location: articles_path
   end
 
@@ -263,5 +263,12 @@ class ArticlesController < ApplicationController
       return link['url'] if link['type'] == type.to_s
     end
     raise ArgumentError, "Missing #{type} fulltext link in document #{document.id}"
+  end
+
+  def flash_message_for_link_error
+    base_key = 'searchworks.articles.flashes.fulltext_link'
+    return I18n.t("#{base_key}.guest_html", login_url: new_user_session_path) if session['eds_guest']
+
+    I18n.t("#{base_key}.non_guest_html")
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -172,6 +172,10 @@ class ArticlesController < ApplicationController
     _response, document = search_service.fetch(params[:id])
     url = extract_fulltext_link(document, params[:type])
     redirect_to url if url.present?
+  rescue => e
+    Honeybadger.notify(e) if defined? Honeybadger
+    flash[:error] = 'Sorry, the PDF download was not successful.<br/>Alternative route: click the title of the article you want, then try the PDF link on the detail page.'
+    redirect_back fallback_location: articles_path
   end
 
   # Used by default Blacklight `index` and `show` actions

--- a/app/models/concerns/eds_links.rb
+++ b/app/models/concerns/eds_links.rb
@@ -58,7 +58,7 @@ module EdsLinks
 
   # Maps EDS-centric links into SearchWorks links
   class Processor < SearchWorks::Links
-    # @return [Array<SearchWorks::Links::Link]
+    # @return [Array<SearchWorks::Links::Link>]
     def all
       # First convert into our FulltextLink objects
       links = link_fields.map do |link_field|
@@ -73,7 +73,8 @@ module EdsLinks
           href:     link.url,
           fulltext: link.present? && show?(categories, link.category),
           sfx:      link.sfx?,
-          ill:      link.ill?
+          ill:      link.ill?,
+          type:     link.type
         )
       end
     end

--- a/app/views/articles/_index_brief_default.html.erb
+++ b/app/views/articles/_index_brief_default.html.erb
@@ -17,7 +17,10 @@
   <ul class='document-metadata dl-horizontal dl-invert'>
     <% document.access_panels.online.links.each do |link| %>
       <li>
-        <% if link.ill? -%>
+        <% if link.href == 'detail' %>
+          <span class="online-label">Full text</span>
+          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type)) %>
+        <% elsif link.ill? -%>
           <%= link_to(link.text, link.href, class: 'sfx') %>
         <% else %>
           <span class="online-label">Full text</span>

--- a/app/views/articles/_index_brief_default.html.erb
+++ b/app/views/articles/_index_brief_default.html.erb
@@ -19,7 +19,7 @@
       <li>
         <% if link.href == 'detail' %>
           <span class="online-label">Full text</span>
-          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type)) %>
+          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
         <% elsif link.ill? -%>
           <%= link_to(link.text, link.href, class: 'sfx') %>
         <% else %>

--- a/app/views/articles/_index_default.html.erb
+++ b/app/views/articles/_index_default.html.erb
@@ -35,7 +35,10 @@
   <ul class='document-metadata dl-horizontal dl-invert'>
     <% document.access_panels.online.links.each do |link| %>
       <li>
-        <% if link.ill? -%>
+        <% if link.href == 'detail' %>
+          <span class="online-label">Full text</span>
+          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type)) %>
+        <% elsif link.ill? -%>
           <%= link_to(link.text, link.href, class: 'sfx') %>
         <% else %>
           <span class="online-label">Full text</span>

--- a/app/views/articles/_index_default.html.erb
+++ b/app/views/articles/_index_default.html.erb
@@ -37,7 +37,7 @@
       <li>
         <% if link.href == 'detail' %>
           <span class="online-label">Full text</span>
-          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type)) %>
+          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
         <% elsif link.ill? -%>
           <%= link_to(link.text, link.href, class: 'sfx') %>
         <% else %>

--- a/app/views/articles/access_panels/_online.html.erb
+++ b/app/views/articles/access_panels/_online.html.erb
@@ -8,7 +8,11 @@
     <ul class='document-metadata dl-horizontal dl-invert'>
       <% document.access_panels.online.links.each do |link| %>
         <li>
-          <%= link_to(link.text, link.href, class: link.ill? ? 'sfx' : '') %>
+          <% if link.href == 'detail' %>
+            <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
+          <% else %>
+            <%= link_to(link.text, link.href, class: link.ill? ? 'sfx' : '') %>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -1,5 +1,10 @@
 en:
   searchworks:
+    articles:
+      flashes:
+        fulltext_link:
+          guest_html: Sorry, the PDF download was not successful because you are currently in guest mode.<br/><a href="%{login_url}">Log in to try the download again</a>.
+          non_guest_html: Sorry, the PDF download was not successful.<br/>We don't know the source of the error. Try again, and if it continues to fail, <a href=" http://library.stanford.edu/ask/email/connection-problems">please report it as a connection problem</a>.
     search_dropdown:
       articles:
         label: articles

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,13 +68,13 @@ Rails.application.routes.draw do
 
   resources :course_reserves, only: :index, path: "reserves"
 
-  constraints(id: /[-~\+\w[:punct:]]+/) do # EDS identifier rules (e.g., db__id)
+  constraints(id: /[-~\+\(\)\.\|,:;%\w]+/) do # EDS identifier rules (e.g., db__id)
     resources :articles, only: %i[index show] do
       concerns :exportable
     end
 
     post 'articles/:id/track' => 'articles#track', as: :track_article
-    get 'articles/:id/:type/fulltext' => 'articles#fulltext_link', as: :article_fulltext_link
+    get 'articles/:id/:type/fulltext' => 'articles#fulltext_link', as: :article_fulltext_link, constraints: { type: /[-\w]+/ }
   end
 
   resource :sfx_data, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,9 @@ Rails.application.routes.draw do
     resources :articles, only: %i[index show] do
       concerns :exportable
     end
+
     post 'articles/:id/track' => 'articles#track', as: :track_article
+    get 'articles/:id/:type/fulltext' => 'articles#fulltext_link', as: :article_fulltext_link
   end
 
   resource :sfx_data, only: :show

--- a/lib/links.rb
+++ b/lib/links.rb
@@ -35,7 +35,7 @@ module SearchWorks
     end
 
     class Link
-      attr_accessor :html, :text, :href, :file_id, :druid
+      attr_accessor :html, :text, :href, :file_id, :druid, :type
       def initialize(options={})
         @html = options[:html]
         @text = options[:text]
@@ -48,6 +48,7 @@ module SearchWorks
         @file_id = options[:file_id]
         @druid = options[:druid]
         @ill = options[:ill]
+        @type = options[:type]
       end
 
       def ==(other)

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe ArticlesController do
     end
   end
 
+  context '#fulltext_link' do
+    it 'redirect to a fulltext link' do
+      stub_article_service(type: :single, docs: [SolrDocument.new(id: '123',
+        eds_fulltext_links: [{ url: 'http://example.com/file.pdf', type: 'pdf' }])])
+      get :fulltext_link, params: { id: '123', type: :pdf }
+      expect(response).to redirect_to('http://example.com/file.pdf')
+    end
+
+    it 'errors on missing links' do
+      stub_article_service(type: :single, docs: [SolrDocument.new(id: '123',
+        eds_fulltext_links: [{ url: 'detail', type: 'pdf' }])])
+      expect { get :fulltext_link, params: { id: '123', type: :pdf } }.to raise_error(ArgumentError, 'Missing pdf fulltext link in document 123')
+    end
+  end
+
   it 'handles authentication'
   it 'handles configuration'
 

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -30,13 +30,44 @@ RSpec.describe ArticlesController do
       expect(response).to redirect_to('http://example.com/file.pdf')
     end
 
-    it 'errors on missing links' do
-      stub_article_service(type: :single, docs: [SolrDocument.new(id: '123',
-        eds_fulltext_links: [{ url: 'detail', type: 'pdf' }])])
-      get :fulltext_link, params: { id: '123', type: :pdf }
-      expect(flash[:error]).to eq 'Sorry, the PDF download was not successful.<br/>Alternative route: click the title of the article you want, then try the PDF link on the detail page.'
-      expect(response).to have_http_status(:found) # redirects back
+    describe 'errors on missing links' do
+      before do
+        stub_article_service(
+          type: :single,
+          docs: [
+            SolrDocument.new(id: '123', eds_fulltext_links: [{ url: 'detail', type: 'pdf' }])
+          ]
+        )
+      end
+      context 'when the user is in guest mode' do
+        before { session['eds_guest'] = true }
+
+        it 'returns an error message indicating to login to view the content' do
+          get :fulltext_link, params: { id: '123', type: :pdf }
+          error_message = Capybara.string(flash[:error])
+          expect(error_message).to have_content(
+            'Sorry, the PDF download was not successful because you are currently in guest mode.'
+          )
+          expect(error_message).to have_css('a', text: 'Log in to try the download again')
+          expect(response).to have_http_status(:found) # redirects back
+        end
+      end
+
+      context 'when the user is not in guest mode' do
+        before { session['eds_guest'] = false }
+
+        it 'returns an error message indicating to report it as a connection problem' do
+          get :fulltext_link, params: { id: '123', type: :pdf }
+          error_message = Capybara.string(flash[:error])
+          expect(error_message).to have_content 'Sorry, the PDF download was not successful'
+          expect(error_message).to have_content 'We don\'t know the source of the error.'
+          expect(error_message).to have_css('a', text: 'please report it as a connection problem')
+          expect(response).to have_http_status(:found) # redirects back
+        end
+      end
     end
+
+
   end
 
   it 'handles authentication'

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe ArticlesController do
     it 'errors on missing links' do
       stub_article_service(type: :single, docs: [SolrDocument.new(id: '123',
         eds_fulltext_links: [{ url: 'detail', type: 'pdf' }])])
-      expect { get :fulltext_link, params: { id: '123', type: :pdf } }.to raise_error(ArgumentError, 'Missing pdf fulltext link in document 123')
+      get :fulltext_link, params: { id: '123', type: :pdf }
+      expect(flash[:error]).to eq 'Sorry, the PDF download was not successful.<br/>Alternative route: click the title of the article you want, then try the PDF link on the detail page.'
+      expect(response).to have_http_status(:found) # redirects back
     end
   end
 

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -4,20 +4,40 @@ RSpec.describe 'Article Routing', type: :routing do
   it '#index' do
     expect(get('/articles')).to route_to('articles#index')
   end
-  it '#show' do
-    expect(get('/articles/1')).to route_to(controller: 'articles', action: 'show', id: '1')
-    expect(get('/articles/eds__style1')).to route_to(controller: 'articles', action: 'show', id: 'eds__style1')
-    expect(get('/articles/eds__Style2-with-hyphens')).to route_to(controller: 'articles', action: 'show', id: 'eds__Style2-with-hyphens')
-    expect(get('/articles/eds__Style2-with~tildes')).to route_to(controller: 'articles', action: 'show', id: 'eds__Style2-with~tildes')
-    expect(get('/articles/eds__Style2-with+pluses')).to route_to(controller: 'articles', action: 'show', id: 'eds__Style2-with+pluses')
-    expect(get('/articles/eds__Style2-with%3bsemicolon')).to route_to(controller: 'articles', action: 'show', id: 'eds__Style2-with;semicolon')
+
+  context '#show' do
+    let(:uri) { '/articles/' + URI.escape(id) }
+    subject(:result) { get(uri) }
+
+    context 'handles EDS identifiers' do
+      let(:id) { 'eds__1(2).3-4~5,6;7|8%9:A_b' }
+
+      it 'route to the show page' do
+        expect(result).to route_to(controller: 'articles', action: 'show', id: id)
+      end
+
+      context 'identifier with an encoded semicolon' do
+        let(:id) { 'eds__idwith%3bsemicolon' }
+
+        it 'routes to the page with the appropriate identifier' do
+          expect(result).to route_to(controller: 'articles', action: 'show', id: 'eds__idwith;semicolon')
+        end
+      end
+    end
+    context 'rejects unknown identifiers' do
+      let(:id) { 'eds__1 2/3' }
+
+      it 'should not route to show page' do
+        expect(result).not_to be_routable
+      end
+    end
   end
   it '#track' do
-    expect(post('/articles/1/track')).to route_to(controller: 'articles', action: 'track', id: '1')
-    expect(post('/articles/eds__style1/track')).to route_to(controller: 'articles', action: 'track', id: 'eds__style1')
-    expect(post('/articles/eds__Style2-with-hyphens/track')).to route_to(controller: 'articles', action: 'track', id: 'eds__Style2-with-hyphens')
-    expect(post('/articles/eds__Style2-with~tildes/track')).to route_to(controller: 'articles', action: 'track', id: 'eds__Style2-with~tildes')
-    expect(post('/articles/eds__Style2-with+pluses/track')).to route_to(controller: 'articles', action: 'track', id: 'eds__Style2-with+pluses')
+    expect(post('/articles/eds__1/track')).to route_to(controller: 'articles', action: 'track', id: 'eds__1')
+  end
+  it '#fulltext' do
+    expect(get('/articles/eds__1/ebook-pdf/fulltext')).to route_to(controller: 'articles', action: 'fulltext_link', id: 'eds__1', type: 'ebook-pdf')
+    expect(get('/articles/eds__1/wrong type/fulltext')).not_to be_routable
   end
   it 'other actions are not routable' do
     expect(post('/articles')).not_to be_routable

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe 'articles/access_panels/_online.html.erb' do
     expect(rendered).to have_css('.panel-body ul li a', text: 'View full text')
   end
 
+  context 'fulltext PDF links (e.g. "detail" href)' do
+    let(:document) do
+      SolrDocument.new(
+        id: 'abc123',
+        eds_fulltext_links: [{ 'label' => 'PDF full text', 'url' => 'detail', 'type' => 'pdf' }]
+      )
+    end
+
+    it 'links to the article_fulltext_link route instead of "detail"' do
+      content = Capybara.string(rendered.to_s)
+      link = content.find('.panel-body li a')
+      expect(link['href']).not_to include('detail')
+      expect(link['href']).to match(%r{abc123\/pdf\/fulltext})
+    end
+  end
+
   context 'ILL links' do
     let(:document) do
       SolrDocument.new(


### PR DESCRIPTION
This PR fixes #1557 and fixes #1580. It affects the PDF links on the *search* results only (the show pages were already working). To implement these links, we need to add a new controller method that does a EDS Retrieve to get the link (it's not available from the EDS Search data). The link shown on the search results page looks like `/article/12345/pdf/fulltext` or `/article/12345/ebook-pdf/fulltext`, etc. Those links will do a Retrieve and then redirect the user to the actual PDF link.

Also, I disabled turbolinks as it seems to be causing problems negotiating the content type for the PDFs (i.e., you'd get raw PDF back in the window).

On failure, it'll display a flash error message and log the exception to Honeybadger.

### Demo from brief view
![pdf-link mov](https://user-images.githubusercontent.com/1861171/29099203-adfc1776-7c58-11e7-91b8-32ca1549e9b4.gif)
