### PR TITLE
Remove login link from EDS Guest flash error message.

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -266,7 +266,7 @@ class ArticlesController < ApplicationController
 
   def flash_message_for_link_error
     base_key = 'searchworks.articles.flashes.fulltext_link'
-    return I18n.t("#{base_key}.guest_html", login_url: new_user_session_path) if session['eds_guest']
+    return I18n.t("#{base_key}.guest_html") if session['eds_guest']
 
     I18n.t("#{base_key}.non_guest_html")
   end

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -8,7 +8,7 @@ en:
         source_type_warning_html:
           Additional selections in this facet will <strong>expand</strong> (rather than narrow) your search result.
         fulltext_link:
-          guest_html: Sorry, the PDF download was not successful because you are currently in guest mode.<br/><a href="%{login_url}">Log in to try the download again</a>.
+          guest_html: Sorry, the PDF download was not successful because you are currently in guest mode.<br/>Log in to try the download again.
           non_guest_html: Sorry, the PDF download was not successful.<br/>We don't know the source of the error. Try again, and if it continues to fail, <a href=" http://library.stanford.edu/ask/email/connection-problems">please report it as a connection problem</a>.
       facets:
         options:

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ArticlesController do
           expect(error_message).to have_content(
             'Sorry, the PDF download was not successful because you are currently in guest mode.'
           )
-          expect(error_message).to have_css('a', text: 'Log in to try the download again')
+          expect(error_message).to have_content('Log in to try the download again')
           expect(response).to have_http_status(:found) # redirects back
         end
       end


### PR DESCRIPTION
If we either put a login link w/o a referrer OR a login link w/ the referrer (which in the context of the flash message is the fulltext method) we get an error message from Shibboleth saying the session is stale.

@jvine said a good stop-gap would be to just not link the text given that the login link is available on every page.