### PR TITLE
Add more search context wording to results page

### DIFF
--- a/app/assets/stylesheets/modules/constraints.scss
+++ b/app/assets/stylesheets/modules/constraints.scss
@@ -1,36 +1,42 @@
-span.constraint.btn-group {
-  margin: 0.5em;
-
-  span.constraint-value.btn {
-    border-top-left-radius: $sul-constraint-btn-radius;
-    border-bottom-left-radius: $sul-constraint-btn-radius;
-    font-size: $font-size-base;
+.constraints-container {
+  .btn-reset span {
+    text-transform: uppercase;
   }
 
-  a.btn.remove {
-    border-top-right-radius: $sul-constraint-btn-radius;
-    border-bottom-right-radius: $sul-constraint-btn-radius;
-    font-size: 12px;
-    padding-left: 4px;
-    padding-top: 8px;
-    padding-bottom: 5px;
-  }
+  span.constraint.btn-group {
+    margin: 0.5em;
 
-}
-@media (max-width: $screen-xs-max) {
-  .constraint {
-    &.query .filterValue {
-      max-width: 227px;
+    span.constraint-value.btn {
+      border-top-left-radius: $sul-constraint-btn-radius;
+      border-bottom-left-radius: $sul-constraint-btn-radius;
+      font-size: $font-size-base;
     }
-    &.filter .filterValue {
-      max-width: 150px;
+
+    a.btn.remove {
+      border-top-right-radius: $sul-constraint-btn-radius;
+      border-bottom-right-radius: $sul-constraint-btn-radius;
+      font-size: 12px;
+      padding-left: 4px;
+      padding-top: 8px;
+      padding-bottom: 5px;
     }
-    .filterValue {
-      display: inline-block;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      margin-bottom: -6px;
+
+  }
+  @media (max-width: $screen-xs-max) {
+    .constraint {
+      &.query .filterValue {
+        max-width: 227px;
+      }
+      &.filter .filterValue {
+        max-width: 150px;
+      }
+      .filterValue {
+        display: inline-block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-bottom: -6px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -116,4 +116,8 @@
     margin-bottom: 0;
   }
 
+  .rss-icon {
+    vertical-align: baseline;
+  }
+
 }

--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -98,7 +98,7 @@
 }
 
 .search_num_of_results {
-  text-align: right;
+  text-align: left;
 
   .results-heading {
     border-bottom: 1px solid $sul-h2-border-color;

--- a/app/views/articles/_constraints.html.erb
+++ b/app/views/articles/_constraints.html.erb
@@ -1,6 +1,6 @@
 <% if query_has_constraints? %>
   <div id="appliedParams" class="clearfix constraints-container">
-    <%= link_to("<i class='fa fa-fast-backward'></i> <span class='hidden-xs'>Start over</span></a>".html_safe, articles_path, class: 'btn btn-primary') %>
+    <%= link_to("<i class='fa fa-fast-backward'></i> <span class='hidden-xs'>Articles+ start</span></a>".html_safe, articles_path, class: 'btn btn-primary btn-reset') %>
     <%= render_constraints(params) %>
   </div>
 <% end %>

--- a/app/views/articles/_index.html.erb
+++ b/app/views/articles/_index.html.erb
@@ -14,15 +14,15 @@
         <div class="search_num_of_results">
           <div class='results-heading'>
             <h1 class="sr-only"><%= t('blacklight.search.zero_results.page_heading') %></h1>
-            <%= t('blacklight.search.pagination_info.no_items_found', search_type: 'articles').html_safe %>
+            <%= t('blacklight.search.pagination_info.no_items_found', search_type: 'articles+').html_safe %>
           </div>
         </div>
         <%= render "shared/zero_results" %>
       <% else %>
         <div class="search_num_of_results">
           <div class='results-heading'>
-            <h1 class="sr-only"><%= t('blacklight.search.page_heading') %></h1>
-            <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'result') %></h2>
+            <h1 class="sr-only"><%= t('blacklight.search.page_heading', search_type: 'articles+') %></h1>
+            <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'articles+ result') %></h2>
           </div>
         </div>
         <%= render 'search_header' %>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,6 +1,6 @@
 <% if query_has_constraints? %>
   <div id="appliedParams" class="clearfix constraints-container">
-    <%= link_to("<i class='fa fa-fast-backward'></i> <span class='hidden-xs'>Start over</span></a>".html_safe, root_path, class: 'btn btn-primary') %>
+    <%= link_to("<i class='fa fa-fast-backward'></i> <span class='hidden-xs'>Catalog start</span></a>".html_safe, root_path, class: 'btn btn-primary btn-reset') %>
     <%= render_constraints(params) %>
   </div>
 <% end %>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -13,7 +13,7 @@
     <h2>
       <%= t("blacklight.search.facets.access_point.#{page_location.access_point}.title",
             access_point: page_location.access_point,
-            default: 'Limit your search') %>
+            default: 'Refine your results') %>
     </h2>
   </div>
 

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -38,7 +38,7 @@
     <div class="search_num_of_results">
       <% if @response.empty? %>
         <div class='results-heading'>
-          <h1 class="sr-only"><%= t('blacklight.search.zero_results.page_heading') %></h1>
+          <h1 class="sr-only"><%= t('blacklight.search.zero_results.page_heading', search_type: 'catalog') %></h1>
           <%= t('blacklight.search.pagination_info.no_items_found', search_type: 'catalog').html_safe %>
         </div>
       <% else %>
@@ -48,7 +48,7 @@
             <i class="rss-icon" aria-hidden="true"></i>
             <span class="sr-only">RSS feed for this result</span>
           <% end %>
-          <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'result') %></h2>
+          <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'catalog result') %></h2>
         </div>
         <%= render 'search_header' %>
       <% end %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -44,11 +44,11 @@
       <% else %>
         <div class='results-heading'>
           <h1 class="sr-only"><%= t('blacklight.search.page_heading') %></h1>
+          <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'catalog result') %></h2>
           <%= link_to new_documents_feed_path do %>
             <i class="rss-icon" aria-hidden="true"></i>
             <span class="sr-only">RSS feed for this result</span>
           <% end %>
-          <h2><%= pluralize(number_with_delimiter(@response.response[:numFound]), 'catalog result') %></h2>
         </div>
         <%= render 'search_header' %>
       <% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -38,7 +38,7 @@ en:
           one: '%{start_num} - %{end_num}'
           other: '%{start_num} - %{end_num}'
         single_item_found: ''
-        no_items_found: "<h2>No results found in %{search_type}</h2>"
+        no_items_found: "<h2>No %{search_type} results found</h2>"
       entry_pagination_info:
         other: '%{current} of %{total}'
       highlight:

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -63,7 +63,7 @@ en:
           invalid: 'You must enter only valid email addresses.'
           too_many: 'You have entered more than the maximum (%{max}) email addresses allowed.'
     search:
-      page_heading: "Search results"
+      page_heading: "%{search_type} search results"
       bookmarks:
         present: "Selected"
         absent: "Select"

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -27,13 +27,13 @@ feature "Databases Access Point" do
   end
 
   scenario 'databases should be able to be prefix filtered' do
-    expect(page).to have_css('h2', text: '8 results')
+    expect(page).to have_css('h2', text: '8 catalog results')
 
     within '.database-prefix' do
       click_link 'S'
     end
 
-    expect(page).to have_css('h2', text: '4 results')
+    expect(page).to have_css('h2', text: '4 catalog results')
     expect(page).to have_css('h3', text: /Selected Database \d/, count: 4)
   end
 end

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -58,7 +58,7 @@ feature 'Article Searching' do
       article_search_for('Kittens')
 
       expect(page).to have_title(/\d+ (result|results) in SearchWorks articles+/)
-      expect(page).to have_css('h2', text: /\d+ results?/)
+      expect(page).to have_css('h2', text: /\d+ articles\+ results?/)
       expect(current_url).to match(%r{/articles\?.*&q=Kittens})
     end
   end

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -123,7 +123,7 @@ feature 'Article Searching' do
 
       expect(page).to have_css('.appliedFilter', text: /kittens/)
 
-      find('a.btn', text: /Start over/).trigger('click')
+      find('a.btn-reset').trigger('click')
       expect(page).to have_current_path(articles_path)
       expect(page).not_to have_css('.appliedFilter', text: /kittens/)
     end

--- a/spec/features/blacklight_customizations/facets_spec.rb
+++ b/spec/features/blacklight_customizations/facets_spec.rb
@@ -53,7 +53,7 @@ feature "Facets Customizations" do
     click_button 'search'
 
     within "div#facets" do
-      expect(page).to have_css("div.top-panel-heading.panel-heading h2", text: "Limit your search")
+      expect(page).to have_css("div.top-panel-heading.panel-heading h2", text: "Refine your results")
     end
   end
 

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -35,7 +35,7 @@ feature "Results Toolbar", js: true do
   scenario "pagination links for multiple items but no pages should not have any number of results info" do
     visit root_path q: '34'
 
-    expect(page).to have_css('h2', text: '4 results')
+    expect(page).to have_css('h2', text: '4 catalog results')
 
     within('.sul-toolbar .page_links') do
       expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: /Previous/)

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -48,7 +48,7 @@ describe "Search toolbar", js: true, feature: true do
         click_link "Selections"
         click_link "Clear list"
         expect(page).to have_css("div.alert.alert-success", text: "Your selections have been deleted.")
-        expect(page).to have_css("h2", text: "Limit your search")
+        expect(page).to have_css("h2", text: "Refine your results")
       end
     end
   end

--- a/spec/features/blacklight_customizations/zero_results_spec.rb
+++ b/spec/features/blacklight_customizations/zero_results_spec.rb
@@ -9,7 +9,7 @@ feature "Zero results" do
     click_button 'search'
   end
   scenario "search widgets and start over should not be present" do
-    expect(page).to_not have_css("a.catalog_startOverLink", text: "Start Over")
+    expect(page).to_not have_css("a.catalog_startOverLink", text: /Catalog start/i)
     expect(page).to_not have_css("div#search-widgets")
   end
 

--- a/spec/features/bookplates_spec.rb
+++ b/spec/features/bookplates_spec.rb
@@ -48,7 +48,7 @@ describe 'Bookplates' do
         expect(page).to have_css('.filterValue', text: 'Susan and Ruth Sharp Fund')
       end
 
-      expect(page).to have_css('h2', text: '1 result')
+      expect(page).to have_css('h2', text: '1 catalog result')
 
       visit solr_document_path('45')
 
@@ -65,7 +65,7 @@ describe 'Bookplates' do
         expect(page).to have_css('.filterValue', text: 'The Edgar Amos Boyles Centennial Book Fund')
       end
 
-      expect(page).to have_css('h2', text: '1 result')
+      expect(page).to have_css('h2', text: '1 catalog result')
     end
 
     it 'returns a gallery view search result sorted by "new to the Libraries"' do

--- a/spec/features/collections_search_spec.rb
+++ b/spec/features/collections_search_spec.rb
@@ -7,6 +7,6 @@ describe "Searching within collections" do
     fill_in 'q', with: 'abcde'
     click_button 'search'
 
-    expect(page).to have_css('h2', text: 'No results found in catalog')
+    expect(page).to have_css('h2', text: 'No catalog results found')
   end
 end

--- a/spec/features/search_num_of_results_spec.rb
+++ b/spec/features/search_num_of_results_spec.rb
@@ -5,7 +5,7 @@ feature "Search results count" do
     visit search_catalog_path f: { format: ["Book"] }
     within "#content" do
       within ".search_num_of_results" do
-        expect(page).to have_css("h2", text: /[\d,]+ results?/)
+        expect(page).to have_css("h2", text: /[\d,]+ catalog results?/)
       end
     end
   end


### PR DESCRIPTION
Closes #1600 

This PR makes several UI changes to make the current search context clearer to users.

1. 'Start over' button reflects search context
2. Change 'Limit your results' to 'Refine your results`
3. Left-align number of results; add search context to text
4. Move RSS icon to the other side of number of results; fix vertical alignment

## Catalog results
### Before
![294_results_in_searchworks_catalog](https://user-images.githubusercontent.com/5402927/29848181-f2eeb88a-8cd3-11e7-8c85-69eaeac35316.png)

### After
![294_results_in_searchworks_catalog](https://user-images.githubusercontent.com/5402927/29848146-bb729462-8cd3-11e7-8572-1b753a54d3c7.png)

## Articles+ results
### Before
![46_994_results_in_searchworks_articles](https://user-images.githubusercontent.com/5402927/29849134-a9ab5754-8cd9-11e7-9fa7-af69a75ee825.png)

### After
![46_994_results_in_searchworks_articles](https://user-images.githubusercontent.com/5402927/29848233-4b7c08c2-8cd4-11e7-9fb2-f7ba9393fc49.png)

## Catalog zero results
### Before
![0_results_in_searchworks_catalog](https://user-images.githubusercontent.com/5402927/29849193-05eda9ea-8cda-11e7-894d-d88a3cb1b1b8.png)

### After
![0_results_in_searchworks_catalog](https://user-images.githubusercontent.com/5402927/29849209-21e013cc-8cda-11e7-8d84-ddd75b596cb4.png)
