### PR TITLE
move faraday_eds_cache to Rails.root/tmp

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :log_level, :info
 set :linked_files, %w{config/database.yml config/blacklight.yml config/honeybadger.yml config/secrets.yml public/robots.txt}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{config/settings log tmp/pids tmp/cache tmp/sockets tmp/faraday_eds_cache vendor/bundle public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,7 +36,7 @@ EDS_PASS: the-eds-password
 EDS_PROFILE: the-eds-profile
 EDS_DEBUG: false
 EDS_CACHE: true
-EDS_CACHE_DIR: /tmp
+EDS_CACHE_DIR: <%= Rails.root.join('tmp') %>
 EDS_LOGDIR: <%= Rails.root.join('log') %>
 EDS_TIMEOUT: 15
 EDS_OPEN_TIMEOUT: 5


### PR DESCRIPTION
@jkeck This PR uses Rails.root/tmp/faraday_eds_cache for the EDS cache folder.