### PR TITLE
Redirect to the home page with a flash alert with an empty query…

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,6 +8,12 @@ class ArticlesController < ApplicationController
   include EmailValidation
   include BackendLookup
 
+  rescue_from 'EBSCO::EDS::BadRequest' do |exception|
+    raise exception if params[:q].present?
+    flash[:alert] = 'An empty search is not possible in articles+. Enter a keyword to start your search.'
+    redirect_back fallback_location: articles_path
+  end
+
   before_action :set_search_query_modifier, only: :index
 
   before_action :eds_init, only: %i[index show]

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe ArticlesController do
       get :index
       expect(response).to render_template('index')
     end
+
+    context 'when a query causes an EDS error' do
+      before { stub_article_service(type: :error, docs: []) }
+      context 'with an empty query' do
+        it 'sets a flash error and redirects' do
+          get :index, params: { q: '' }
+
+          expect(flash[:alert]).to eq(
+            'An empty search is not possible in articles+. Enter a keyword to start your search.'
+          )
+
+          expect(response).to redirect_to(articles_path)
+        end
+      end
+
+      context 'with a query' do
+        it 'raises the error' do
+          expect do
+            get :index, params: { q: 'A query' }
+          end.to raise_error(EBSCO::EDS::BadRequest)
+        end
+      end
+    end
   end
 
   context '#show' do

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -65,6 +65,8 @@ module StubArticleService
       allow_any_instance_of(Eds::Repository).to receive(:find).and_return(
         StubArticleResponse.new([docs.first])
       )
+    when :error
+      allow_any_instance_of(Eds::Repository).to receive(:search).and_raise(EBSCO::EDS::BadRequest)
     else
       raise "Unknown article stub type #{type} provided."
     end


### PR DESCRIPTION
…causes EDS to throw an error.

Closes #1752 

<img width="1240" alt="empty-query-alert" src="https://user-images.githubusercontent.com/96776/30505702-3fadc76a-9a2b-11e7-9c95-557710382656.png">
