### PR TITLE
Updates to SFX panel 

### DIFF
--- a/app/assets/stylesheets/modules/sfx-panel.scss
+++ b/app/assets/stylesheets/modules/sfx-panel.scss
@@ -1,0 +1,6 @@
+.sfx-panel {
+  .sfx-emphasis {
+    color: $cardinal-red;
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -56,6 +56,7 @@
 @import 'modules/research-starter';
 @import 'modules/results-documents';
 @import 'modules/search-bar';
+@import 'modules/sfx-panel';
 @import 'modules/spinner';
 @import 'modules/subnavbar';
 @import 'modules/selected-databases';

--- a/app/models/sfx_data.rb
+++ b/app/models/sfx_data.rb
@@ -16,7 +16,7 @@ class SfxData
   def targets
     return [] unless sfx_xml
     @targets ||= sfx_xml.xpath('//target').map do |t|
-      next unless t.xpath('./service_type').try(:text) == FULL_TEXT_SERVICE_TYPE
+      next unless target_xml_is_fulltext?(t)
 
       Target.new(t)
     end.compact
@@ -25,6 +25,11 @@ class SfxData
   private
 
   attr_reader :base_sfx_url
+
+  def target_xml_is_fulltext?(target_xml)
+    target_xml.xpath('./service_type').try(:text) == FULL_TEXT_SERVICE_TYPE &&
+      target_xml.xpath('./is_related').try(:text) == 'no'
+  end
 
   def sfx_xml
     return unless sfx_response.success?

--- a/app/models/sfx_data.rb
+++ b/app/models/sfx_data.rb
@@ -22,6 +22,17 @@ class SfxData
     end.compact
   end
 
+  class << self
+    def url_without_sid(sfx_url)
+      uri = Addressable::URI.parse(sfx_url)
+      params = uri.query_values
+      params.delete('sid') if params.present?
+      uri.query_values = params
+
+      uri.to_s
+    end
+  end
+
   private
 
   attr_reader :base_sfx_url

--- a/app/views/articles/access_panels/_sfx.html.erb
+++ b/app/views/articles/access_panels/_sfx.html.erb
@@ -1,10 +1,17 @@
-<div class="panel panel-default access-panel panel-online" data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: CGI.escape(document.access_panels.sfx.links.first.href)) %>">
+<% sfx_url = document.access_panels.sfx.links.first.href %>
+<div class="panel panel-default access-panel panel-online sfx-panel" data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: CGI.escape(sfx_url)) %>">
   <div class="access-panel-heading panel-heading">
     <h3>
       All available sources
     </h3>
   </div>
-  <div class="panel-body" data-behavior="sfx-panel-body">
-    <div class='loading-spinner'></div>
+  <div class="panel-body">
+    <div data-behavior="sfx-panel-body">
+      <div class='loading-spinner'></div>
+    </div>
+
+    <%= link_to(SfxData.url_without_sid(sfx_url)) do %>
+      See the full <span class='sfx-emphasis'>find it @ Stanford</span> menu
+    <% end %>
   </div>
 </div>

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -104,6 +104,7 @@ feature 'Article Record Display' do
                   <service_type>getFullTxt</service_type>
                   <target_public_name>TargetName</target_public_name>
                   <target_url>http://example.com</target_url>
+                  <is_related>no</is_related>
                   <coverage>
                     <coverage_statement>Statement 1</coverage_statement>
                     <coverage_statement>Statement 2</coverage_statement>

--- a/spec/models/sfx_data_spec.rb
+++ b/spec/models/sfx_data_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SfxData do
-  let(:sfx_url) { 'http://sul-sfx.stanford.edu/sfx?thing=thing&other_thing=this_other_thing' }
+  let(:sfx_url) { 'http://sul-sfx.stanford.edu/sfx?thing=thing&other_thing=this_other_thing&sid=the_sid_of_the_url' }
 
   let(:sfx_xml) do
     Nokogiri::XML.parse(
@@ -25,7 +25,16 @@ describe SfxData do
   subject(:sfx_data) { described_class.new(sfx_url) }
 
   before do
-    expect(sfx_data).to receive(:sfx_xml).at_least(:once).and_return(sfx_xml)
+    allow(sfx_data).to receive(:sfx_xml).at_least(:once).and_return(sfx_xml)
+  end
+
+  describe '#url_without_sid' do
+    it 'removes the "sid" param from the URL and returns the rest' do
+      new_url = described_class.url_without_sid(sfx_url)
+      expect(sfx_url).to include 'sid=the_sid_of_the_url'
+      expect(new_url).not_to include 'sid=the_sid_of_the_url'
+      expect(new_url).to include 'http://sul-sfx.stanford.edu'
+    end
   end
 
   describe '#targets' do

--- a/spec/models/sfx_data_spec.rb
+++ b/spec/models/sfx_data_spec.rb
@@ -9,6 +9,7 @@ describe SfxData do
         <root>
           <target>
             <service_type>getFullTxt</service_type>
+            <is_related>no</is_related>
             <target_public_name>TargetName</target_public_name>
             <target_url>http://example.com</target_url>
             <coverage>
@@ -49,6 +50,7 @@ describe SfxData do
             <root>
               <target>
                 <service_type>notFullTxt</service_type>
+                <is_related>no</is_related>
                 <target_public_name>TargetName</target_public_name>
                 <target_url>http://example.com</target_url>
               </target>
@@ -60,6 +62,27 @@ describe SfxData do
       it 'is not returned' do
         expect(sfx_data.targets).to eq([])
       end
+    end
+  end
+
+  context 'when the target is related full-text' do
+    let(:sfx_xml) do
+      Nokogiri::XML.parse(
+        <<-XML
+          <root>
+            <target>
+              <service_type>getFullTxt</service_type>
+              <is_related>remote</is_related>
+              <target_public_name>TargetName</target_public_name>
+              <target_url>http://example.com</target_url>
+            </target>
+          </root>
+        XML
+      )
+    end
+
+    it 'is not returned' do
+      expect(sfx_data.targets).to eq([])
     end
   end
 


### PR DESCRIPTION
Closes #1614 

* Only selects SFX items where the `is_related` is `no`.
* Generates a link to the full sfx menu for the item.

## edsgao__edsgcl 459339678 (before)
<img width="396" alt="edsgao__edsgcl 459339678-before" src="https://user-images.githubusercontent.com/96776/30089219-5bc8862e-9260-11e7-9200-9c558184a358.png">

## edsgao__edsgcl 459339678 (after)
<img width="393" alt="edsgao__edsgcl 459339678-after" src="https://user-images.githubusercontent.com/96776/30089221-5de62e52-9260-11e7-8a91-834d975bc4e5.png">
