### PR TITLE
Remove coverage number from Articles+ mini-bento

### DIFF
--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -15,7 +15,7 @@
         <div class="panel-body">
           <%= image_tag 'homepage/articles.jpg' %>
           <h4><%= link_to_unless article_search?, 'Articles+', articles_path %></h4>
-          <p class="hidden-xs">Search a combined index of 100s of databases, and connect directly to the article or resource. Covers ~87% of our subscribed databases.</p>
+          <p class="hidden-xs">Search a combined index of 100s of databases, and connect directly to the article or resource.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #1772 

Removes "Covers ~87% of our subscribed databases" from the Articles+ section of the mini-bento. 

## Before
![minibento_before](https://user-images.githubusercontent.com/5402927/30405057-a108bba2-989e-11e7-8b3a-fc39585e23bc.png)

## After
![minibento_after](https://user-images.githubusercontent.com/5402927/30405058-a10a0e80-989e-11e7-874c-fd38d3fbfce8.png)
