### PR TITLE
add image suffixes to home page assets

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -20,21 +20,21 @@
       <div class="col-md-6">
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= image_tag('homepage/digital', class: 'pull-left', alt: "", title: "'The Burning of San Francisco April 18, 19, 20, 1906.'", data: { "no-link-href" => search_catalog_path(collections_search_params) }) %>
+            <%= image_tag('homepage/digital.svg', class: 'pull-left', alt: "", title: "'The Burning of San Francisco April 18, 19, 20, 1906.'", data: { "no-link-href" => search_catalog_path(collections_search_params) }) %>
             <h4><%= link_to "Digital collections", search_catalog_path(collections_search_params) %></h4>
             <p>Images, maps, data, &amp; more from the Stanford Digital Repository.</p>
           </div>
         </div>
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= image_tag('homepage/theses', class: 'pull-left', alt: "", title: '', data: { "no-link-href" => search_catalog_path(f: {genre_ssim: ['Thesis/Dissertation']}) } ) %>
+            <%= image_tag('homepage/theses.svg', class: 'pull-left', alt: "", title: '', data: { "no-link-href" => search_catalog_path(f: {genre_ssim: ['Thesis/Dissertation']}) } ) %>
             <h4><%= link_to "Theses & dissertations", search_catalog_path(f: {genre_ssim: ['Thesis/Dissertation']}) %></h4>
             <p>Theses &amp; dissertations in the Stanford Libraries and Digital Repository.</p>
           </div>
         </div>
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= image_tag('homepage/databases', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  selected_databases_path }) %>
+            <%= image_tag('homepage/databases.svg', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  selected_databases_path }) %>
             <h4><%= link_to "Databases", selected_databases_path %></h4>
             <p>A-Z list of topic-specific databases. Not sure where to start? Try these <%= link_to 'selected databases', selected_databases_path %>.</p>
           </div>
@@ -44,7 +44,7 @@
         <% if Settings.GOVERNMENT_DOCUMENTS_ACCESS_POINT %>
           <div class="panel panel-default">
             <div class="panel-body">
-              <%= image_tag('homepage/govdocs', class: 'pull-left', alt: '', title: '', data: { 'no-link-href' => govdocs_path} ) %>
+              <%= image_tag('homepage/govdocs.svg', class: 'pull-left', alt: '', title: '', data: { 'no-link-href' => govdocs_path} ) %>
               <h4><%= link_to 'Government documents', govdocs_path %></h4>
               <p>Stanford is a depository library for state, federal, UN, and EU government documents.</p>
             </div>
@@ -52,7 +52,7 @@
         <% end %>
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= image_tag('homepage/coursereserves', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  course_reserves_path }) %>
+            <%= image_tag('homepage/coursereserves.svg', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  course_reserves_path }) %>
             <h4><%= link_to "Course reserves", course_reserves_path %></h4>
             <p>Find books, media, and e-resources set aside for classes.</p>
           </div>

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -4,7 +4,7 @@
     <div class="col-md-3 home-page-catalog <%= 'home-page-you-are-here' unless article_search? %>">
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= image_tag 'homepage/catalog' %>
+          <%= image_tag 'homepage/catalog.png' %>
           <h4><%= link_to 'Catalog', root_path %></h4>
           <p>Search the physical collections and digital resources of Stanford’s libraries. Find books, media, <%= link_to 'topic-specific databases', databases_path %>.</p>
         </div>
@@ -13,7 +13,7 @@
     <div class="col-md-3 home-page-articles <%= 'home-page-you-are-here' if article_search? %>">
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= image_tag 'homepage/articles' %>
+          <%= image_tag 'homepage/articles.png' %>
           <h4>Articles+</h4>
           <p>Search a combined index of 100s of databases, and connect directly to the article or resource. Covers ~87% of our subscribed databases.</p>
         </div>
@@ -22,7 +22,7 @@
     <div class="col-md-3 home-page-website">
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= image_tag 'homepage/website' %>
+          <%= image_tag 'homepage/website.png' %>
           <h4><%= link_to 'Library website', 'https://library.stanford.edu/search' %></h4>
           <p>Find topic specialists, blog posts, descriptions of our notable collections, as well as libraries, hours, and policies.</p>
         </div>
@@ -31,7 +31,7 @@
     <div class="col-md-3 home-page-yewno">
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= image_tag 'homepage/yewno' %>
+          <%= image_tag 'homepage/yewno.png' %>
           <h4><%= link_to 'Yewno', 'https://yewno.com/edu' %></h4>
           <p>Explore concepts and connections, and understand interdisciplinary subjects, in a graph interface.</p>
         </div>
@@ -53,7 +53,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <div class="col-md-1 home-page-search-tools">
-            <%= image_tag 'homepage/search' %>
+            <%= image_tag 'homepage/search.svg' %>
           </div>
           <div class="col-md-11">
             <h4><%= link_to 'More search tools', 'https://library.stanford.edu/search-services' %></h4>


### PR DESCRIPTION
This PR changes the `image_tag` on the home pages to be explicit about the image format for the asset pipeline to hopefully fix a problem where rails isn't finding the asset in RAILS_ENV=production