### PR TITLE
Change/simplify encoding strategy for SFX links in the SFX panel.

### DIFF
--- a/app/controllers/sfx_data_controller.rb
+++ b/app/controllers/sfx_data_controller.rb
@@ -14,8 +14,6 @@ class SfxDataController < ApplicationController
   private
 
   def setup_sfx_data
-    url = CGI.unescape(params.fetch(:url))
-
-    @sfx_data = SfxData.new(url)
+    @sfx_data = SfxData.new(params.fetch(:url))
   end
 end

--- a/app/models/sfx_data.rb
+++ b/app/models/sfx_data.rb
@@ -1,8 +1,8 @@
 ##
 # Pull full-text source data from the SFX XML endpoint and render it.
 #
-# Initializes with the SFX URL that would normally render the HTML
-# form/links and append a paramter to it that returns XML instead.
+# Initializes with the a URI encoded SFX URL that would normally render
+# the HTML form/links and append a parameter to it that returns XML instead.
 #
 # This class parses that XML and returns it both as ruby objects and an HTML rendering.
 class SfxData

--- a/app/views/articles/access_panels/_sfx.html.erb
+++ b/app/views/articles/access_panels/_sfx.html.erb
@@ -1,5 +1,5 @@
 <% sfx_url = document.access_panels.sfx.links.first.href %>
-<div class="panel panel-default access-panel panel-online sfx-panel" data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: CGI.escape(sfx_url)) %>">
+<div class="panel panel-default access-panel panel-online sfx-panel" data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: URI.encode(sfx_url)) %>">
   <div class="access-panel-heading panel-heading">
     <h3>
       All available sources

--- a/spec/controllers/sfx_data_controller_spec.rb
+++ b/spec/controllers/sfx_data_controller_spec.rb
@@ -5,7 +5,7 @@ describe SfxDataController do
     it 'unescapes the incoming URL param' do
       expect(SfxData).to receive(:new).with('http://example.com').and_return(double(targets: []))
 
-      get :show, params: { url: CGI.escape('http://example.com') }
+      get :show, params: { url: URI.encode('http://example.com') }
     end
   end
 
@@ -15,7 +15,7 @@ describe SfxDataController do
     end
 
     it 'is successful and renders the show template' do
-      get :show, params: { url: CGI.escape('http://example.com') }
+      get :show, params: { url: URI.encode('http://example.com') }
 
       expect(response).to be_success
       expect(response).to render_template('show')
@@ -24,7 +24,7 @@ describe SfxDataController do
 
   context 'when a URL does not have SFX data' do
     it 'returns a 404/Not Found' do
-      get :show, params: { url: CGI.escape('http://example.com') }
+      get :show, params: { url: URI.encode('http://example.com') }
 
       expect(response).to be_not_found
     end


### PR DESCRIPTION
We now just URI encode the URL in the data attribute and keep it encoded through the entire stack.

Closes #1647 

(note that this PR won't work until #1778 is merged as the entire feature is broken right now due to redirects)