### PR TITLE
Use absolute URLs for article icons

### DIFF
--- a/app/presenters/article_fulltext_link_presenter.rb
+++ b/app/presenters/article_fulltext_link_presenter.rb
@@ -3,7 +3,7 @@
 ##
 # A presenter class handle the logic to render markup for fulltext links from EDS
 class ArticleFulltextLinkPresenter
-  delegate :article_url, :article_fulltext_link_url, :link_to, :image_tag, to: :context
+  delegate :article_url, :article_fulltext_link_url, :link_to, :image_tag, :image_url, to: :context
   def initialize(document:, context:)
     @document = document
     @context = context
@@ -49,7 +49,7 @@ class ArticleFulltextLinkPresenter
     <<-HTML
       #{online_label}
       #{(link_to('View on detail page', article_url(document)) if document_has_fulltext?)}
-      #{image_tag('pdf-icon.svg', height: '20px', alt: 'PDF')}
+      #{image_tag(image_url('pdf-icon.svg'), height: '20px', alt: 'PDF')}
       #{link_to(link.text, article_fulltext_link_url(id: document.id, type: link.type), data: { 'turbolinks' => false })}
     HTML
   end


### PR DESCRIPTION
Closes #1796 and fixes sul-dlss/sul-bento-app#68 once deployed to production.

This PR uses absolute URLs for the article brief view PDF icon. 
![pdf-icon](https://user-images.githubusercontent.com/5402927/30659801-cb30c3ca-9df3-11e7-869c-93dd2dec589c.png)

## Before
`<img height="20px" alt="PDF" src="/assets/pdf-icon-32b0b2f9280075f9a41fbf98446d3ed2a53cad1271f3bfec84029861f8e78b94.svg">`

## After
`<img height="20px" alt="PDF" src="http://localhost:3000/assets/pdf-icon-32b0b2f9280075f9a41fbf98446d3ed2a53cad1271f3bfec84029861f8e78b94.svg">`


