### PR TITLE
Override SolrDocument#id to escape slashes in IDs.

### DIFF
--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -33,7 +33,7 @@ module Eds
 
     def eds_find(id, params, eds_params)
       dbid = id.split('__', 2).first
-      accession = id.split('__', 2).last
+      accession = id.split('__', 2).last.gsub('%2F', '/')
       eds_session = Eds::Session.new(eds_params.update(caller: 'bl-repo-find'))
       record = eds_session.retrieve(dbid: dbid, an: accession)
       blacklight_config.response_model.new(record.to_solr,

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -44,6 +44,11 @@ class SolrDocument
     super
   end
 
+  # TODO: change this to #to_param when we have upgraded to Blacklight 6.11.1
+  def id
+    (super || '').to_s.gsub('/', '%2F')
+  end
+
       # The following shows how to setup this blacklight document to display marc documents
   extension_parameters[:marc_source_field] = :marcfield
   extension_parameters[:marc_format_type] = :marcxml

--- a/spec/controllers/concerns/eds_paging_spec.rb
+++ b/spec/controllers/concerns/eds_paging_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe EdsPaging do
       expect(@docs.first).to be_truthy
       expect(@docs.first['id']).to eq 'abc123'
       expect(@docs.last).to be_truthy
-      expect(@docs.last['id']).to eq 'wqoeif.zzz'
+      expect(@docs.last['id']).to eq 'wq/oeif.zzz'
     end
 
     context 'last hit' do
@@ -172,7 +172,7 @@ RSpec.describe EdsPaging do
 
       it 'grabs the penultimate hit for the previous doc but no next doc' do
         expect(@docs.first).to be_truthy
-        expect(@docs.first['id']).to eq 'wqoeif.zzz'
+        expect(@docs.first['id']).to eq 'wq/oeif.zzz'
         expect(@docs.last).to be_nil
       end
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -122,6 +122,12 @@ describe SolrDocument do
     end
   end
 
+  describe '#id' do
+    it 'escapes slashes' do
+      expect(SolrDocument.new(id: 'abc/123').id).to eq 'abc%2F123'
+    end
+  end
+
   describe 'EdsDocument' do
     let(:eds) { SolrDocument.new(eds_title: 'yup') }
     let(:non_eds) { SolrDocument.new }

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -23,7 +23,7 @@ module StubArticleService
       }]
     ),
     SolrDocument.new(
-      id: 'wqoeif.zzz',
+      id: 'wq/oeif.zzz',
       eds_title: 'Yet another title for the document',
       eds_fulltext_links: [{
         'label' => 'View request options',


### PR DESCRIPTION
Fixes #1716 

I'm working on updating Blacklight, but I don't want this to hold up a release and I think that we're functionally equivalent at the moment.