### PR TITLE
Update library services menu

### DIFF
--- a/app/assets/javascripts/search_navbar_services_menu.js
+++ b/app/assets/javascripts/search_navbar_services_menu.js
@@ -4,4 +4,3 @@ Blacklight.onLoad(function() {
   $('.navbar-toggle').rotateHelper();
 
 });
-

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -25,12 +25,12 @@
     color: $white;
   }
 
-  .sul-top-menu {
+  .sul-services-menu {
     white-space: nowrap;
   }
 
   // For all subnavbar navbar lists
-  .sul-top-menu ul {
+  .sul-services-menu ul {
     list-style-type: none;
     padding-left: 20px;
   }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -25,7 +25,15 @@
     color: $white;
   }
 
+  .sul-top-menu {
+    white-space: nowrap;
+  }
+
   // For all subnavbar navbar lists
+  .sul-top-menu ul {
+    list-style-type: none;
+    padding-left: 20px;
+  }
   .navbar-nav > li {
     a {
       background-color: $sul-subnavbar-bg-color;
@@ -88,6 +96,10 @@
   @media screen and (max-width: $screen-sm-min) {
     .navbar-collapse {
       padding: 0 15px;
+    }
+
+    .sul-top-menu {
+      white-space: normal;
     }
   }
 }

--- a/app/views/shared/_search_navbar_services_menu.html.erb
+++ b/app/views/shared/_search_navbar_services_menu.html.erb
@@ -1,47 +1,58 @@
-<ul class="dropdown-menu sul-top-menu" role="menu" aria-labelledby="searchNavbarTopMenu">
+<ul class="dropdown-menu sul-services-menu" role="menu" aria-labelledby="searchNavbarTopMenu">
   <li>
     <a role="menuitem" href="https://library.stanford.edu/using">Using the libraries</a>
     <ul>
-        <li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connecting to e-resources</a>
-        </li><li>
+      </li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">Interlibrary services</a>
-        </li>
+      </li>
     </ul>
-  </li><li>
+  </li>
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/ask">Ask us</a>
     <ul>
-        <li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Ask a reference question</a>
-        </li><li>
+      </li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/ask/email/connection-problems">Report a connection problem</a>
-        </li><li>
+      </li>
+      <li>
         <a role="menuitem" href="https://web.stanford.edu/group/dlss/requestform/suggestpurchase.fb">Suggest a purchase (requires login)</a>
-        </li>
+      </li>
     </ul>
-  </li><li>
+  </li>
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/about">About the Stanford Libraries</a>
     <ul>
-        <li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/people">Find a specialist</a>
-        </li><li>
+      </li>
+      <li>
         <a role="menuitem" href="https://library-hours.stanford.edu/">Library hours</a>
-        </li>
+      </li>
     </ul>
-  </li><li>
+  </li>
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/libraries">Libraries</a>
-  </li><li>
+  </li>
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/collections">Collections</a>
-  </li><li>
+  </li>
+  <li>
     <a role="menuitem" href="https://library.stanford.edu/research">Research support</a>
     <ul>
-        <li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/guides/topic">Topic guides</a>
-        </li><li>
+      </li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/guides/course">Course guides</a>
-        </li><li>
+      </li>
+      <li>
         <a role="menuitem" href="https://library.stanford.edu/search-tools">More search tools</a>
-        </li>
+      </li>
     </ul>
   </li>
 </ul>

--- a/app/views/shared/_search_navbar_top_menu.html.erb
+++ b/app/views/shared/_search_navbar_top_menu.html.erb
@@ -1,57 +1,47 @@
 <ul class="dropdown-menu sul-top-menu" role="menu" aria-labelledby="searchNavbarTopMenu">
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/about">About</a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/libraries">Libraries</a>
-  </li>
-  <li>
     <a role="menuitem" href="https://library.stanford.edu/using">Using the libraries</a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/areas">Collections</a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/research">Research support</a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/academic-technology">Academic technology</a>
-  </li>
-  <li>
+    <ul>
+        <li>
+        <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connecting to e-resources</a>
+        </li><li>
+        <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">Interlibrary services</a>
+        </li>
+    </ul>
+  </li><li>
     <a role="menuitem" href="https://library.stanford.edu/ask">Ask us</a>
+    <ul>
+        <li>
+        <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Ask a reference question</a>
+        </li><li>
+        <a role="menuitem" href="https://library.stanford.edu/ask/email/connection-problems">Report a connection problem</a>
+        </li><li>
+        <a role="menuitem" href="https://web.stanford.edu/group/dlss/requestform/suggestpurchase.fb">Suggest a purchase (requires login)</a>
+        </li>
+    </ul>
+  </li><li>
+    <a role="menuitem" href="https://library.stanford.edu/about">About the Stanford Libraries</a>
+    <ul>
+        <li>
+        <a role="menuitem" href="https://library.stanford.edu/people">Find a specialist</a>
+        </li><li>
+        <a role="menuitem" href="https://library-hours.stanford.edu/">Library hours</a>
+        </li>
+    </ul>
+  </li><li>
+    <a role="menuitem" href="https://library.stanford.edu/libraries">Libraries</a>
+  </li><li>
+    <a role="menuitem" href="https://library.stanford.edu/collections">Collections</a>
+  </li><li>
+    <a role="menuitem" href="https://library.stanford.edu/research">Research support</a>
+    <ul>
+        <li>
+        <a role="menuitem" href="https://library.stanford.edu/guides/topic">Topic guides</a>
+        </li><li>
+        <a role="menuitem" href="https://library.stanford.edu/guides/course">Course guides</a>
+        </li><li>
+        <a role="menuitem" href="https://library.stanford.edu/search-tools">More search tools</a>
+        </li>
+    </ul>
   </li>
-
-  <li role="separator" class="divider"></li>
-
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">
-      <i class="fa fa-bookmark-o"></i> Connect from off campus
-    </a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/hours">
-      <i class="fa fa-bookmark-o"></i> Hours &amp; locations
-    </a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">
-      <i class="fa fa-bookmark-o"></i> Interlibrary borrowing
-    </a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/ask/email/request_purchase">
-      <i class="fa fa-bookmark-o"></i> Suggest a purchase
-    </a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/guides/topic">
-      <i class="fa fa-bookmark-o"></i> Topic guides
-    </a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/guides/course">
-      <i class="fa fa-bookmark-o"></i> Course guides
-    </a>
-  </li>
-
 </ul>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -13,7 +13,7 @@
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             Library services<span class="caret"/>
           </a>
-          <%= render :partial => 'shared/search_navbar_top_menu' %>
+          <%= render :partial => 'shared/search_navbar_services_menu' %>
         </li>
       </ul>
       <% unless article_search? %>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -4,7 +4,7 @@
       <%= image_tag "sul-logo.svg", class: "su-logo hidden-xs", alt: "Stanford Libraries", height: 25 %>
       <%= image_tag "sul-logo-stacked.svg", class: "su-logo visible-xs", alt: "Stanford Libraries", height: 25 %>
     <% end %>
-    <%= render :partial => 'shared/search_navbar_top_menu' %>
+    <%= render :partial => 'shared/search_navbar_services_menu' %>
     <div class="header-links">
       <% if current_user %>
         <%= link_to "#{current_user.sunet}: Logout", destroy_user_session_path, class: 'first' %>


### PR DESCRIPTION
Fixes #1444 

This PR:
- updates the link content of the Library Services menu
- increases the width of the menu to 300px and adjusts submenu padding
- renames `search_navbar_top_menu` to `search_navbar_services_menu` in several files to reflect its place in the redesign

## Demo

### Before
![services-menu-before](https://user-images.githubusercontent.com/5402927/29797265-f17e2f90-8c0a-11e7-935e-e5715bf54427.png)

### After
![services-menu-after](https://user-images.githubusercontent.com/5402927/29797266-f64efc02-8c0a-11e7-808a-06a05d4a5b38.png)