### PR TITLE
Update home page link URLs and suppress bento link

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -5,6 +5,10 @@
   }
 }
 
+.bento-search-panel {
+  display: none;
+}
+
 .article-home-page {
   .home-settings {
     label {
@@ -39,6 +43,7 @@
 }
 
 .home-page-bento {
+
   .panel .panel-body {
     padding: 0px;
   }

--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -58,7 +58,7 @@
             <div class="col-md-6">
               <h4>Off campus</h4>
               <p>You’ll need to log in. You can <%= link_to 'log in now', new_user_session_path %>, or when you find an article of interest.</p>
-              <p class="text-right"><%= link_to 'More about article access at Stanford Libraries', 'https://library.stanford.edu' %></p>
+              <p class="text-right"><%= link_to 'More about article access at Stanford Libraries', 'https://library.stanford.edu/using/connect-campus' %></p>
             </div>
           </div>
         </div>

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -24,7 +24,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/website.png' %>
-          <h4><%= link_to 'Library website', 'https://library.stanford.edu/search' %></h4>
+          <h4><%= link_to 'Library website', 'https://library.stanford.edu' %></h4>
           <p class="hidden-xs">Find topic specialists, blog posts, descriptions of our notable collections, as well as libraries, hours, and policies.</p>
         </div>
       </div>

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -40,7 +40,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-12 home-page-bento">
+    <div class="col-md-12 home-page-bento bento-search-panel">
       <div class="panel panel-default">
         <div class="panel-body text-center">
           <h4><%= link_to 'All of the above', root_path %></h4>


### PR DESCRIPTION
Addresses #1676 until further updates

This PR:
- adds a URL to "More about article access at Stanford libraries"
- changes URL for library website
- suppresses "All of the above" link to bento search for now

## Catalog
### Before
<img width="1192" alt="before_catalog" src="https://user-images.githubusercontent.com/5402927/30231329-3ff2d210-949f-11e7-976f-0d8fb9739617.png">

### After
<img width="1192" alt="after_catalog" src="https://user-images.githubusercontent.com/5402927/30231326-3fee14dc-949f-11e7-93f2-e67e92ce6066.png">


## Articles
### Before
<img width="1190" alt="before_articles" src="https://user-images.githubusercontent.com/5402927/30231328-3ff2b99c-949f-11e7-94d1-ab5ff02786aa.png">

### After
<img width="1187" alt="after_articles" src="https://user-images.githubusercontent.com/5402927/30231327-3ff26776-949f-11e7-87ad-977d1221e5ed.png">
