### PR TITLE
improve responsiveness of more search tools icon on article homepage

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -74,13 +74,10 @@
   }
 
   .home-page-search-tools {
-    img {
-      width: unset;
-      display: inline-block;
-      vertical-align: middle;
-      float: left;
-      margin-top: 25px;
-      padding: 0px;
+    .media-object {
+      width: 40px;
+      margin-top: 10px;
+      margin-bottom: 10px;
     }
   }
 

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -53,12 +53,14 @@
     <div class="col-md-6 home-page-more">
       <div class="panel panel-default">
         <div class="panel-body">
-          <div class="col-md-1 home-page-search-tools">
-            <%= image_tag 'homepage/search.svg' %>
-          </div>
-          <div class="col-md-11">
-            <h4><%= link_to 'More search tools', 'https://library.stanford.edu/search-services' %></h4>
-            <p class="hidden-xs">Discover and access library and archival materials, journals, databases, data, and e-resources beyond SearchWorks.</p>
+          <div class="col-md-12 home-page-search-tools media">
+            <div class="search-tools-icon media-left">
+              <%= image_tag 'homepage/search.svg', class: 'media-object' %>
+            </div>
+            <div class="search-tools-body media-body">
+              <h4><%= link_to 'More search tools', 'https://library.stanford.edu/search-services' %></h4>
+              <p class="hidden-xs">Discover and access library and archival materials, journals, databases, data, and e-resources beyond SearchWorks.</p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes #1688 by using the bootstrap `media` classes.

### After

![screen shot 2017-09-08 at 11 38 05 am](https://user-images.githubusercontent.com/1861171/30226358-94fb833e-948a-11e7-945d-e92ebb761c04.png)
![screen shot 2017-09-08 at 11 37 44 am](https://user-images.githubusercontent.com/1861171/30226359-94fb8046-948a-11e7-9746-12368995a659.png)
![screen shot 2017-09-08 at 11 37 29 am](https://user-images.githubusercontent.com/1861171/30226357-94fb5abc-948a-11e7-96ec-dffb9899f18e.png)
