### PR TITLE
upgrade to eds 0.3.7.pre for pagination workaround

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.3.6.pre)
+    ebsco-eds (0.3.7.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -47,6 +47,7 @@ module Eds
         eds_cache_dir:  Settings.EDS_CACHE_DIR,
         timeout:        Settings.EDS_TIMEOUT,
         open_timeout:   Settings.EDS_OPEN_TIMEOUT,
+        api_hosts_list: Settings.EDS_HOSTS,
         debug:          Settings.EDS_DEBUG,
         log:            File.join(Settings.EDS_LOGDIR, 'faraday.log')
       }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,9 @@ EDS_CACHE_DIR: /tmp
 EDS_LOGDIR: <%= Rails.root.join('log') %>
 EDS_TIMEOUT: 15
 EDS_OPEN_TIMEOUT: 5
+EDS_HOSTS:
+  - edshost1.example.com
+  - edshost2.example.com
 STANFORD_NETWORK:
   singletons: []
   ranges: []


### PR DESCRIPTION
This PR fixes #1426.

To use, you need to add the correct `EDS_HOSTS` setting to your configuration. See https://github.com/sul-dlss/shared_configs/pull/354. I've added it to `production.local.yml` on the article preview box.