### PR TITLE
Link Catalog and Articles section of home pages only when not in…

### DIFF
--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -5,7 +5,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/catalog.png' %>
-          <h4><%= link_to 'Catalog', root_path %></h4>
+          <h4><%= link_to_unless controller_name == 'catalog', 'Catalog', root_path %></h4>
           <p>Search the physical collections and digital resources of Stanford’s libraries. Find books, media, <%= link_to 'topic-specific databases', databases_path %>.</p>
         </div>
       </div>
@@ -14,7 +14,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/articles.png' %>
-          <h4><%= link_to 'Articles+', articles_path %></h4>
+          <h4><%= link_to_unless article_search?, 'Articles+', articles_path %></h4>
           <p>Search a combined index of 100s of databases, and connect directly to the article or resource. Covers ~87% of our subscribed databases.</p>
         </div>
       </div>

--- a/spec/views/shared/_home_page_bento.html.erb_spec.rb
+++ b/spec/views/shared/_home_page_bento.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'shared/_home_page_bento.html.erb' do
+  context 'catalog controller' do
+    before { expect(view).to receive(:controller_name).at_least(:once).and_return('catalog') }
+
+    it 'links the "Articles+" section' do
+      render
+      expect(rendered).to have_css('h4 a', text: 'Articles+')
+    end
+
+    it 'does not link the "Catalog" section' do
+      render
+      expect(rendered).to have_css('h4', text: 'Catalog')
+      expect(rendered).not_to have_css('h4 a', text: 'Catalog')
+    end
+  end
+
+  context 'articles controller' do
+    before { expect(view).to receive(:controller_name).at_least(:once).and_return('articles') }
+
+    it 'links the "Catalog" section' do
+      render
+      expect(rendered).to have_css('h4 a', text: 'Catalog')
+    end
+
+    it 'does not link the "Articles+" section' do
+      render
+      expect(rendered).to have_css('h4', text: 'Articles+')
+      expect(rendered).not_to have_css('h4 a', text: 'Articles+')
+    end
+  end
+end


### PR DESCRIPTION
…their own context.

Closes #1680 

## Catalog Home Page
<img width="1201" alt="catalog-home" src="https://user-images.githubusercontent.com/96776/29990416-2ddfd688-8f2f-11e7-9ee7-bb7497946738.png">

## Articles Home Page
<img width="1181" alt="articles-home" src="https://user-images.githubusercontent.com/96776/29990415-2ddfb072-8f2f-11e7-9d03-0350297c45f2.png">
