### PR TITLE
Change article fulltext html to be open by default and add a chevron.

### DIFF
--- a/app/assets/javascripts/article.js
+++ b/app/assets/javascripts/article.js
@@ -1,10 +1,10 @@
 Blacklight.onLoad(function(){
   $('#toggleFulltext').on('show.bs.collapse', function(){
-    $('#fulltextToggleBar').html('<h2>Hide full text</h2>')
+    $('#fulltextToggleBar').html('<h2>Hide full text <i class="fa fa-chevron-down"></i></h2>')
   });
 
   $('#toggleFulltext').on('hide.bs.collapse', function(){
-    $('#fulltextToggleBar').html('<h2>Show full text</h2>')
+    $('#fulltextToggleBar').html('<h2>Show full text <i class="fa fa-chevron-right"></i></h2>')
   });
 
   // toggles close icon from plus to X and vice versa

--- a/app/views/articles/record/_html_fulltext.erb
+++ b/app/views/articles/record/_html_fulltext.erb
@@ -1,13 +1,13 @@
 <% doc_presenter = presenter(document) -%>
-<button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="false" aria-controls="toggleFulltext">
-  <h2>Full text</h2>
+<button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="true" aria-controls="toggleFulltext">
+  <h2>Hide full text <i class='fa fa-chevron-down'></i></h2>
 </button>
-<div class='section-body <%= document.research_starter? ? 'collapse.in' : 'collapse' -%>' id="toggleFulltext">
-<% fields.each do |field_name| -%>
-  <% field_name = field_name.to_s -%>
-  <% value = doc_presenter.field_value field_name -%>
-  <% if value.present? %>
-    <div class="blacklight-<%= field_name.parameterize %>"><%= value %></div>
+<div class='section-body collapse in' id="toggleFulltext">
+  <% fields.each do |field_name| -%>
+    <% field_name = field_name.to_s -%>
+    <% value = doc_presenter.field_value field_name -%>
+    <% if value.present? %>
+      <div class="blacklight-<%= field_name.parameterize %>"><%= value %></div>
+    <% end -%>
   <% end -%>
-<% end -%>
 </div>

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -25,11 +25,14 @@ feature 'Article Record Display' do
 
     it 'toggled via panel heading' do
       visit article_path(document[:id])
-      expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: false)
-
-      find('#fulltextToggleBar').click
+      expect(page).to have_css('.fulltext-toggle-bar', text: 'Hide full text')
       expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
       expect(page).to have_content('This Journal')
+
+      find('#fulltextToggleBar').click
+      expect(page).to have_css('.fulltext-toggle-bar', text: 'Show full text')
+      expect(page).not_to have_css('div.blacklight-eds_html_fulltext', visible: true)
+      expect(page).not_to have_content('This Journal')
     end
 
     it 'renders HTML' do


### PR DESCRIPTION
Closes #1604 

![html-fulltext-toggle](https://user-images.githubusercontent.com/96776/29434680-e119d6f0-8358-11e7-87d6-a63ff0937b28.gif)
