### PR TITLE
Handle users with multiple (semicolon delimited) affiliations.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,9 @@ class ApplicationController < ActionController::Base
   def user_is_stanford_affiliated?
     return unless current_user.present? && session['suAffiliation']
 
-    Settings.SU_AFFILIATIONS.include?(session['suAffiliation'])
+    session['suAffiliation'].split(';').any? do |affiliation|
+      Settings.SU_AFFILIATIONS.include?(affiliation.strip)
+    end
   end
 
   def page_location

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,6 +13,12 @@ describe ApplicationController do
       it { expect(controller.send(:on_campus_or_su_affiliated_user?)).to be true }
     end
 
+    context 'when the user has multiple affiliations' do
+      before { stub_current_user(context: controller, affiliation: 'test-stanford:test; test-stanford:another-test;test-stanford:testing') }
+
+      it { expect(controller.send(:on_campus_or_su_affiliated_user?)).to be true }
+    end
+
     context 'when there is a current user not in the correct affilation' do
       before { stub_current_user(context: controller) }
 


### PR DESCRIPTION
Tested this w/ @snydman and he has many affiliations (that are returned semicolon delimited).
