### PR TITLE
Remove 'more about article access' link from homepage

### DIFF
--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -58,7 +58,6 @@
             <div class="col-md-6">
               <h3>Off campus</h3>
               <p>You’ll need to log in. You can <%= link_to 'log in now', new_user_session_path %>, or when you find an article of interest.</p>
-              <p class="text-right"><%= link_to 'More about article access at Stanford Libraries', 'https://library.stanford.edu/using/connect-campus' %></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #1783 

Removes 'More about articles access at Stanford Libraries` link from articles homepage.

## Before
![articles_link_before](https://user-images.githubusercontent.com/5402927/30458368-0b6738d6-9960-11e7-8788-92e2319a8415.png)

## After
![articles_link_after](https://user-images.githubusercontent.com/5402927/30458355-fd51c162-995f-11e7-9057-05c1b8e89c36.png)
