### PR TITLE
remove s/_/./ on the accession identifiers and permit any non-/ character as part of the id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     docile (1.1.5)
     dot-properties (0.1.3)
     dotenv (2.2.1)
-    ebsco-eds (0.3.7.pre)
+    ebsco-eds (0.3.8.pre)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -26,7 +26,7 @@ module Eds
 
     def eds_find(id, params, eds_params)
       dbid = id.split('__', 2).first
-      accession = id.split('__', 2).last.tr('_', '.')
+      accession = id.split('__', 2).last
       eds_session = Eds::Session.new(eds_params.update(caller: 'bl-repo-find'))
       record = eds_session.retrieve(dbid: dbid, an: accession)
       blacklight_config.response_model.new(record.to_solr,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
       concerns :exportable
     end
 
-    post 'articles/:id/track' => 'articles#track', as: :track_article
+    post 'articles/:id/track' => 'articles#track', as: :track_articles
     get 'articles/:id/:type/fulltext' => 'articles#fulltext_link', as: :article_fulltext_link, constraints: { type: /[-\w]+/ }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
 
   resources :course_reserves, only: :index, path: "reserves"
 
-  constraints(id: /[-~\+\(\)\.\|,:;%\w]+/) do # EDS identifier rules (e.g., db__id)
+  constraints(id: /[^\/]+/) do # EDS identifier rules (e.g., db__acid) where acid has all sorts of different punctuation
     resources :articles, only: %i[index show] do
       concerns :exportable
     end

--- a/spec/controllers/concerns/eds_paging_spec.rb
+++ b/spec/controllers/concerns/eds_paging_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe EdsPaging do
       expect(@docs.first).to be_truthy
       expect(@docs.first['id']).to eq 'abc123'
       expect(@docs.last).to be_truthy
-      expect(@docs.last['id']).to eq 'wqoeif'
+      expect(@docs.last['id']).to eq 'wqoeif.zzz'
     end
 
     context 'last hit' do
@@ -172,7 +172,7 @@ RSpec.describe EdsPaging do
 
       it 'grabs the penultimate hit for the previous doc but no next doc' do
         expect(@docs.first).to be_truthy
-        expect(@docs.first['id']).to eq 'wqoeif'
+        expect(@docs.first['id']).to eq 'wqoeif.zzz'
         expect(@docs.last).to be_nil
       end
     end

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -19,7 +19,7 @@ module StubArticleService
       }]
     ),
     SolrDocument.new(
-      id: 'wqoeif',
+      id: 'wqoeif.zzz',
       eds_title: 'Yet another title for the document',
       eds_fulltext_links: [{
         'label' => 'View request options',


### PR DESCRIPTION
This PR fixes #1603. We've changed the EDS gem such that it passes the accession id verbatim rather than doing `s/_/./` substitutions on it (which mangle the id in some cases, hence the errors in #1603). 

Since the id's constraints have changed, I discovered that our tracking URL was pointing to `/catalog/xxx/track` rather than `/articles/xxx/track` so I've fixed the named route.

I've also added a `.zzz` to one of the identifiers in the EDS spec stubs so we have punctuation in at least one of the stub hits -- the EDS document ids can have all sorts of punctuation in them -- see https://github.com/sul-dlss/SearchWorks/blob/1603-delimiters/spec/routing/article_routes_spec.rb#L13
