### PR TITLE
Adds  implementation of an article sms and bitly + shortning!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Rails:
 Metrics/LineLength:
   Max: 120
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: single_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,4 @@ gem 'rubocop', '~> 0.36'
 
 gem 'ebsco-eds'
 gem 'whenever' # manages cron jobs
+gem 'bitly' # For bit.ly

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
     bibtex-ruby (4.4.4)
       latex-decode (~> 0.0)
     bindex (0.5.0)
+    bitly (1.1.0)
+      httparty (>= 0.7.6)
+      multi_json (~> 1.3)
+      oauth2 (>= 0.5.0, < 2.0)
     blacklight (6.10.1)
       bootstrap-sass (~> 3.2)
       deprecation
@@ -206,6 +210,9 @@ GEM
       activesupport (>= 4.2.0)
     hashie (3.5.5)
     honeybadger (3.1.2)
+    httparty (0.15.6)
+      multi_xml (>= 0.5.2)
+    httpauth (0.2.1)
     httpclient (2.8.3)
     i18n (0.8.6)
     iso-639 (0.2.8)
@@ -275,6 +282,7 @@ GEM
       i18n
       stanford-mods (~> 2.1)
     multi_json (1.12.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     mysql2 (0.4.6)
     namae (0.11.3)
@@ -290,6 +298,10 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
+    oauth2 (0.6.1)
+      faraday (~> 0.7)
+      httpauth (~> 0.1)
+      multi_json (~> 1.3)
     okcomputer (1.16.0)
     openseadragon (0.3.3)
       rails (> 3.2.0)
@@ -476,6 +488,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bitly
   blacklight (~> 6.0)
   blacklight-gallery (~> 0.4)
   blacklight-hierarchy (~> 1.0)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -234,7 +234,7 @@ class ArticlesController < ApplicationController
       guest:          session['eds_guest'],
       session_token:  session['eds_session_token']
     }
-    Eds::SearchService.new(blacklight_config, eds_params)
+    Eds::SearchService.new(blacklight_config, {}, eds_params)
   end
 
   def set_search_query_modifier

--- a/app/models/concerns/eds_document.rb
+++ b/app/models/concerns/eds_document.rb
@@ -12,4 +12,8 @@ module EdsDocument
     # TODO: we probably need a better way to determine this
     self['eds_title'] =~ ::SolrDocument::EDS_RESTRICTED_PATTERN
   end
+
+  def eds?
+    self[:eds_title].present?
+  end
 end

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -17,7 +17,8 @@ module Eds
     def eds_search(search_builder = {}, eds_params = {})
       eds_session = Eds::Session.new(eds_params.update(caller: 'bl-search'))
       bl_params = search_builder.to_hash
-      if bl_params && bl_params['q'] && bl_params['q']['id']
+
+      if bl_params.try(:dig, 'q').try(:dig, 'id')
         # List of ID's
         results = eds_session.solr_retrieve_list(list: bl_params['q']['id'])
       else

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -17,7 +17,13 @@ module Eds
     def eds_search(search_builder = {}, eds_params = {})
       eds_session = Eds::Session.new(eds_params.update(caller: 'bl-search'))
       bl_params = search_builder.to_hash
