### PR TITLE
restore facet counts for Source Type facet

### DIFF
--- a/app/assets/stylesheets/modules/facets.scss
+++ b/app/assets/stylesheets/modules/facets.scss
@@ -13,11 +13,6 @@
       margin-bottom: 0;
     }
   }
-
-  // Source Type facet counts disabled 
-  .blacklight-eds_publication_type_facet {
-    .facet-count { display: none; }
-  }
 }
 .panel-group .facet_limit {
   margin-bottom: 7px;


### PR DESCRIPTION
This PR fixes #1650 by putting the facet counts back for the Source Type facet:

### Before
![screen shot 2017-08-28 at 3 24 30 pm](https://user-images.githubusercontent.com/1861171/29796338-60b8770e-8c05-11e7-8a91-f7d822de892e.png)

### After
![screen shot 2017-08-28 at 3 24 04 pm](https://user-images.githubusercontent.com/1861171/29796335-5d99ec56-8c05-11e7-8bf8-24154150c0f1.png)
