### PR TITLE
Add an after_sign_out_path to redirect users to Shib's logout page …

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def after_sign_out_path_for(*)
+    '/Shibboleth.sso/Logout'
+  end
+
   def on_campus_or_su_affiliated_user?
     IPRange.includes?(request.remote_ip) || current_user.present?
   end


### PR DESCRIPTION
…after destroying the devise session.