-      results = eds_session.search(bl_params).to_solr
+      if bl_params && bl_params['q'] && bl_params['q']['id']
+        # List of ID's
+        results = eds_session.solr_retrieve_list(list: bl_params['q']['id'])
+      else
+        # Regular search
+        results = eds_session.search(bl_params).to_solr
+      end
       blacklight_config.response_model.new(results,
                                            bl_params,
                                            document_model: blacklight_config.document_model,

--- a/app/models/eds/session.rb
+++ b/app/models/eds/session.rb
@@ -4,7 +4,7 @@ module Eds
   # We are wrapping this class so that we can easily instantiate a session object
   # without having to pass in all the session options every time (which is very versbose).
   class Session
-    delegate :info, :retrieve, :search, :session_token, to: :object
+    delegate :info, :retrieve, :search, :session_token, :solr_retrieve_list, to: :object
     def initialize(eds_params)
       @eds_params = eds_params
     end

--- a/app/presenters/sms_presenter.rb
+++ b/app/presenters/sms_presenter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+##
+# For cleaning up nicely presented sms messages
+class SmsPresenter
+  include ActionView::Helpers
+
+  attr_reader :document, :url
+
+  SMS_LENGTH = 160
+
+  def initialize(document, url)
+    @document = document
+    @url = url
+  end
+
+  def sms_content
+    "#{sms_text}\n#{short_url}"
+  end
+
+  private
+
+  def sms_text
+    truncate(document.to_sms_text, length: text_length)
+  end
+
+  def text_length
+    SMS_LENGTH - short_url.length - 4
+  end
+
+  ##
+  # If the Bit.ly call fails, fallback to the URL
+  # @return [String]
+  def short_url
+    @short_url ||= Bitly.client.shorten(url).short_url
+  rescue => e
+    Rails.logger.warn("Could not shorten bit.ly url #{e.message}")
+    url
+  end
+end

--- a/app/services/eds/search_service.rb
+++ b/app/services/eds/search_service.rb
@@ -5,13 +5,14 @@ module Eds
   class SearchService
     include Blacklight::RequestBuilders
 
-    def initialize(blacklight_config, eds_params = {})
+    def initialize(blacklight_config, user_params = {}, eds_params = {})
       @blacklight_config = blacklight_config
+      @user_params = user_params
       @repository = @blacklight_config.repository_class.new(@blacklight_config)
       @eds_params = eds_params
     end
 
-    attr_reader :blacklight_config # used by search_builder
+    attr_reader :blacklight_config, :user_params # used by search_builder
 
     def search_results(user_params)
       builder = search_builder.with(user_params)
@@ -24,10 +25,34 @@ module Eds
     # @param [Array{#to_s},#to_s] id
     # @return [Blacklight::Solr::Response, Blacklight::SolrDocument] the solr response object and the first document
     def fetch(id = nil, extra_controller_params = {})
-      raise NotImplementedError if id.is_a? Array
-      fetch_one(id, extra_controller_params)
+      if id.is_a? Array
+        fetch_many(id, extra_controller_params)
+      else
+        fetch_one(id, extra_controller_params)
+      end
     end
 
+    ##
+    # Retrieve a set of documents by id
+    # @param [Array] ids
+    # @param [HashWithIndifferentAccess] extra_controller_params
+    def fetch_many(ids, extra_controller_params)
+      extra_controller_params ||= {}
+
+      query = search_builder
+              .with(user_params)
+              .where(blacklight_config.document_model.unique_key => ids)
+              .merge(extra_controller_params)
+              .merge(fl: '*')
+      solr_response = @repository.search(query, @eds_params)
+
+      [solr_response, solr_response.documents]
+    end
+
+    ##
+    # Retrieve a single document
+    # @param [String] id
+    # @param [HashWithIndifferentAccess] extra_controller_params
     def fetch_one(id, extra_controller_params)
       solr_response = @repository.find id, extra_controller_params, @eds_params
       [solr_response, solr_response.documents.first]

--- a/app/views/record_mailer/sms_record.text.erb
+++ b/app/views/record_mailer/sms_record.text.erb
@@ -1,0 +1,4 @@
+<% # Overridden from Blacklight to create Bit.ly urls %>
+<% @documents.each do |document| %>
+<%= SmsPresenter.new(document, polymorphic_url(document, @url_gen_params)).sms_content %>  
+<% end %>

--- a/app/views/search_works_record_mailer/article_email_record.html.erb
+++ b/app/views/search_works_record_mailer/article_email_record.html.erb
@@ -11,7 +11,7 @@
     <ol>
       <% @documents.each do |document| %>
         <li>
-          <strong><a href="<%= article_url(document, {:only_path => false}.merge(@url_gen_params)) %>"><%= document[:eds_title] if document[:eds_title].present? %></a></strong>
+          <strong><a href="<%= article_url(document, {:only_path => false}.merge(@url_gen_params)) %>"><%= document[:eds_title] if document.eds? %></a></strong>
           <div><%= document[:eds_authors].to_sentence if document[:eds_authors].present? %></div>
           <div><%= document[:eds_composed_title].html_safe  if document[:eds_composed_title].present? %></div>
           <% if document.eds_links.present? %>

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -1,6 +1,6 @@
 <% if @document.respond_to?( :to_sms_text ) %>
   <li class="sms" role="presentation">
-    <% if @document[:eds_title].present? %>
+    <% if @document.eds? %>
       <%= link_to t('blacklight.tools.sms_html'), sms_articles_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
     <% else %>
       <%= link_to t('blacklight.tools.sms_html'), sms_solr_document_path(:id => @document), {:id => 'smsLink', :data => {:ajax_modal => "trigger"}} %>
@@ -9,7 +9,7 @@
 <% end %>
 <% if @document.respond_to?( :to_email_text ) %>
   <li class="email" role="presentation">
-    <% if @document[:eds_title].present? %>
+    <% if @document.eds? %>
       <%= link_to t('blacklight.tools.email_html'), email_articles_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
     <% else %>
       <%= link_to t('blacklight.tools.email_html'), email_solr_document_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -1,6 +1,10 @@
 <% if @document.respond_to?( :to_sms_text ) %>
   <li class="sms" role="presentation">
-    <%= link_to t('blacklight.tools.sms_html'), sms_solr_document_path(:id => @document), {:id => 'smsLink', :data => {:ajax_modal => "trigger"}} %>
+    <% if @document[:eds_title].present? %>
+      <%= link_to t('blacklight.tools.sms_html'), sms_articles_path(:id => @document), {:id => 'emailLink', :data => {:ajax_modal => "trigger"}} %>
+    <% else %>
+      <%= link_to t('blacklight.tools.sms_html'), sms_solr_document_path(:id => @document), {:id => 'smsLink', :data => {:ajax_modal => "trigger"}} %>
+    <% end %>
   </li>
 <% end %>
 <% if @document.respond_to?( :to_email_text ) %>

--- a/config/initializers/bitly.rb
+++ b/config/initializers/bitly.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Bitly.use_api_version_3
+
+Bitly.configure do |config|
+  config.api_version = 3
+  config.access_token = Settings.BITLY.ACCESS_TOKEN
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,3 +45,5 @@ EDS_HOSTS:
 STANFORD_NETWORK:
   singletons: []
   ranges: []
+BITLY:
+  ACCESS_TOKEN: 'the_bitly_apikey'

--- a/spec/lib/sms_spec.rb
+++ b/spec/lib/sms_spec.rb
@@ -10,6 +10,11 @@ describe "Searchworks::Document::Sms" do
       ]
     )
   }
