### PR TITLE
Fix responsive behavior for show page record toolbar

### DIFF
--- a/app/assets/stylesheets/modules/record-toolbar.scss
+++ b/app/assets/stylesheets/modules/record-toolbar.scss
@@ -3,7 +3,6 @@
   margin-top: 35px;
   margin-bottom: 35px;
   padding: 5px;
-  height: 40px;
   color: $sul-toolbar-color;
   font-size: 15px;
 
@@ -63,8 +62,8 @@
 }
 
 .sul-record-page-info {
+  display: inline-block;
   margin: 0;
-  float: left;
 }
 
 .sul-record-page-info-inner {
@@ -76,7 +75,8 @@
 }
 
 .back-to-results {
-  float: left;
+  border-radius: 0;
+  display: inline-block;
 }
 
 #citeLink {
@@ -97,16 +97,16 @@ div.record-toolbar > div > div > ul > li:nth-child(3) > form > div > label {
     }
 
     .navbar-nav .open .dropdown-menu > li > a {
-      color: #000;
-      &:hover {
-        color: #000;
+      color: $white;
+      &:hover, &:focus {
+        text-decoration: underline;
       }
     }
 
     .navbar-header {
-      margin-top: 6px;
       .navbar-toggle {
-        margin-top: 0px;
+        border: 0;
+        margin: 0 15px 0 0;
       }
     }
     .navbar-collapse > ul > li {

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -66,6 +66,7 @@
       display: inline-block;
       margin: 30px 0 0;
       padding: 0;
+      text-indent: 0;
     }
   }
 

--- a/app/assets/stylesheets/modules/sul-toolbar.scss
+++ b/app/assets/stylesheets/modules/sul-toolbar.scss
@@ -3,12 +3,10 @@
   padding: 0;
   margin: 35px 0px;
   min-height: 40px;
-  height: 40px;
   color: $sul-toolbar-color;
 
   // Back to results button
   .back-to-results {
-    margin-left: -10px;
     margin-right: 10px;
     padding-left: 5px;
     padding-right: 10px;

--- a/app/views/articles/record/_record_toolbar.html.erb
+++ b/app/views/articles/record/_record_toolbar.html.erb
@@ -1,6 +1,10 @@
 <div class="record-toolbar container-fluid sul-toolbar navbar navbar-default" role="navigation">
   <div class="container-fluid">
     <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".toolbar-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="fa fa-bars"></span>
+      </button>
       <%= link_back_to_catalog :class => 'btn btn-sul-toolbar back-to-results', :label => t('blacklight.back_to_search').html_safe -%>
       <% if @previous_document || @next_document -%>
         <div class="sul-record-page-info">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,7 +1,6 @@
 <div class="row">
   <div id="content" class="col-md-12 show-document">
-    <%= render "articles/record/record_toolbar" %>
-
+    <%= render "shared/record/record_toolbar" %>
     <% @page_title = t 'blacklight.search.show.title_html', document_title: document_show_html_title, application_name: "#{application_name} articles" %>
     <% # content_for(:head) { render_link_rel_alternates } Commented out for now %>
 

--- a/app/views/catalog/record/_record_toolbar.html.erb
+++ b/app/views/catalog/record/_record_toolbar.html.erb
@@ -25,7 +25,7 @@
           </li>
         <% end %>
         <li class="dropdown">
-          <button class="btn btn-sul-toolbar" data-toggle="dropdown">
+          <button class="btn btn-sul-toolbar" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= t('blacklight.tools.send_to_html').html_safe %>
           </button>
           <ul class="dropdown-menu" role="menu">

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div id="content" class="col-md-12 show-document">
 
-    <%= render "catalog/record/record_toolbar" %>
+    <%= render "shared/record/record_toolbar" %>
 
     <% @page_title = t 'blacklight.search.show.title_html', :document_title => document_show_html_title, :application_name => "#{application_name} catalog" -%>
     <% content_for(:head) { render_link_rel_alternates } -%>

--- a/app/views/shared/record/_record_toolbar.html.erb
+++ b/app/views/shared/record/_record_toolbar.html.erb
@@ -5,8 +5,8 @@
         <span class="sr-only">Toggle navigation</span>
         <span class="fa fa-bars"></span>
       </button>
+      <%= link_back_to_catalog :class => 'btn btn-sul-toolbar back-to-results', :label => t('blacklight.back_to_search').html_safe %>
       <% if @previous_document || @next_document %>
-        <%= link_back_to_catalog :class => 'btn btn-sul-toolbar back-to-results', :label => t('blacklight.back_to_search').html_safe %>
         <div class="sul-record-page-info">
           <div class="sul-record-page-info-inner">
             <%= link_to_previous_document @previous_document if @previous_document %>
@@ -17,7 +17,6 @@
       <% end %>
     </div>
     <div class="navbar-collapse collapse toolbar-collapse">
-
       <ul class="nav navbar-nav navbar-right">
         <% if @document.citable? %>
           <li>
@@ -33,9 +32,8 @@
           </ul>
         </li>
         <li>
-          <%= render(:partial => 'bookmark_control', :locals => {:document=> @document}) %>
+          <%= render(:partial => 'bookmark_control', :locals => {:document=> @document}) unless article_search? %>
         </li>
-
       </ul>
     </div>
   </div>

--- a/spec/features/article_record_toolbar_spec.rb
+++ b/spec/features/article_record_toolbar_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'Article Record Toolbar', js: true do
     end
   end
   it 'shows both prev and next buttons' do
-    skip 'TODO: disabled temporarily'
     within '.record-toolbar' do
       expect(page).to have_css('.previous', text: 'Previous')
       expect(page).to have_css('.next', text: 'Next')

--- a/spec/features/blacklight_customizations/record_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/record_toolbar_spec.rb
@@ -13,7 +13,7 @@ feature "Record Toolbar" do
 
       within "div.navbar-header" do
         expect(page).to_not have_css("button.navbar-toggle", visible: true)
-        expect(page).to_not have_css("a.btn.btn-sul-toolbar", text:"Back to results", visible: true)
+        expect(page).to have_css("a.btn.btn-sul-toolbar", text:"Back to results", visible: true)
         expect(page).to_not have_css("a.previous.disabled", visible: true)
         expect(page).to_not have_css("a.previous", visible: true)
         expect(page).to_not have_css("a.next.disabled", visible: true)


### PR DESCRIPTION
Closes #1494

This PR
- fixes responsive behavior for the show page record toolbar
- moves record toolbar to a shared partial
- fixes search target dropdown alignment

## Before
![sul-toolbar-bug](https://user-images.githubusercontent.com/5402927/28344950-c3ca008c-6bdb-11e7-9a31-9646a7d0be55.gif)

## After

### Article
![article-record-toolbar](https://user-images.githubusercontent.com/5402927/29285138-4b393b6c-80e2-11e7-99dd-21ab9be84130.gif)

### Catalog
![catalog-record-toolbar](https://user-images.githubusercontent.com/5402927/29285141-51a39722-80e2-11e7-81ad-8b5cfeb9f838.gif)
