### PR TITLE
upgrade to the 0.3.1.pre EDS gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.3.0.pre)
+    ebsco-eds (0.3.1.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)


### PR DESCRIPTION
This PR upgrades to the latest EDS gem which has file caching fixes. Namely, it uses the guest mode as part of the cache key.