### PR TITLE
Update zero results page to be article/catalog controller agnostic.

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,6 +6,7 @@ class ArticlesController < ApplicationController
   include Blacklight::Configurable
   include EdsPaging
   include EmailValidation
+  include BackendLookup
 
   before_action :set_search_query_modifier, only: :index
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,6 +26,8 @@ class CatalogController < ApplicationController
 
   include EmailValidation
 
+  include BackendLookup
+
   before_action :set_search_query_modifier, only: :index
 
   before_action only: :index do
@@ -366,19 +368,6 @@ class CatalogController < ApplicationController
     respond_to do |format|
       format.html
       format.js { render layout: false }
-    end
-  end
-
-  def backend_lookup
-    (@response, @document_list) = search_results(params)
-    respond_to do |format|
-      format.json do
-        @presenter = Blacklight::JsonPresenter.new(@response,
-                                                   @document_list,
-                                                   facets_from_request,
-                                                   blacklight_config)
-      end
-      format.html { render status: :bad_request, layout: false, file: Rails.root.join('public', '500.html') }
     end
   end
 

--- a/app/controllers/concerns/backend_lookup.rb
+++ b/app/controllers/concerns/backend_lookup.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# Simple mixin to share the backend_lookup method between search controllers
+module BackendLookup
+  def backend_lookup
+    (@response, @document_list) = search_results(params)
+    respond_to do |format|
+      format.json do
+        @presenter = Blacklight::JsonPresenter.new(@response,
+                                                   @document_list,
+                                                   facets_from_request,
+                                                   blacklight_config)
+      end
+      format.html { render status: :bad_request, layout: false, file: Rails.root.join('public', '500.html') }
+    end
+  end
+end

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -24,7 +24,7 @@
               <%= t 'blacklight.search.zero_results.limit_fields' %>
             </dt>
             <dd>
-              <%= link_to "#{search_field_label(params)} > #{params[:q]}", search_catalog_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_filters)}"} %>
+              <%= link_to "#{search_field_label(params)} > #{params[:q]}", searchworks_search_action_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_filters))}"} %>
             </dd>
           <% end %>
           <% if @search_modifier.fielded_search? %>
@@ -32,7 +32,7 @@
               <%= t 'blacklight.search.zero_results.search_fields' %>
             </dt>
             <dd>
-              <%= link_to "#{params[:q]}", search_catalog_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{catalog_backend_lookup_path(@search_modifier.params_without_fielded_search_and_filters)}"} %>
+              <%= link_to "#{params[:q]}", searchworks_search_action_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_fielded_search_and_filters))}"} %>
             </dd>
           <% end %>
         </dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
 
   get "feedback" => "feedback_forms#new"
   get "backend_lookup" => "catalog#backend_lookup", defaults: {format: :json}, as: :catalog_backend_lookup
+  get 'articles/backend_lookup' => 'articles#backend_lookup', defaults: {format: :json}, as: :articles_backend_lookup
 
   get 'view/:id/availability' => 'catalog#availability', defaults: { format: :json }
 

--- a/spec/features/zero_results_spec.rb
+++ b/spec/features/zero_results_spec.rb
@@ -36,4 +36,15 @@ feature "Zero results" do
       expect(page).to have_css('a', text: 'All fields > sdfsda')
     end
   end
+
+  context 'article search' do
+    before { stub_article_service(docs: []) }
+
+    scenario 'displays backend lookup links', js: true do
+      visit articles_path(q: 'Kittens', f: { 'eds_facet' => ['Abc'] })
+
+      # Has zero results because we pass an empty array of docs, but is sucessfully searching
+      expect(page).to have_link('Keyword > Kittens... found 0 results', href: %r{.*/articles\?q=Kittens})
+    end
+  end
 end

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe 'Article Routing', type: :routing do
     expect(get('/articles/eds__1/ebook-pdf/fulltext')).to route_to(controller: 'articles', action: 'fulltext_link', id: 'eds__1', type: 'ebook-pdf')
     expect(get('/articles/eds__1/wrong type/fulltext')).not_to be_routable
   end
+
+  it '#backend_lookup' do
+    expect(get('/articles/backend_lookup')).to route_to(controller: 'articles', action: 'backend_lookup', format: :json)
+  end
+
   it 'other actions are not routable' do
     expect(post('/articles')).not_to be_routable
     expect(put('/articles')).not_to be_routable

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -44,7 +44,7 @@ module StubArticleService
   end
 
   def stub_article_service(type: :multiple, docs:)
-    raise 'Article search service stubbed without any documents.' if docs.blank?
+    raise 'Article search service stubbed without any documents.' unless docs
 
     allow_any_instance_of(Eds::Session).to receive_messages(
       info: double(available_search_criteria: available_search_criteria),

--- a/spec/views/shared/_zero_results.html.erb_spec.rb
+++ b/spec/views/shared/_zero_results.html.erb_spec.rb
@@ -14,6 +14,7 @@ describe "shared/_zero_results.html.erb" do
       f: {'fieldA' => ["ValueA"], 'fieldB' => ['ValueB']},
       search_field: 'search_title'
     }, config))
+    allow(view).to receive(:controller_name).and_return('catalog')
     allow(view).to receive(:label_for_search_field).and_return('Title')
     allow(view).to receive(:on_campus_or_su_affiliated_user?).and_return(true)
   end


### PR DESCRIPTION
Closes #1705 

Example search from ticket:
- [localhost](http://localhost:3000/articles?utf8=%E2%9C%93&f%5Beds_language_facet%5D%5B%5D=%ED%95%9C%EA%B5%AD%EC%96%B4&f%5Beds_publication_type_facet%5D%5B%5D=Videos&f%5Beds_search_limiters_facet%5D%5B%5D=Direct+access+to+full+text&search_field=title&q=kittens)
- [preview](http://sw-webapp-sandbox-f.stanford.edu/articles?utf8=%E2%9C%93&f%5Beds_language_facet%5D%5B%5D=%ED%95%9C%EA%B5%AD%EC%96%B4&f%5Beds_publication_type_facet%5D%5B%5D=Videos&f%5Beds_search_limiters_facet%5D%5B%5D=Direct+access+to+full+text&search_field=title&q=kittens)


## Before
<img width="789" alt="before" src="https://user-images.githubusercontent.com/96776/30231959-3c378cd0-94a2-11e7-9394-fd8c385d4687.png">

## After
<img width="805" alt="after" src="https://user-images.githubusercontent.com/96776/30231960-3c535b9a-94a2-11e7-8972-ee4deadb03bf.png">
