### PR TITLE
Disable selecting current context from search dropdown in show view

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,7 +89,8 @@ module ApplicationHelper
       mapped_params = { q: params[:q] }
       mapped_params[:search_field] = blacklight_config.index.search_field_mapping[params[:search_field].to_sym] if params[:search_field]
     end
-    link_to_unless_current(
+    link_to_unless(
+      controller_name == 'catalog',
       t('searchworks.search_dropdown.catalog.description_html'),
       root_path(mapped_params)
     )
@@ -100,7 +101,8 @@ module ApplicationHelper
       mapped_params = { q: params[:q] }
       mapped_params[:search_field] = blacklight_config.index.search_field_mapping[params[:search_field].to_sym] if params[:search_field]
     end
-    link_to_unless_current(
+    link_to_unless(
+      controller_name == 'articles',
       t('searchworks.search_dropdown.articles.description_html'),
       articles_path(mapped_params)
     )

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -19,11 +19,16 @@ feature 'Article Searching' do
 
       expect(page).to have_current_path(articles_path) # the landing page for Article Search
       expect(page).to have_title('SearchWorks articles : Stanford Libraries')
+    end
+
+    scenario 'does not allow selecting current search context' do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+      visit articles_path
+
       within '.search-dropdown' do
         click_link 'search articles'
         expect(page).to have_css('.dropdown-menu', visible: true)
-
-        expect(page).not_to have_css('li.active a', text: /catalog/)
+        expect(page).not_to have_css('li.active a', text: /articles/)
         expect(page).to have_css('li.active', text: /articles/)
       end
     end


### PR DESCRIPTION
Finishes work on #1556 

This PR :
- updates the `link_to_catalog_search` and `link_to_article_search` helpers. 
- disables clicking on the current search context / uses appropriate styling in the search dropdown

## Before (show view):
![dropdown-bug](https://user-images.githubusercontent.com/5402927/29295929-0c5a643c-810c-11e7-82e7-baeb015d45b2.gif)

## After
![dropdown-fix](https://user-images.githubusercontent.com/5402927/29295954-2cbdfa22-810c-11e7-9bae-3db8147e1083.gif)
