### PR TITLE
add missing Articles+ link on home page

### DIFF
--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -14,7 +14,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/articles.png' %>
-          <h4>Articles+</h4>
+          <h4><%= link_to 'Articles+', articles_path %></h4>
           <p>Search a combined index of 100s of databases, and connect directly to the article or resource. Covers ~87% of our subscribed databases.</p>
         </div>
       </div>


### PR DESCRIPTION
This PR is connected to #1676 and adds a missing `Articles+` link.