### PR TITLE
Add the "range: true" flag to the article date range facet so it is...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     blacklight_advanced_search (6.3.1)
       blacklight (~> 6.0, >= 6.0.1)
       parslet
-    blacklight_range_limit (6.2.0)
+    blacklight_range_limit (6.2.1)
       blacklight (>= 6.0.2)
       jquery-rails
       rails (>= 3.0)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -145,7 +145,7 @@ class ArticlesController < ApplicationController
     # a facet but we still can apploy our configured label to the breadcrumbs
     config.add_facet_field 'eds_search_limiters_facet', label: 'Settings', if: false
     # Commenting this out temporarily until we have a better date facet option
-    config.add_facet_field 'pub_year_tisim', label: 'Date', partial: 'articles/range_limit_panel'
+    config.add_facet_field 'pub_year_tisim', label: 'Date', partial: 'articles/range_limit_panel', range: true
     config.add_facet_field 'eds_publication_type_facet', label: 'Source type', partial: "facet_eds_publication_type"
     config.add_facet_field 'eds_language_facet', label: 'Language' # , limit: 20 TODO: Need to handle facet limiting
     config.add_facet_field 'eds_subject_topic_facet', label: 'Topic'

--- a/spec/features/date_range_spec.rb
+++ b/spec/features/date_range_spec.rb
@@ -20,9 +20,9 @@ feature 'Date Range', js: true do
       fill_in 'range_pub_year_tisim_begin', with: 1900
       click_button 'Apply'
     end
-    page.find('h3.panel-title', text: 'Date').click
+
     within '.panel.blacklight-pub_year_tisim' do
-      expect(page).to have_field 'range[pub_year_tisim][begin]', with: 1900
+      expect(page).to have_field 'range[pub_year_tisim][begin]', with: 1900, visible: true
     end
   end
 end


### PR DESCRIPTION
...expanded properly.

Closes #1687 

![date-slider](https://user-images.githubusercontent.com/96776/30232610-d08dc1e4-94a5-11e7-871d-0f18ee46599f.gif)
