### PR TITLE
store guest mode in Blacklight session

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -177,7 +177,7 @@ class ArticleController < ApplicationController
 
   def search_service
     eds_params = {
-      guest:          !eds_authenticated_user?,
+      guest:          session['eds_guest'],
       session_token:  session['eds_session_token']
     }
     Eds::SearchService.new(blacklight_config, eds_params)
@@ -190,9 +190,10 @@ class ArticleController < ApplicationController
   # Reuse the EDS session token if available in the user's session data,
   # otherwise establish a session
   def setup_eds_session(session)
-    return if session['eds_session_token'].present?
+    return if session['eds_session_token'].present? && session.has_key?('eds_guest')
+    session['eds_guest'] = !eds_authenticated_user?
     session['eds_session_token'] = EBSCO::EDS::Session.new(
-      guest:    !eds_authenticated_user?,
+      guest:    session['eds_guest'],
       caller:   'new-session',
       user:     Settings.EDS_USER,
       pass:     Settings.EDS_PASS,

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -23,16 +23,30 @@ RSpec.describe ArticleController do
   context 'EDS Session Management' do
     let(:user_session) { {} }
     let(:eds_session) { instance_double(EBSCO::EDS::Session, session_token: 'abc') }
-    before { allow(controller).to receive(:session).and_return(user_session) }
+    before do
+      allow(controller).to receive(:session).and_return(user_session)
+      allow(controller).to receive(:eds_authenticated_user?).and_return(true)
+    end
     it 'will create a new session' do
       expect(EBSCO::EDS::Session).to receive(:new).with(
-        hash_including(caller: 'new-session', guest: true)
+        hash_including(caller: 'new-session', guest: false)
       ).and_return(eds_session)
       controller.eds_init
     end
     it 'will reuse the session if in the user session data' do
+      user_session['eds_guest'] = false
       user_session['eds_session_token'] = 'def'
       expect(EBSCO::EDS::Session).not_to receive(:new)
+      controller.eds_init
+    end
+    it 'will require the guest mode in the user session data' do
+      user_session['eds_session_token'] = 'def'
+      expect(EBSCO::EDS::Session).to receive(:new).and_return(eds_session)
+      controller.eds_init
+    end
+    it 'will require the session token in the user session data' do
+      user_session['eds_guest'] = false
+      expect(EBSCO::EDS::Session).to receive(:new).and_return(eds_session)
       controller.eds_init
     end
   end


### PR DESCRIPTION
This PR is connected to #1531. 

It stores the guest mode in the Blacklight session at the time the EDS session was created. 

The session cookie must have both the EDS session token and the guest mode stored, otherwise, it'll create a new EDS session and calculate the guest mode (based on IP address).

### Before OFF->ON campus

1. User visits site for first time from off-campus
1. An EDS session is created with guest mode ON
1. User visits site from on-campus later and executes a search
1. The EDS session is reused, but we send guest mode OFF to the EDS API  (which is incorrect as the EDS session is tied to the original guest mode in the EDS service and is ignored and will return guest mode ON results, thus causing confusion).

### Before ON->OFF campus

1. User visits site for first time from on-campus
1. An EDS session is created with guest mode OFF
1. User visits site from off-campus later and executes a search
1. The EDS session is reused, but we send guest mode ON to the EDS API (which is incorrect as the EDS session is tied to the original guest mode in the EDS service and is ignored and will return guest mode OFF results, thus causing confusion).

### After OFF->ON campus

1. User visits site for first time from off-campus
1. An EDS session is created with guest mode ON
1. User visits site from on-campus later and executes a search
1. The EDS session is reused and we send guest mode ON to the EDS API. 

### After ON->OFF campus

1. User visits site for first time from on-campus
1. An EDS session is created with guest mode OFF
1. User visits site from off-campus later and executes a search
1. The EDS session is reused and we send guest mode OFF to the EDS API. 

Note that the switch from off to on campus has no effect (as expected for this PR). We need to create a ticket for that case and implemented some kind of IP change detection. That said, this PR is really intended to reduce confusion by coming into parity with the EDS API's expectations.