+  let(:eds_doc) do
+    SolrDocument.new(
+      eds_title: 'holla back'
+    )
+  end
 
   before(:all) do
     SolrDocument.use_extension(Searchworks::Document::Sms)
@@ -20,6 +25,12 @@ describe "Searchworks::Document::Sms" do
     expect(sms_text).to match(/callnumber2/)
     expect(sms_text).to match(/Green Library - Stacks/)
     expect(sms_text).to_not match(/Biology Library (Falconer) - Stacks/)
+  end
+
+  context 'eds document' do
+    it 'should use the eds title' do
+      expect(eds_doc.to_sms_text).to eq 'holla back'
+    end
   end
 
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -123,8 +123,14 @@ describe SolrDocument do
   end
 
   describe 'EdsDocument' do
+    let(:eds) { SolrDocument.new(eds_title: 'yup') }
+    let(:non_eds) { SolrDocument.new }
     it 'is included' do
       expect(subject).to be_kind_of EdsDocument
+    end
+    it 'eds?' do
+      expect(eds.eds?).to eq true
+      expect(non_eds.eds?).to eq false
     end
   end
 end

--- a/spec/presenters/sms_presenter_spec.rb
+++ b/spec/presenters/sms_presenter_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SmsPresenter do
+  describe '#sms_content' do
+    let(:doc) { SolrDocument.new(eds_title: 'a' * 50) }
+    let(:url) { 'http://www.example.com/really_great' }
+    subject { described_class.new(doc, url) }
+    let(:bitly) { double(short_url: 'http://bit.ly/2evYAOW') }
+    before do
+      allow_any_instance_of(Bitly::V3::Client).to receive(:shorten).and_return(bitly)
+    end
+    context 'with a really long title' do
+      let(:doc) { SolrDocument.new(eds_title: 'a' * 170) }
+      it { expect(subject.sms_content.length).to be < 160 }
+    end
+    context 'when bitly returns ok' do
+      it 'uses bitly shortened url' do
+        expect(subject.sms_content).to include 'http://bit.ly/2evYAOW'
+      end
+    end
+    context 'when something bad happens to bitly' do
+      it 'returns original url' do
+        allow_any_instance_of(Bitly::V3::Client).to receive(:shorten).and_raise(StandardError)
+        expect(subject.sms_content).to include 'http://www.example.com/really_great'
+      end
+    end
+  end
+end

