### PR TITLE
in field search, remove Abstract, Series, ISSN, and ISBN, and relabel Article and Journal titles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -38,11 +38,7 @@ class ArticlesController < ApplicationController
       author:   :search_author,
       title:    :search_title,
       subject:  :subject_terms,
-      source:   :search_title,
-      abstract: :search,
-      series: :search_series,
-      issn:     :isbn_search, # advanced search
-      isbn:     :isbn_search  # advanced search
+      source:   :search_title
     }
     config.add_index_field "eds_authors", label: 'Authors', helper_method: :strip_author_relators
     config.add_index_field "eds_composed_title", label: 'Source', helper_method: :italicize_composed_title
@@ -58,7 +54,7 @@ class ArticlesController < ApplicationController
     end
 
     config.add_search_field('title') do |field|
-      field.label = 'Article title'
+      field.label = 'Title'
     end
 
     config.add_search_field('subject') do |field|
@@ -66,23 +62,7 @@ class ArticlesController < ApplicationController
     end
 
     config.add_search_field('source') do |field|
-      field.label = 'Journal title'
-    end
-
-    config.add_search_field('abstract') do |field|
-      field.label = 'Abstract'
-    end
-
-    config.add_search_field('series') do |field|
-      field.label = 'Series'
-    end
-
-    config.add_search_field('issn') do |field|
-      field.label = 'ISSN'
-    end
-
-    config.add_search_field('isbn') do |field|
-      field.label = 'ISBN'
+      field.label = 'Journal/Source'
     end
 
     # solr field configuration for document/show views

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,7 +73,7 @@ class CatalogController < ApplicationController
       search_title:   :title,
       subject_terms:  :subject,
       call_number:    :search,
-      search_series:  :series
+      search_series:  :search
     }
 
     # solr field configuration for document/show views

--- a/spec/features/article_home_page_spec.rb
+++ b/spec/features/article_home_page_spec.rb
@@ -12,7 +12,7 @@ feature 'Article Home Page' do
 
   it 'has fielded search' do
     within '#search_field' do
-      %w[search author title subject source abstract issn isbn].each do |search_field|
+      %w[search author title subject source].each do |search_field|
         expect(page).to have_css("option[value=\"#{search_field}\"]")
       end
       expect(page).not_to have_css("option[selected]") # defaults to top one (i.e., search)


### PR DESCRIPTION
This PR fixes #1711 

Note that it also affects the switching between catalog/articles+ for fielded search.

### Before

![screen shot 2017-09-07 at 3 45 08 pm](https://user-images.githubusercontent.com/1861171/30188502-8bb077dc-93e3-11e7-8494-f942f5cc1b8b.png)

### After
![screen shot 2017-09-07 at 3 47 29 pm](https://user-images.githubusercontent.com/1861171/30188561-e1c2cf80-93e3-11e7-989f-7f80039c3a86.png)
