### PR TITLE
Add a temporary flash alert on the article home page.

### DIFF
--- a/app/assets/stylesheets/modules/alert.scss
+++ b/app/assets/stylesheets/modules/alert.scss
@@ -3,3 +3,11 @@
   border-color: $state-danger-border;
   color: $state-danger-text;
 }
+
+.temp-article-alert {
+  color: $black;
+
+  h2 {
+    border-bottom: 0;
+  }
+}

--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -1,4 +1,14 @@
 <% @page_title= t 'blacklight.articles.home.title' %>
+
+<div class="alert alert-warning temp-article-alert" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <h2>Welcome to articles+ beta!</h2>
+  <p>This is a pre-release version of the new article search feature, still in active development. Small updates will be happening frequently over the next 2 weeks while we finish up details.</p>
+  <p>Feel free to explore, and please send feedback!</p>
+</div>
+
 <div class="article-home-page">
   <h1>Journal articles &amp; other e-resources</h1>
   <div class="row">


### PR DESCRIPTION
Closes #1723 

<img width="1213" alt="article-alert" src="https://user-images.githubusercontent.com/96776/30194217-a67285ec-9406-11e7-8568-53a496d99220.png">
