### PR TITLE
Add warning for article source type facet behavior

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -145,9 +145,8 @@ class ArticlesController < ApplicationController
 
     # Facet field configuration
     config.add_facet_field 'eds_search_limiters_facet', label: 'Options'
-    # Commenting this out temporarily until we have a better date facet option
     config.add_facet_field 'pub_year_tisim', label: 'Date', partial: 'articles/range_limit_panel'
-    config.add_facet_field 'eds_publication_type_facet', label: 'Source type'
+      config.add_facet_field 'eds_publication_type_facet', label: 'Source type', partial: "facet_eds_publication_type"
     config.add_facet_field 'eds_language_facet', label: 'Language' # , limit: 20 TODO: Need to handle facet limiting
     config.add_facet_field 'eds_subject_topic_facet', label: 'Topic'
     config.add_facet_field 'eds_subjects_geographic_facet', label: 'Geography'

--- a/app/views/articles/_facet_eds_publication_type.html.erb
+++ b/app/views/articles/_facet_eds_publication_type.html.erb
@@ -1,3 +1,9 @@
+<% if facet_field_in_params?(solr_field) %>
+  <div class="alert alert-warning" role="alert">
+    <%= t('searchworks.articles.flashes.source_type_warning_html') %>
+  </div>
+<% end %>
+
 <% # Overridden from Blacklight to use   %>
 <ul class="facet-values list-unstyled">
   <% paginator = facet_paginator(facet_field, display_facet) %>
@@ -7,5 +13,4 @@
     <% config = facet_configuration_for_field(display_facet.name) %>
     <li class="more_facets_link"><%= link_to(t('blacklight.search.facets.more_html', facet: config.label.downcase.pluralize), params.merge(:id => solr_field, :action=>"facet", :page => nil), :class => "more_facets_link") %></li>
   <% end %>
-
 </ul>

--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,4 +1,11 @@
 <% # Overridden from Blacklight to use   %>
+<% if article_search? && facet_field.key == 'eds_publication_type_facet'%>
+  <% if facet_field_in_params?('eds_publication_type_facet') %>
+    <div class="alert alert-warning" role="alert">
+      <%= t('searchworks.articles.flashes.source_type_warning_html') %>
+    </div>
+  <% end %>
+<% end %>
 <ul class="facet-values list-unstyled">
   <% paginator = facet_paginator(facet_field, display_facet) %>
   <%= render_facet_limit_list paginator, solr_field %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -2,6 +2,8 @@ en:
   searchworks:
     articles:
       flashes:
+        source_type_warning_html:
+          Additional selections in this facet will <strong>expand</strong> (rather than narrow) your search result.
         fulltext_link:
           guest_html: Sorry, the PDF download was not successful because you are currently in guest mode.<br/><a href="%{login_url}">Log in to try the download again</a>.
           non_guest_html: Sorry, the PDF download was not successful.<br/>We don't know the source of the error. Try again, and if it continues to fail, <a href=" http://library.stanford.edu/ask/email/connection-problems">please report it as a connection problem</a>.

--- a/spec/features/source_type_facet_spec.rb
+++ b/spec/features/source_type_facet_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+feature 'Source Type Facet', js: true do
+  context 'articles+ search' do
+    scenario 'shows warning message when 1 field is selected' do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+      visit articles_path f: {
+        eds_search_limiters_facet: ['Stanford has it'],
+        eds_publication_type_facet: ['Academic journals']
+      }
+      within '.panel.blacklight-eds_publication_type_facet' do
+        expect(page).to have_css('.alert-warning')
+        click_link 'remove'
+      end
+      page.find('h3.panel-title', text: 'Source type').click
+      within '.panel.blacklight-eds_publication_type_facet' do
+        expect(page).not_to have_css('.facet_limit-active')
+        expect(page).not_to have_css('.alert-warning')
+      end
+    end
+  end
+end

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -69,7 +69,8 @@ module StubArticleService
     def facet_counts
       {
         'facet_fields' => {
-          'pub_year_tisim' => ['2001', 1, '2002', 1]
+          'pub_year_tisim' => ['2001', 1, '2002', 1],
+          'eds_publication_type_facet' => ['Academic journals', 1]
         }
       }
     end


### PR DESCRIPTION
Closes #1638 

This PR adds a warning to the `Source type ` facet in article search. After one source type is selected, the user is informed that additional selections will expand (rather than narrow) search results. 

## Example
### 0 selected (2,660,418 articles+ results)
![0_selected](https://user-images.githubusercontent.com/5402927/29900924-c54aae9e-8da9-11e7-9ed8-38d0ed072dd2.png)

### 1 selected (1,099,359 articles+ results)
![1_selected](https://user-images.githubusercontent.com/5402927/29894851-cb044494-8d8b-11e7-9857-4184d9d0c49d.png)

### 2 selected (1,701,079 articles+ results)
![2_selected](https://user-images.githubusercontent.com/5402927/29894852-cb050352-8d8b-11e7-8c19-aa5d688453ab.png)

