### PR TITLE
ensure that all links meet type requirements so non-fulltext links are excluded

### DIFF
--- a/app/models/concerns/eds_links.rb
+++ b/app/models/concerns/eds_links.rb
@@ -65,6 +65,9 @@ module EdsLinks
         EdsLinks::FulltextLink.new(link_field)
       end
 
+      # Ensure they meet our requirements
+      links.select!(&:present?)
+
       # Then, map them into the SearchWorks objects
       categories = links.map(&:category).compact.map(&:to_i)
       links.map do |link|

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -72,7 +72,7 @@ feature 'Article Record Display' do
     let(:document) do
       SolrDocument.new(
         id: 'abc123',
-        eds_fulltext_links: [{ 'label' => 'Check SFX for full text', 'url' => 'http://example.com?param=abc&sid=xyz' }]
+        eds_fulltext_links: [{ 'label' => 'Check SFX for full text', 'url' => 'http://example.com?param=abc&sid=xyz', 'type' => 'customlink-fulltext' }]
       )
     end
     let(:sfx_xml) { Nokogiri::XML.parse('') }

--- a/spec/lib/access_panels/sfx_spec.rb
+++ b/spec/lib/access_panels/sfx_spec.rb
@@ -20,7 +20,7 @@ describe AccessPanels::Sfx do
     context 'when an sfx link is present' do
       let(:document) do
         SolrDocument.new(
-          'eds_fulltext_links' => [{ 'label' => 'Check SFX for full text', 'url' => 'http://example.com' }]
+          'eds_fulltext_links' => [{ 'label' => 'Check SFX for full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]
         )
       end
 
@@ -34,7 +34,7 @@ describe AccessPanels::Sfx do
     context 'when no sfx links is present' do
       let(:document) do
         SolrDocument.new(
-          'eds_fulltext_links' => [{ 'label' => 'HTML full text', 'url' => 'http://example.com' }]
+          'eds_fulltext_links' => [{ 'label' => 'HTML full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }]
         )
       end
 

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe EdsLinks do
   context 'non customlink-fulltext links' do
     it 'ignores other link types' do
       document['eds_fulltext_links'].first['type'] = 'unknown'
-      expect(document.eds_links.fulltext).to be_blank
+      expect(document.eds_links.all).not_to be_present
     end
   end
 


### PR DESCRIPTION
This PR fixes #1696. The problem was that non-fulltext links (e.g., `cataloglink`) were sneaking in for some cases (i.e., it thought they were open access links). It was fixed by filtering out bad links using `.present?`

Test case is `mzh__2017307227`

### Before search
![screen shot 2017-09-06 at 4 14 18 pm](https://user-images.githubusercontent.com/1861171/30138733-c19b22c2-931e-11e7-9d4e-21090345a9bd.png)

### After search
![screen shot 2017-09-06 at 4 14 31 pm](https://user-images.githubusercontent.com/1861171/30138735-c41686ea-931e-11e7-92ae-fe7f82521456.png)

### Before show
![screen shot 2017-09-06 at 4 15 01 pm](https://user-images.githubusercontent.com/1861171/30138743-cc4a207e-931e-11e7-9bfb-35ef49eaa5bd.png)

### After show
![screen shot 2017-09-06 at 4 14 51 pm](https://user-images.githubusercontent.com/1861171/30138746-d135946a-931e-11e7-865d-751aac20f402.png)
