### PR TITLE
Refactor render_fulltext_link into a presenter

### DIFF
--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -94,14 +94,6 @@ module ArticleHelper
     end.flatten
   end
 
-  def render_fulltext_link(link, document)
-    if link.href == 'detail'
-      link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false })
-    else
-      link_to(link.text, link.href, class: link.ill? ? 'sfx' : '')
-    end
-  end
-
   private
 
   RELATOR_TERMS = %w[Author Originator]

--- a/app/presenters/article_fulltext_link_presenter.rb
+++ b/app/presenters/article_fulltext_link_presenter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+##
+# A presenter class handle the logic to render markup for fulltext links from EDS
+class ArticleFulltextLinkPresenter
+  delegate :article_url, :article_fulltext_link_url, :link_to, :image_tag, to: :context
+  def initialize(document:, context:)
+    @document = document
+    @context = context
+  end
+
+  def links
+    return [] unless online_access_panel? || document_has_fulltext?
+    return access_panel_links.map { |link| render_fulltext_link(link) } if online_access_panel?
+    ["#{online_label} #{link_to('View on detail page', article_url(document))}"]
+  end
+
+  private
+
+  attr_reader :document, :context
+
+  def online_label
+    "<span class='online-label'>Full text</span>"
+  end
+
+  def online_access_panel?
+    document.access_panels.online?
+  end
+
+  def access_panel_links
+    document.access_panels.online.links || []
+  end
+
+  def document_has_fulltext?
+    document.html_fulltext? && !online_access_panel?
+  end
+
+  def render_fulltext_link(link)
+    if link.href == 'detail' # PDFs
+      detail_link_markup(link)
+    elsif link.ill?
+      link_to(link.text, link.href, class: 'sfx')
+    else
+      "#{online_label} #{link_to(link.text, link.href)}"
+    end
+  end
+
+  def detail_link_markup(link)
+    <<-HTML
+      #{online_label}
+      #{(link_to('View on detail page', article_url(document)) if document_has_fulltext?)}
+      #{image_tag('pdf-icon.svg', height: '20px', alt: 'PDF')}
+      #{link_to(link.text, article_fulltext_link_url(id: document.id, type: link.type), data: { 'turbolinks' => false })}
+    HTML
+  end
+end

--- a/app/views/articles/_index_default.html.erb
+++ b/app/views/articles/_index_default.html.erb
@@ -37,27 +37,8 @@
 
 <% if !document.eds_restricted? %>
   <ul class='document-metadata dl-horizontal dl-invert'>
-    <% if document.access_panels.online? %>
-      <% document.access_panels.online.links.each do |link| %>
-        <li>
-        <% if link.href == 'detail' # PDFs %>
-          <span class="online-label">Full text</span>
-          <%= link_to('View on detail page',article_path(document)) unless !document.html_fulltext? %>
-          <%= image_tag("pdf-icon.svg", height: "20px", alt: "PDF") %>
-          <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
-        <% elsif link.ill? -%>
-          <%= link_to(link.text, link.href, class: 'sfx') %>
-        <% else %>
-          <span class="online-label">Full text</span>
-          <%= link_to(link.text, link.href) %>
-        <% end %>
-        </li>
-      <% end %>
-    <% elsif document.html_fulltext? # HTML fulltext only %>
-      <li>
-        <span class="online-label">Full text</span>
-        <%= link_to('View on detail page',article_path(document)) %>
-      </li>
+    <% ArticleFulltextLinkPresenter.new(document: document, context: self).links.each do |link| %>
+      <li><%= link.html_safe %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/articles/access_panels/_online.html.erb
+++ b/app/views/articles/access_panels/_online.html.erb
@@ -8,7 +8,11 @@
     <ul class='document-metadata dl-horizontal dl-invert'>
       <% document.access_panels.online.links.each do |link| %>
         <li>
