### PR TITLE
Change request options link text

### DIFF
--- a/app/models/concerns/eds_links.rb
+++ b/app/models/concerns/eds_links.rb
@@ -43,7 +43,7 @@ module EdsLinks
       'PDF eBook Full Text'.downcase =>      { label: 'View/download PDF', category: 2 },
       'Check SFX for full text'.downcase =>  { label: 'View on content provider\'s site', category: 3 },
       :open_access_link =>                   { label: :as_is, category: 4 },
-      'View request options'.downcase =>     { label: 'Find it in print or via interlibrary services', category: 5 }
+      'View request options'.downcase =>     { label: 'Find full text or request', category: 5 }
     }.freeze
 
     def map

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -111,7 +111,7 @@ feature 'Article Searching' do
       expect(page).to have_css('ul.document-metadata li span.online-label', text: 'Full text')
       expect(page).to have_css('ul.document-metadata li a', text: /^View on detail page/)
       expect(page).to have_css('ul.document-metadata li a', text: /^View full text/)
-      expect(page).to have_css('ul.document-metadata li a', text: /^Find it in print/)
+      expect(page).to have_css('ul.document-metadata li a', text: /^Find full text or request/)
       expect(page).to have_css('ul.document-metadata li a', text: /^View\/download PDF/)
     end
   end
@@ -154,7 +154,7 @@ feature 'Article Searching' do
       results = JSON.parse(page.body)
       expect(results['response']['docs'][0]).not_to include('fulltext_link_html')
       expect(results['response']['docs'][1]).to include('fulltext_link_html' => '<a class="" href="http://example.com">View full text</a>')
-      expect(results['response']['docs'][2]).to include('fulltext_link_html' => '<a class="sfx" href="http://example.com">Find it in print or via interlibrary services</a>')
+      expect(results['response']['docs'][2]).to include('fulltext_link_html' => '<a class="sfx" href="http://example.com">Find full text or request</a>')
       expect(results['response']['docs'][3]).to include('fulltext_link_html' => '<a data-turbolinks="false" href="/articles/pdfyyy/pdf/fulltext">View/download PDF</a>')
     end
   end

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -64,7 +64,7 @@ describe SearchWorksRecordMailer do
       end
 
       it 'includes links to fulltext' do
-        expect(mail.body).to have_link('Find it in print', href: "http://example.com")
+        expect(mail.body).to have_link('Find full text or request', href: "http://example.com")
       end
     end
 

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe EdsLinks do
 
     it 'handles View request options' do
       document['eds_fulltext_links'].first['label'] = 'View request options'
-      expect(document.eds_links.all.first.text).to eq('Find it in print or via interlibrary services')
+      expect(document.eds_links.all.first.text).to eq('Find full text or request')
     end
 
     it 'handles Open Access' do

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'articles/access_panels/_online.html.erb' do
     end
 
     it 'includes label icon' do
-      expect(rendered).to have_css('.panel-body ul li a.sfx', text: /^Find it in print/)
+      expect(rendered).to have_css('.panel-body ul li a.sfx', text: /^Find full text or request/)
     end
   end
 end


### PR DESCRIPTION
Closes #1784 

This PR changes "Find it in print or via interlibrary services" to "Find full text or request".

## Before
![request_options_before](https://user-images.githubusercontent.com/5402927/30458609-2ee45bf8-9961-11e7-94b0-49666ab8e9fb.png)

## After
![request_options_after](https://user-images.githubusercontent.com/5402927/30458569-026cd910-9961-11e7-97ce-b87a5e7ee475.png)
