### PR TITLE
add preformatted HTML for fulltext link to JSON API

### DIFF
--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -94,6 +94,14 @@ module ArticleHelper
     end.flatten
   end
 
+  def render_fulltext_link(link, document)
+    if link.href == 'detail'
+      link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false })
+    else
+      link_to(link.text, link.href, class: link.ill? ? 'sfx' : '')
+    end
+  end
+
   private
 
   RELATOR_TERMS = %w[Author Originator]

--- a/app/views/articles/access_panels/_online.html.erb
+++ b/app/views/articles/access_panels/_online.html.erb
@@ -8,11 +8,7 @@
     <ul class='document-metadata dl-horizontal dl-invert'>
       <% document.access_panels.online.links.each do |link| %>
         <li>
-          <% if link.href == 'detail' %>
-            <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
-          <% else %>
-            <%= link_to(link.text, link.href, class: link.ill? ? 'sfx' : '') %>
-          <% end %>
+          <%= render_fulltext_link(link, document) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/articles/index.json.jbuilder
+++ b/app/views/articles/index.json.jbuilder
@@ -1,0 +1,11 @@
+docs = @presenter.documents.collect do |document|
+  link = document.eds_links.all.first # top priority one only
+  data = document.to_h # avoids deprecation warning
+  data['fulltext_link_html'] = render_fulltext_link(link, document) if link.present?
+  data
+end
+json.response do
+  json.docs docs
+  json.facets @presenter.search_facets_as_json
+  json.pages @presenter.pagination_info
+end

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -147,6 +147,18 @@ feature 'Article Searching' do
     end
   end
 
+  describe 'JSON API' do
+    it 'includes the fulltext_link_html data' do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+      visit articles_path(q: 'kittens', format: 'json')
+      results = JSON.parse(page.body)
+      expect(results['response']['docs'][0]).not_to include('fulltext_link_html')
+      expect(results['response']['docs'][1]).to include('fulltext_link_html' => '<a class="" href="http://example.com">View full text</a>')
+      expect(results['response']['docs'][2]).to include('fulltext_link_html' => '<a class="sfx" href="http://example.com">Find it in print or via interlibrary services</a>')
+      expect(results['response']['docs'][3]).to include('fulltext_link_html' => '<a data-turbolinks="false" href="/articles/pdfyyy/pdf/fulltext">View/download PDF</a>')
+    end
+  end
+
   it 'displays the appropriate fields in the search' do
     skip 'we need some EDS fixtures'
   end


### PR DESCRIPTION
This PR fixes #1753. The simple rendering of the link, which the JSON API surfaces, is migrated to a helper method, but there's more complex renderings in the index pages that I didn't migrate.

#### After: via `format=json` query for /articles

like so http://localhost:3000/articles?q=climate+change&format=json
![screen shot 2017-09-12 at 2 41 13 pm](https://user-images.githubusercontent.com/1861171/30349627-73e87a9e-97c8-11e7-9290-44fd19885864.png)

^^^The link is relative so the Bento app will need to inject the host.

![screen shot 2017-09-12 at 3 05 45 pm](https://user-images.githubusercontent.com/1861171/30350534-e5df4e36-97cb-11e7-9389-be30009e73e8.png)

^^^Other links are fully qualified