-          <%= render_fulltext_link(link, document) %>
+          <% if link.href == 'detail' %>
+            <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
+          <% else %>
+            <%= link_to(link.text, link.href, class: link.ill? ? 'sfx' : '') %>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/articles/index.json.jbuilder
+++ b/app/views/articles/index.json.jbuilder
@@ -1,7 +1,7 @@
 docs = @presenter.documents.collect do |document|
-  link = document.eds_links.all.first # top priority one only
+  link = ArticleFulltextLinkPresenter.new(document: document, context: self).links.try(:first) # top priority one only
   data = document.to_h # avoids deprecation warning
-  data['fulltext_link_html'] = render_fulltext_link(link, document) if link.present?
+  data['fulltext_link_html'] = link if link.present?
   data
 end
 json.response do

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -152,10 +152,14 @@ feature 'Article Searching' do
       stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit articles_path(q: 'kittens', format: 'json')
       results = JSON.parse(page.body)
-      expect(results['response']['docs'][0]).not_to include('fulltext_link_html')
-      expect(results['response']['docs'][1]).to include('fulltext_link_html' => '<a class="" href="http://example.com">View full text</a>')
-      expect(results['response']['docs'][2]).to include('fulltext_link_html' => '<a class="sfx" href="http://example.com">Find full text or request</a>')
-      expect(results['response']['docs'][3]).to include('fulltext_link_html' => '<a data-turbolinks="false" href="/articles/pdfyyy/pdf/fulltext">View/download PDF</a>')
+      expect(Capybara.string(results['response']['docs'][0]['fulltext_link_html'])).to have_link('View on detail page')
+      expect(Capybara.string(results['response']['docs'][1]['fulltext_link_html'])).to have_link('View full text')
+
+      expect(
+        Capybara.string(results['response']['docs'][2]['fulltext_link_html'])
+      ).to have_link('Find full text or request')
+
+      expect(Capybara.string(results['response']['docs'][3]['fulltext_link_html'])).to have_link('View/download PDF')
     end
   end
 

--- a/spec/presenters/article_fulltext_link_presenter_spec.rb
+++ b/spec/presenters/article_fulltext_link_presenter_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ArticleFulltextLinkPresenter do
+  let(:context) do
+    Class.new do
+      include Rails.application.routes.url_helpers
+      include ActionView::Helpers::UrlHelper
+
+      # mapping this to path for tests so
+      # we don't have to provide a host
+      def article_url(args)
+        article_path(args)
+      end
+    end.new
+  end
+
+  let(:document) { SolrDocument.new }
+  subject(:presenter) { described_class.new(document: document, context: context) }
+
+  describe '#links' do
+    context 'when the document does not have links' do
+      it 'is an empty array' do
+        expect(presenter.links).to eq([])
+      end
+    end
+
+    context 'when the document has link' do
+      let(:document) do
+        SolrDocument.new(
+          'eds_fulltext_links' => [
+            { 'label' => 'Check SFX for full text', 'url' => 'http://example.com', 'type' => 'customlink-fulltext' }
+          ]
+        )
+      end
+
+      it 'includes a rendered link representing that data' do
+        expect(presenter.links.length).to eq 1
+        link = Capybara.string(presenter.links.first)
+
+        expect(link).to have_css('span.online-label', text: 'Full text')
+        expect(link).to have_link('View on content provider\'s site', href: 'http://example.com')
+      end
+    end
+
+    context 'when the document does not have a link but does include full-text' do
+      let(:document) { SolrDocument.new(id: 'abc123', 'eds_html_fulltext_available' => true) }
+
+      it 'includes a link to the document to view the full text' do
+        expect(presenter.links.length).to eq 1
+        link = Capybara.string(presenter.links.first)
+
+        expect(link).to have_css('span.online-label', text: 'Full text')
+        expect(link).to have_link('View on detail page', href: '/articles/abc123')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors `render_fulltext_link` into a presenter as well as changes the functionality to handle the links that are presented on the search result instead of what's on the record view.

This change is necessary for the bento app (and referenced in sul-dlss/sul-bento-app#57).