### PR TITLE
Truncate eds author data in search results.

### DIFF
--- a/app/views/articles/_index_default.html.erb
+++ b/app/views/articles/_index_default.html.erb
@@ -1,7 +1,11 @@
 <% doc_presenter = presenter(document) %>
 <ul class='document-metadata dl-horizontal dl-invert'>
   <% if document['eds_authors'].present? %>
-    <li><%= doc_presenter.field_value('eds_authors') %></li>
+    <li>
+      <div data-behavior='article-metadata-truncate'>
+        <%= doc_presenter.field_value('eds_authors') %>
+      </div>
+    </li>
   <% end %>
 
   <% if document['eds_composed_title'].present? %>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -86,10 +86,11 @@ feature 'Article Searching' do
       expect(current_url).to match(%r{/articles/abc123})
     end
 
-    scenario 'subject and abstracts are truncated', js: true do
+    scenario 'authors, subjects, and abstracts are truncated', js: true do
       long_data = Array.new(100) { |_| 'Lorem ipsum dolor sit amet' }.join(', ')
       document = SolrDocument.new(
         id: '1234',
+        eds_authors:  long_data,
         eds_abstract: long_data,
         eds_subjects: long_data
       )
@@ -100,7 +101,7 @@ feature 'Article Searching' do
       within(first('.document')) do
         expect(page).to have_css('dt', text: /subjects/i)
         expect(page).to have_css('dt', text: /abstract/i)
-        expect(page).to have_css('a.responsiveTruncatorToggle', text: 'more...', count: 2)
+        expect(page).to have_css('a.responsiveTruncatorToggle', text: 'more...', count: 3)
       end
     end
 


### PR DESCRIPTION
Closes #1548 

## edsjsr__edsjsr_25665551
<img width="787" alt="edsjsr__edsjsr_25665551" src="https://user-images.githubusercontent.com/96776/29387759-7a189e04-8296-11e7-8b71-2df544d1b9d6.png">

@jvine does this look okay?