### PR TITLE
add searchworks:clear_eds_cache task

### DIFF
--- a/lib/tasks/searchworks.rake
+++ b/lib/tasks/searchworks.rake
@@ -67,13 +67,25 @@ namespace :searchworks do
       sleep(10)
     end
   end
+
+  def eds_cache
+    cache_dir = File.join(Settings.EDS_CACHE_DIR, 'faraday_eds_cache')
+    return ActiveSupport::Cache::FileStore.new(cache_dir) if File.directory?(cache_dir)
+    nil
+  end
+
   desc "Prune expired files in EDS cache"
   task :prune_eds_cache => [:environment] do |t, args|
-    cache_dir = File.join(Settings.EDS_CACHE_DIR, 'faraday_eds_cache')
-    if File.directory?(cache_dir)
-      cache = ActiveSupport::Cache::FileStore.new(cache_dir)
-      puts "Cleaning cache in #{cache_dir}"
-      cache.cleanup
+    if eds_cache
+      puts "Cleaning cache in #{eds_cache.cache_path}"
+      eds_cache.cleanup
+    end
+  end
+  desc "Clear all files in EDS cache"
+  task :clear_eds_cache => [:environment] do |t, args|
+    if eds_cache
+      puts "Clearing cache in #{eds_cache.cache_path}"
+      eds_cache.clear
     end
   end
 end


### PR DESCRIPTION
`prune_eds_cache` (existing task) cleans the cache by expiring all old files, whereas `clear_eds_cache` deletes all files regardless of their TTLs. The `prune_eds_cache` task is already run hourly via [config/schedule.rb](https://github.com/sul-dlss/SearchWorks/blob/master/config/schedule.rb#L8)

```
$ bundle exec rake -T | grep searchworks | grep cache
rake searchworks:clear_eds_cache                     # Clear all files in EDS cache
rake searchworks:prune_eds_cache                     # Prune expired files in EDS cache
$ bundle exec rake searchworks:prune_eds_cache
Cleaning cache in /Users/drh/workspace/SearchWorks/tmp/faraday_eds_cache
$ bundle exec rake searchworks:clear_eds_cache
Clearing cache in /Users/drh/workspace/SearchWorks/tmp/faraday_eds_cache
```