--- a/spec/services/eds/search_service_spec.rb
+++ b/spec/services/eds/search_service_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Eds::SearchService do
+  let(:document_model) { double(unique_key: :id) }
   let(:blacklight_config) {
     instance_double(
       Blacklight::Configuration,
       repository_class: Eds::Repository,
-      search_builder_class: Blacklight::SearchBuilder
+      search_builder_class: Blacklight::SearchBuilder,
+      document_model: document_model
     )
   }
   subject(:instance) { described_class.new(blacklight_config) }
@@ -23,10 +25,34 @@ RSpec.describe Eds::SearchService do
     expect(results[1]).to eq StubArticleService::SAMPLE_RESULTS
   end
 
-  it '#fetch' do
+  describe '#fetch' do
+    context 'with a single id' do
+      it 'returns a single result' do
+        results = instance.fetch('a')
+        expect(results[1].id).to eq StubArticleService::SAMPLE_RESULTS.first.id
+        expect(results[1]).to be_an SolrDocument
+      end
+    end
+    context 'with multiple ids' do
+      it 'returns a single result' do
+        results = instance.fetch(%w[a b])
+        expect(results[1].count).to eq StubArticleService::SAMPLE_RESULTS.count
+        expect(results[1]).to be_an Array
+      end
+    end
+  end
+
+  it '#fetch_one' do
     results = instance.fetch(StubArticleService::SAMPLE_RESULTS.first.id)
     expect(results.length).to eq 2
     expect(results[0]).to be_an(Blacklight::Solr::Response)
     expect(results[1].id).to eq StubArticleService::SAMPLE_RESULTS.first.id
+  end
+
+  it '#fetch_many' do
+    results = instance.fetch_many(StubArticleService::SAMPLE_RESULTS.map(&:id), {})
+    expect(results.length).to eq 2
+    expect(results[0]).to be_an(Blacklight::Solr::Response)
+    expect(results[1].count).to eq StubArticleService::SAMPLE_RESULTS.count
   end
 end


### PR DESCRIPTION
Originally outlined in: #1641 , closes #1641 

Previously an article sms was blank. Now:

```
Forasmuch as there have been many disputes and controversies for a long time, concerning the titles to a great part of the lands in ...
http://bit.ly/2wpCGmG 
```

And for Stanford urls (deployed apps) it will get the stanford custom domain.

One a new 6.x version of Blacklight is released with https://github.com/projectblacklight/blacklight/pull/1771/commits/bb6ba0f2ca42dbf08bc8817b424092b7cb7f3678 we can remove our implementation of `to_semantic_values`