### PR TITLE
Remove markup from Series & Document Type

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -130,7 +130,7 @@ class ArticlesController < ApplicationController
         eds_issns:                { label: 'ISSN' },
         eds_publication_info:     { label: 'Published' },
         eds_document_oclc:        { label: 'OCLC' },
-        eds_document_type:        { label: 'Document Type' },
+        eds_document_type:        { label: 'Document Type', helper_method: :remove_html_from_document_field },
         eds_other_titles:         { label: 'Other Titles' },
         eds_physical_description: { label: 'Physical Description' }
       }

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -122,7 +122,7 @@ class ArticlesController < ApplicationController
         eds_database_name:        { label: 'Database' },
         eds_source_title:         { label: 'Journal' },
         eds_volume:               { label: 'Volume' },
-        eds_series:               { label: 'Series' },
+        eds_series:               { label: 'Series', helper_method: :remove_html_from_document_field },
         eds_issue:                { label: 'Issue' },
         eds_page_start:           { label: 'Page Start' },
         eds_page_count:           { label: 'Page Count' },

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -76,6 +76,13 @@ module ArticleHelper
     sanitize(fulltext).html_safe
   end
 
+  def remove_html_from_document_field(options = {})
+    return if options[:value].blank?
+
+    separators = options.dig(:config, :separator_options) || {}
+    render_text_from_html(options[:value]).map(&:to_s).to_sentence(separators)
+  end
+
   def render_text_from_html(values)
     values = Array.wrap(values)
     return [] if values.blank?

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe ArticleHelper do
     end
   end
 
+  describe '#remove_html_from_document_field' do
+    it 'returns to_sentance joined text splitting on and stripping HTML' do
+      result = remove_html_from_document_field(value: Array.wrap('Thing1<br/>Thing2<br/>Thing3'))
+
+      expect(result).to eq 'Thing1, Thing2, and Thing3'
+    end
+  end
+
   context '#italicize_composed_title' do
     let(:result) { helper.italicize_composed_title(value: Array.wrap(title)) }
 


### PR DESCRIPTION
Closes #1602
Closes #1589

## nlebk__1459045 (before)
<img width="803" alt="nlebk__1459045-before" src="https://user-images.githubusercontent.com/96776/29479408-dfd4ff30-8426-11e7-898a-cda6bbfecd61.png">

## nlebk__1459045 (after)
<img width="821" alt="nlebk__1459045-after" src="https://user-images.githubusercontent.com/96776/29479409-dfd8171a-8426-11e7-886a-ada19219e4c9.png">


## edsgao__edsgcl_320590702 (before)
<img width="420" alt="edsgao__edsgcl_320590702-before" src="https://user-images.githubusercontent.com/96776/29479407-dfd2dc5a-8426-11e7-97bb-29b6c667569e.png">

## edsgao__edsgcl_320590702 (after)
<img width="517" alt="edsgao__edsgcl_320590702-after" src="https://user-images.githubusercontent.com/96776/29479410-dfd8ca48-8426-11e7-805d-075b8d14eb97.png">
