### PR TITLE
Use h3 for homepage sub-headings

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -54,6 +54,10 @@
     margin: auto;
   }
 
+  h4 {
+    font-weight: normal;
+  }
+
   h4, p {
     padding: 2px 10px;
   }

--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -52,11 +52,11 @@
           <h2>How do I access articles?</h2>
           <div class="row">
             <div class="col-md-6">
-              <h4>On campus</h4>
+              <h3>On campus</h3>
               <p>No configuration required. Just click the links in the search results or detail page.</p>
             </div>
             <div class="col-md-6">
-              <h4>Off campus</h4>
+              <h3>Off campus</h3>
               <p>You’ll need to log in. You can <%= link_to 'log in now', new_user_session_path %>, or when you find an article of interest.</p>
               <p class="text-right"><%= link_to 'More about article access at Stanford Libraries', 'https://library.stanford.edu/using/connect-campus' %></p>
             </div>

--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -21,21 +21,21 @@
         <div class="panel panel-default">
           <div class="panel-body">
             <%= image_tag('homepage/digital.svg', class: 'pull-left', alt: "", title: "'The Burning of San Francisco April 18, 19, 20, 1906.'", data: { "no-link-href" => search_catalog_path(collections_search_params) }) %>
-            <h4><%= link_to "Digital collections", search_catalog_path(collections_search_params) %></h4>
+            <h3><%= link_to "Digital collections", search_catalog_path(collections_search_params) %></h3>
             <p>Images, maps, data, &amp; more from the Stanford Digital Repository.</p>
           </div>
         </div>
         <div class="panel panel-default">
           <div class="panel-body">
             <%= image_tag('homepage/theses.svg', class: 'pull-left', alt: "", title: '', data: { "no-link-href" => search_catalog_path(f: {genre_ssim: ['Thesis/Dissertation']}) } ) %>
-            <h4><%= link_to "Theses & dissertations", search_catalog_path(f: {genre_ssim: ['Thesis/Dissertation']}) %></h4>
+            <h3><%= link_to "Theses & dissertations", search_catalog_path(f: {genre_ssim: ['Thesis/Dissertation']}) %></h3>
             <p>Theses &amp; dissertations in the Stanford Libraries and Digital Repository.</p>
           </div>
         </div>
         <div class="panel panel-default">
           <div class="panel-body">
             <%= image_tag('homepage/databases.svg', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  selected_databases_path }) %>
-            <h4><%= link_to "Databases", selected_databases_path %></h4>
+            <h3><%= link_to "Databases", selected_databases_path %></h3>
             <p>A-Z list of topic-specific databases. Not sure where to start? Try these <%= link_to 'selected databases', selected_databases_path %>.</p>
           </div>
         </div>
@@ -45,7 +45,7 @@
           <div class="panel panel-default">
             <div class="panel-body">
               <%= image_tag('homepage/govdocs.svg', class: 'pull-left', alt: '', title: '', data: { 'no-link-href' => govdocs_path} ) %>
-              <h4><%= link_to 'Government documents', govdocs_path %></h4>
+              <h3><%= link_to 'Government documents', govdocs_path %></h3>
               <p>Stanford is a depository library for state, federal, UN, and EU government documents.</p>
             </div>
           </div>
@@ -53,7 +53,7 @@
         <div class="panel panel-default">
           <div class="panel-body">
             <%= image_tag('homepage/coursereserves.svg', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  course_reserves_path }) %>
-            <h4><%= link_to "Course reserves", course_reserves_path %></h4>
+            <h3><%= link_to "Course reserves", course_reserves_path %></h3>
             <p>Find books, media, and e-resources set aside for classes.</p>
           </div>
         </div>

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -1,5 +1,5 @@
 <div class="home-page-bento">
-  <h1>Search Stanford's library resources</h1>
+  <h4>Search Stanford's library resources</h4>
   <div class="row">
     <div class="col-sm-3 col-xs-6 home-page-catalog <%= 'home-page-you-are-here' unless article_search? %>">
       <div class="panel panel-default">


### PR DESCRIPTION
Closes #1729 

This PR changes `<h4>` to `<h3>` tags on both the Catalog and Articles+ home pages. 

## Articles
### Before
<img width="1212" alt="articles_before" src="https://user-images.githubusercontent.com/5402927/30234890-d46d65e2-94b6-11e7-8f81-6932bd00be17.png">

### After
<img width="1209" alt="articles_after" src="https://user-images.githubusercontent.com/5402927/30234891-d46d7226-94b6-11e7-85cc-2d27b837ddd2.png">

## Catalog
### Before
<img width="1228" alt="catalog_before" src="https://user-images.githubusercontent.com/5402927/30234889-d46c6976-94b6-11e7-93dd-454b453fa4de.png">

### After
<img width="1202" alt="catalog_after" src="https://user-images.githubusercontent.com/5402927/30234888-d466dace-94b6-11e7-9221-b1126a6c465e.png">