### PR TITLE
Update databases link in featured resources

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -34,8 +34,8 @@
         </div>
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= image_tag('homepage/databases.svg', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  selected_databases_path }) %>
-            <h3><%= link_to "Databases", selected_databases_path %></h3>
+            <%= image_tag('homepage/databases.svg', class: 'pull-left', alt: "", title: '',  data: { "no-link-href" =>  databases_path }) %>
+            <h3><%= link_to "Databases", databases_path %></h3>
             <p>A-Z list of topic-specific databases. Not sure where to start? Try these <%= link_to 'selected databases', selected_databases_path %>.</p>
           </div>
         </div>


### PR DESCRIPTION
Closes #1773 

Changes "Databases" link in catalog homepage "Featured Resources" from `/selected-databases` to `/databases`. 

## Links to:
![screen shot 2017-09-13 at 4 01 18 pm](https://user-images.githubusercontent.com/5402927/30404742-e702fc8c-989c-11e7-8da7-8851cfc93bcb.png)

