### PR TITLE
Add HTML full text link to article results

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.3.1.pre)
+    ebsco-eds (0.3.2.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)

--- a/app/models/concerns/eds_document.rb
+++ b/app/models/concerns/eds_document.rb
@@ -1,6 +1,6 @@
 module EdsDocument
-  def html_fulltext_available?
-    self[:eds_html_fulltext].present?
+  def html_fulltext?
+    self['eds_html_fulltext_available'] == true
   end
 
   def research_starter?

--- a/app/views/articles/_index_default.html.erb
+++ b/app/views/articles/_index_default.html.erb
@@ -35,16 +35,23 @@
   </dl>
 <% end %>
 
-<% if document.access_panels.online? && !document.eds_restricted? %>
+<% if !document.eds_restricted? %>
   <ul class='document-metadata dl-horizontal dl-invert'>
-    <% document.access_panels.online.links.each do |link| %>
+    <% if document.access_panels.online? %>
+      <% document.access_panels.online.links.each do |link| %>
+        <li>
+          <% if link.ill? -%>
+            <%= link_to(link.text, link.href, class: 'sfx') %>
+          <% else %>
+            <span class="online-label">Full text</span>
+            <%= link_to(link.text, link.href) %>
+          <% end %>
+        </li>
+      <% end %>
+    <% elsif document.html_fulltext? %>
       <li>
-        <% if link.ill? -%>
-          <%= link_to(link.text, link.href, class: 'sfx') %>
-        <% else %>
-          <span class="online-label">Full text</span>
-          <%= link_to(link.text, link.href) %>
-        <% end %>
+        <span class="online-label">Full text</span>
+        <%= link_to('View on detail page',article_path(document)) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/articles/_show_default.html.erb
+++ b/app/views/articles/_show_default.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="article-record-sections record-sections col-md-8">
     <% sections = blacklight_config.show.sections %>
-    <% if document.html_fulltext_available? %>
+    <% if document.html_fulltext? %>
       <div class="html-fulltext-container">
         <%= render('articles/record/html_fulltext', document: document, fields: sections["Fulltext"].keys)%>
       </div>

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -20,7 +20,7 @@ feature 'Article Record Display' do
 
   describe 'Fulltext', js: true do
     let(:document) do
-      SolrDocument.new(id: '123', eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
+      SolrDocument.new(id: '123', eds_html_fulltext_available: true, eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
     end
 
     it 'toggled via panel heading' do

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -110,7 +110,9 @@ feature 'Article Searching' do
       article_search_for('Kittens')
 
       expect(page).to have_css('ul.document-metadata li span.online-label', text: 'Full text')
-      expect(page).to have_css('ul.document-metadata li a.sfx', text: /^Find it in print/)
+      expect(page).to have_css('ul.document-metadata li a', text: /^View on detail page/)
+      expect(page).to have_css('ul.document-metadata li a', text: /^View full text/)
+      expect(page).to have_css('ul.document-metadata li a', text: /^Find it in print/)
     end
   end
 

--- a/spec/models/concerns/eds_document.rb
+++ b/spec/models/concerns/eds_document.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe EdsDocument do
   let(:document) do
-    SolrDocument.new(id: '123', eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
+    SolrDocument.new(id: '123', eds_html_fulltext_available: true, eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
   end
   let(:empty_document) do
     SolrDocument.new(id: '456', eds_html_fulltext: '')
@@ -10,11 +10,11 @@ describe EdsDocument do
 
   describe '#html_fulltext_available' do
     it 'should return true when fulltext is present' do
-      expect(document.html_fulltext_available?).to be true
+      expect(document.html_fulltext?).to be true
     end
 
     it 'returns nil when fulltext is not available' do
-      expect(empty_document.html_fulltext_available?).to be_falsey
+      expect(empty_document.html_fulltext?).to be_falsey
     end
   end
 end

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -2,9 +2,31 @@
 # Module included for RSpec tests to stub the article search service
 module StubArticleService
   SAMPLE_RESULTS = [
-      SolrDocument.new(id: 'abc123', eds_title: 'The title of the document', eds_subjects: %w[Kittens Felines Companions]),
-      SolrDocument.new(id: '321cba', eds_title: 'Another title for the document', eds_fulltext_links: [{ 'label' => 'HTML full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]),
-      SolrDocument.new(id: 'wqoeif', eds_title: 'Yet another title for the document', eds_fulltext_links: [{ 'label' => 'View request options', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }])
+    SolrDocument.new(
+      id: 'abc123',
+      eds_title: 'The title of the document',
+      eds_subjects: %w[Kittens Felines Companions],
+      eds_html_fulltext_available: true
+    ),
+    SolrDocument.new(
+      id: '321cba',
+      eds_title: 'Another title for the document',
+      eds_html_fulltext_available: true,
+      eds_fulltext_links: [{
+        'label' => 'HTML full text',
+        'url' => 'http://example.com',
+        'type' => 'customlink-fulltext'
+      }]
+    ),
+    SolrDocument.new(
+      id: 'wqoeif',
+      eds_title: 'Yet another title for the document',
+      eds_fulltext_links: [{
+        'label' => 'View request options',
+        'url' => 'http://example.com',
+        'type' => 'customlink-fulltext'
+      }]
+    )
   ]
 
   def stub_article_service(type: :multiple, docs:)


### PR DESCRIPTION
Closes #1570 

This PR
- upgrades to the latest version of the `ebsco-eds` gem. This makes `:eds_ebook_pdf_fulltext_available`, `:eds_ebook_epub_fulltext_available`, `:eds_pdf_fulltext_available`, `:eds_html_fulltext_available` available.
- adds a 'Full text' label, and a link to the article record with the text `View on detail page`

[Example search](https://sw-webapp-sandbox-f.stanford.edu/articles?utf8=%E2%9C%93&f%5Beds_search_limiters_facet%5D%5B%5D=Stanford+has+it&search_field=search&q=Guzman%2C+Andrew+T.%3A+Overheated%3A+The+Human+Cost+of+Climate+Change)

## Before
![results_before](https://user-images.githubusercontent.com/5402927/29389138-51acc998-829d-11e7-912f-638fd48aef0a.png)

## After
![results_after](https://user-images.githubusercontent.com/5402927/29389140-56371f40-829d-11e7-9099-a0ab7f1b1261.png)