### PR TITLE
remove panel-heading for right-hand panels on articles+ homepage

### DIFF
--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -38,10 +38,8 @@
     </div>
     <div class="col-md-8 home-page-tips">
       <div class="panel panel-default">
-        <div class="panel-heading">
-          <h2>How do I access articles?</h2>
-        </div>
         <div class="panel-body">
+          <h2>How do I access articles?</h2>
           <div class="row">
             <div class="col-md-6">
               <h4>On campus</h4>
@@ -56,10 +54,8 @@
         </div>
       </div>
       <div class="panel panel-default">
-        <div class="panel-heading">
-          <h2>Search tip</h2>
-        </div>
         <div class="panel-body">
+          <h2>Search tip</h2>
           <h4><%= t("searchworks.articles.search_tips.heading") %></h4>
           <p><%= t("searchworks.articles.search_tips.body") %></p>
           <p class="text-right"><%= link_to 'More article search tips', 'https://library.stanford.edu/guides/article-search-tips' %></p>


### PR DESCRIPTION
This PR fixes #1684.

### Before
![screen shot 2017-09-01 at 2 58 49 pm](https://user-images.githubusercontent.com/1861171/29989189-4c0ea6c4-8f26-11e7-82c2-fee2425f9ba6.png)


### After

![screen shot 2017-09-01 at 2 58 27 pm](https://user-images.githubusercontent.com/1861171/29989185-4959d520-8f26-11e7-9c67-cb0817373ffa.png)
