### PR TITLE
update online and SFX panel wording

### DIFF
--- a/app/views/articles/access_panels/_online.html.erb
+++ b/app/views/articles/access_panels/_online.html.erb
@@ -1,7 +1,7 @@
 <div class="panel panel-default access-panel panel-online">
   <div class="access-panel-heading panel-heading">
     <h3>
-      Available online
+      Best source
     </h3>
   </div>
   <div class="panel-body">

--- a/app/views/articles/access_panels/_sfx.html.erb
+++ b/app/views/articles/access_panels/_sfx.html.erb
@@ -1,7 +1,7 @@
 <div class="panel panel-default access-panel panel-online" data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: CGI.escape(document.access_panels.sfx.links.first.href)) %>">
   <div class="access-panel-heading panel-heading">
     <h3>
-      All full-text sources
+      All available sources
     </h3>
   </div>
   <div class="panel-body" data-behavior="sfx-panel-body">

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'articles/access_panels/_online.html.erb' do
   end
 
   it 'has the proper heading' do
-    expect(rendered).to have_css('.panel-heading h3', text: 'Available online')
+    expect(rendered).to have_css('.panel-heading h3', text: 'Best source')
   end
 
   it 'includes EDS fulltext links' do


### PR DESCRIPTION
Closes #1575 

This PR changes the titles of the following access panels (articles only):
- Online: "Available online" -> "Best source"
- SFX: "All full-text sources" -> "All available sources"

## Before
<img width="341" alt="panels_before" src="https://user-images.githubusercontent.com/5402927/29344001-ccc280f0-81e9-11e7-81ea-0d6feef923be.png">

## After
<img width="347" alt="panels_after" src="https://user-images.githubusercontent.com/5402927/29344008-d372f484-81e9-11e7-9ff7-f010cc4b0680.png">
