### PR TITLE
Display a login link instead of a fulltext section toggle for users …

### DIFF
--- a/app/views/articles/record/_html_fulltext.erb
+++ b/app/views/articles/record/_html_fulltext.erb
@@ -1,13 +1,21 @@
 <% doc_presenter = presenter(document) -%>
-<button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="true" aria-controls="toggleFulltext">
-  <h2>Hide full text <i class='fa fa-chevron-down'></i></h2>
-</button>
-<div class='section-body collapse in' id="toggleFulltext">
-  <% fields.each do |field_name| -%>
-    <% field_name = field_name.to_s -%>
-    <% value = doc_presenter.field_value field_name -%>
-    <% if value.present? %>
-      <div class="blacklight-<%= field_name.parameterize %>"><%= value %></div>
+<% if on_campus_or_su_affiliated_user? %>
+  <button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="true" aria-controls="toggleFulltext">
+    <h2>Hide full text <i class='fa fa-chevron-down'></i></h2>
+  </button>
+  <div class='section-body collapse in' id="toggleFulltext">
+    <% fields.each do |field_name| -%>
+      <% field_name = field_name.to_s -%>
+      <% value = doc_presenter.field_value field_name -%>
+      <% if value.present? %>
+        <div class="blacklight-<%= field_name.parameterize %>"><%= value %></div>
+      <% end -%>
     <% end -%>
-  <% end -%>
-</div>
+  </div>
+<% else %>
+  <div class='section-container-heading fulltext-toggle-bar'>
+    <%= link_to(new_user_session_path(referrer: request.original_url)) do %>
+      <h2>Log in to show fulltext <i class='fa fa-chevron-right'></i></h2>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -23,24 +23,38 @@ feature 'Article Record Display' do
       SolrDocument.new(id: '123', eds_html_fulltext_available: true, eds_html_fulltext: '<anid>09dfa;</anid><p>This Journal</p>, 10(1)')
     end
 
-    it 'toggled via panel heading' do
-      visit article_path(document[:id])
-      expect(page).to have_css('.fulltext-toggle-bar', text: 'Hide full text')
-      expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
-      expect(page).to have_content('This Journal')
+    context 'when a user has access' do
+      before { stub_current_user }
 
-      find('#fulltextToggleBar').click
-      expect(page).to have_css('.fulltext-toggle-bar', text: 'Show full text')
-      expect(page).not_to have_css('div.blacklight-eds_html_fulltext', visible: true)
-      expect(page).not_to have_content('This Journal')
+      it 'toggled via panel heading' do
+        visit article_path(document[:id])
+        expect(page).to have_css('.fulltext-toggle-bar', text: 'Hide full text')
+        expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
+        expect(page).to have_content('This Journal')
+
+        find('#fulltextToggleBar').click
+        expect(page).to have_css('.fulltext-toggle-bar', text: 'Show full text')
+        expect(page).not_to have_css('div.blacklight-eds_html_fulltext', visible: true)
+        expect(page).not_to have_content('This Journal')
+      end
+
+      it 'renders HTML' do
+        visit article_path(document[:id])
+        find('#fulltextToggleBar').click
+        expect(page).to have_css('.blacklight-eds_html_fulltext')
+        within('div.blacklight-eds_html_fulltext') do
+          expect(page).not_to have_content('<anid>')
+        end
+      end
     end
 
-    it 'renders HTML' do
-      visit article_path(document[:id])
-      find('#fulltextToggleBar').click
-      expect(page).to have_css('.blacklight-eds_html_fulltext')
-      within('div.blacklight-eds_html_fulltext') do
-        expect(page).not_to have_content('<anid>')
+    context 'when a user does not have access' do
+      it 'renders a login link instead' do
+        visit article_path(document[:id])
+
+        expect(page).not_to have_css('button#fulltextToggleBar')
+
+        expect(page).to have_css('a h2', text: 'Log in to show fulltext')
       end
     end
   end


### PR DESCRIPTION
…who do not have access.

Closes #1698 

Example record: bah__116897973
## Before
<img width="1223" alt="bah__116897973-before" src="https://user-images.githubusercontent.com/96776/30135907-9cff1516-9311-11e7-91ca-aefbb2ca14cd.png">

## After 
<img width="1219" alt="bah__116897973-after" src="https://user-images.githubusercontent.com/96776/30135905-9ceb9176-9311-11e7-85b5-fbf7d0bcc582.png">

## Markup
<img width="658" alt="bah__116897973-markup" src="https://user-images.githubusercontent.com/96776/30135908-9d04e022-9311-11e7-8936-0f886f7d4b06.png">
