### PR TITLE
Update articles to articles+ in nav and titles

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -7,7 +7,7 @@ en:
       title: 'SearchWorks catalog : Stanford Libraries'
     articles:
       home:
-        title: 'SearchWorks articles : Stanford Libraries'
+        title: 'SearchWorks articles+ : Stanford Libraries'
     search:
       facets:
         access_point:

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -12,8 +12,8 @@ en:
           default: books & media
     search_dropdown:
       articles:
-        label: articles
-        description_html: <span class="h3">articles</span> <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
+        label: articles+
+        description_html: <span class="h3">articles+</span> <span class="help-block">journal articles, e-books, and other licensed e-resources</span>
       catalog:
         label: catalog
         description_html: <span class="h3">catalog</span> <span class="help-block">books &amp; media in the Stanford Libraries' collections</span>

--- a/spec/features/article_home_page_spec.rb
+++ b/spec/features/article_home_page_spec.rb
@@ -7,7 +7,7 @@ feature 'Article Home Page' do
   end
 
   it 'has the correct title' do
-    expect(page).to have_title('SearchWorks articles : Stanford Libraries')
+    expect(page).to have_title('SearchWorks articles+ : Stanford Libraries')
   end
 
   it 'has fielded search' do

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -18,7 +18,7 @@ feature 'Article Searching' do
       end
 
       expect(page).to have_current_path(articles_path) # the landing page for Article Search
-      expect(page).to have_title('SearchWorks articles : Stanford Libraries')
+      expect(page).to have_title('SearchWorks articles+ : Stanford Libraries')
     end
 
     scenario 'does not allow selecting current search context' do
@@ -57,7 +57,7 @@ feature 'Article Searching' do
     scenario 'renders results page if search parameters are present' do
       article_search_for('Kittens')
 
-      expect(page).to have_title(/\d+ (result|results) in SearchWorks articles/)
+      expect(page).to have_title(/\d+ (result|results) in SearchWorks articles+/)
       expect(page).to have_css('h2', text: /\d+ results?/)
       expect(current_url).to match(%r{/articles\?.*&q=Kittens})
     end


### PR DESCRIPTION
Closes #1643

This PR changes "articles" to "articles+" in response to user feedback. Changes are made in the following areas:

## Search dropdown
### Before
![dropdown_before](https://user-images.githubusercontent.com/5402927/29837841-3920041a-8cae-11e7-81a4-72f5ad51c3d2.png)

### After
![dropdown_after](https://user-images.githubusercontent.com/5402927/29837850-3f9dc1a6-8cae-11e7-9dc0-3acda2a38d47.png)

## Page titles
### Before
![title_before](https://user-images.githubusercontent.com/5402927/29837848-3f5ff696-8cae-11e7-84dc-71af1c4760c5.png)

### After
![title_after](https://user-images.githubusercontent.com/5402927/29837849-3f62afe4-8cae-11e7-81c6-26f5d9ab046e.png)
