### PR TITLE
Add feedback link to articles+ beta flash message

### DIFF
--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -5,8 +5,8 @@
     <span aria-hidden="true">&times;</span>
   </button>
   <h2>Welcome to articles+ beta!</h2>
-  <p>This is a pre-release version of the new article search feature, still in active development. Small updates will be happening frequently over the next 2 weeks while we finish up details.</p>
-  <p>Feel free to explore, and please send feedback!</p>
+  <p>This is an early release of the new article search feature, still in active development. Small updates will be happening frequently over the next 2 weeks while we finish up details.</p>
+  <p>Explore and let us know what you think! Your <%= link_to 'feedback', feedback_path, data: { toggle: 'collapse', target: '#feedback-form' }, class: 'collapsed', aria: { hidden: true } %> will help us improve the service.</p>
 </div>
 
 <div class="article-home-page">


### PR DESCRIPTION
Closes #1726 

This PR:
- updates the "Welcome to articles+ beta!" flash message text
- adds a link to toggle the feedback form

## Before
<img width="1183" alt="flash_before" src="https://user-images.githubusercontent.com/5402927/30228238-b2fcf2d0-9491-11e7-93ba-95d6865e6869.png">

## After
<img width="1190" alt="flash_after" src="https://user-images.githubusercontent.com/5402927/30228239-b3196708-9491-11e7-8edc-899ca937e46b.png">

