### PR TITLE
include any punctuation character as EDS accession id

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
 
   resources :course_reserves, only: :index, path: "reserves"
 
-  constraints(id: /[-~\+\w]+/) do # EDS identifier rules (e.g., db__id)
+  constraints(id: /[-~\+\w[:punct:]]+/) do # EDS identifier rules (e.g., db__id)
     resources :article, only: %i[index show] do
       concerns :exportable
     end

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Article Routing', type: :routing do
     expect(get('/article/eds__Style2-with-hyphens')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with-hyphens')
     expect(get('/article/eds__Style2-with~tildes')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with~tildes')
     expect(get('/article/eds__Style2-with+pluses')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with+pluses')
+    expect(get('/article/eds__Style2-with%3bsemicolon')).to route_to(controller: 'article', action: 'show', id: 'eds__Style2-with;semicolon')
   end
   it '#track' do
     expect(post('/article/1/track')).to route_to(controller: 'article', action: 'track', id: '1')


### PR DESCRIPTION
This PR fixes #1577, although we don't have a spec on allowable characters in the EDS' accession identifiers.

An example: http://localhost:3000/article/awn__sajae-138570-%3b-1165365