### PR TITLE
Remove XML from EDS author affiliations

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -94,7 +94,7 @@ class ArticleController < ApplicationController
       },
       'Summary' => {
         eds_authors:              { label: 'Authors', separator_options: BREAKS, helper_method: :link_authors },
-        eds_author_affiliations:  { label: 'Author Affiliations' },
+        eds_author_affiliations:  { label: 'Author Affiliations', separator_options: BREAKS, helper_method: :clean_affiliations },
         eds_composed_title:       { label: 'Source', helper_method: :italicize_composed_title },
         eds_publication_date:     { label: 'Publication Date' },
         eds_languages:            { label: 'Language', helper_method: :mark_html_safe }

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -38,9 +38,7 @@ module ArticleHelper
     return if options[:value].blank?
     separators = options.dig(:config, :separator_options) || {}
     affiliations = options[:value].map(&:to_s).to_sentence(separators)
-    affiliations = Nokogiri::HTML.fragment(CGI.unescapeHTML(affiliations))
-    affiliations.search('relatesto').remove
-    affiliations.to_html.html_safe
+    remove_eds_tag(affiliations,'relatesto').html_safe
   end
 
   def link_to_doi(options = {})
@@ -73,11 +71,9 @@ module ArticleHelper
     return unless options[:value].present?
     return safe_join(options[:value]) if @document && @document.research_starter?
     separators = options.dig(:config, :separator_options) || {}
-    textblock = options[:value].map(&:to_s).to_sentence(separators)
-    textblock = Nokogiri::HTML.fragment(CGI.unescapeHTML(textblock))
-    textblock.search('anid').remove
-    textblock = textblock.to_html
-    sanitize(textblock).html_safe
+    fulltext = options[:value].map(&:to_s).to_sentence(separators)
+    fulltext = remove_eds_tag(fulltext, 'anid')
+    sanitize(fulltext).html_safe
   end
 
   def render_text_from_html(values)
@@ -102,5 +98,11 @@ module ArticleHelper
       value.gsub!(/, #{relator}$/i, '')
     end
     [value, label]
+  end
+
+  def remove_eds_tag(text, tag)
+    text = Nokogiri::HTML.fragment(CGI.unescapeHTML(text))
+    text.search(tag).remove
+    text.to_html
   end
 end

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -34,6 +34,15 @@ module ArticleHelper
     end.to_sentence(separators).html_safe # this is what Blacklight's Join step does
   end
 
+  def clean_affiliations(options = {})
+    return if options[:value].blank?
+    separators = options.dig(:config, :separator_options) || {}
+    affiliations = options[:value].map(&:to_s).to_sentence(separators)
+    affiliations = Nokogiri::HTML.fragment(CGI.unescapeHTML(affiliations))
+    affiliations.search('relatesto').remove
+    affiliations.to_html.html_safe
+  end
+
   def link_to_doi(options = {})
     doi = options[:value].try(:first)
     return if doi.blank?

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe ArticleHelper do
 
   context 'authors' do
     let(:authors) { %w[John\ Doe,\ Author Doe,\ Jane Fred\ Doe] }
+    let(:affiliations) { ["<relatesTo>1</relatesTo>Institute A<br /><relatesTo>2</relatesTo>Institute B<br /><relatesTo>3</relatesTo>Institute C"] }
 
     context '#link_authors' do
       subject(:result) { Capybara.string(helper.link_authors(value: authors)) }
@@ -58,6 +59,7 @@ RSpec.describe ArticleHelper do
         expect(result).to have_content 'John Doe, Author, Doe, Jane, and Fred Doe'
       end
     end
+
     context '#strip_author_relators' do
       subject(:result) { Capybara.string(helper.strip_author_relators(value: authors)) }
 
@@ -66,6 +68,15 @@ RSpec.describe ArticleHelper do
       end
       it 'has no links' do
         expect(result).not_to have_link
+      end
+    end
+
+    context '#clean_affiliations' do
+      let(:result) {helper.clean_affiliations(value: affiliations)}
+
+      it 'removes relatesTo tags and content' do
+        expect(result).not_to have_content('1')
+        expect(result).to have_content('Institute A')
       end
     end
   end


### PR DESCRIPTION
Closes #1551

This PR removes `<relatesTo>` tags in `eds_author_affiliations`. @jvine, I didn't see any markup to relate specific authors to their  affiliations. I'm not sure if that's a feature available in the API yet. 

## Before
![before_cleaning_affiliations](https://user-images.githubusercontent.com/5402927/29098810-37dc86e0-7c56-11e7-8799-bf4d93b60be3.png)

## After
![after_cleaning_affiliations](https://user-images.githubusercontent.com/5402927/29098815-3ed9f860-7c56-11e7-9c3b-ab874720c417.png)

