### PR TITLE
[WIP] fix punctuation in subject linking

### DIFF
--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -15,7 +15,7 @@ module ArticleHelper
     separators = options.dig(:config, :separator_options) || {}
     values = render_text_from_html(options[:value])
     values.collect do |value|
-      link_to value, articles_path(q: "\"#{value}\"", search_field: :subject)
+      link_to value.html_safe, articles_path(q: "\"#{CGI.unescapeHTML(value)}\"", search_field: :subject)
     end.to_sentence(separators).html_safe # this is what Blacklight's Join step does
   end
 

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe ArticleHelper do
       expect(result).to have_link 'ABC', href: /\?q=%22ABC%22&search_field=subject/
       expect(result).to have_link '123', href: /\?q=%22123%22&search_field=subject/
     end
+
+    it 'properly handles HTML entities' do
+      result = Capybara.string(helper.link_subjects(value: %w[ABC\ &amp;\ 123]))
+      expect(result).to have_link 'ABC & 123', href: /\?q=%22ABC\+%26\+123%22&search_field=subject/
+    end
   end
 
   context 'authors' do


### PR DESCRIPTION
This PR is connected to #1664. It changes the `link_subjects` helper method to handle HTML entities for punctuation, etc.

Marked **WIP** since we're looking to make the subject linking more robust using the searchLink markup from EDS.