### PR TITLE
Update how document links are generated in SMS records.

### DIFF
--- a/app/views/record_mailer/sms_record.text.erb
+++ b/app/views/record_mailer/sms_record.text.erb
@@ -1,4 +1,8 @@
 <% # Overridden from Blacklight to create Bit.ly urls %>
 <% @documents.each do |document| %>
-<%= SmsPresenter.new(document, polymorphic_url(document, @url_gen_params)).sms_content %>  
+<%= SmsPresenter.new(
+      document,
+      url_for(@url_gen_params.merge((@url_gen_params[:_recall] || {}).merge(id: @documents.first.id, action: :show)))
+    ).sms_content
+%>
 <% end %>

--- a/spec/mailers/record_mailer_spec.rb
+++ b/spec/mailers/record_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Testing Blacklight's RecordMailer because we override sms_record.text.erb
+describe RecordMailer do
+  let(:documents) { [SolrDocument.new(id: 'abc')] }
+  let(:url_gen_params) { { host: 'example.com' } }
+
+  describe 'SMS' do
+    subject(:mailer) do
+      described_class.sms_record(documents, {}, url_gen_params)
+    end
+
+    context 'when an item is an article' do
+      before { url_gen_params[:_recall] = { controller: 'articles' } }
+
+      it 'links to /articles/:id' do
+        expect(mailer.body.to_s).to match(%r{/articles/abc})
+      end
+    end
+
+    context 'when the item is from the catalog' do
+      before { url_gen_params[:_recall] = { controller: 'catalog' } }
+
+      it 'links to /view/:id' do
+        expect(mailer.body.to_s).to match(%r{/view/abc})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1747 

## edsgin__edsgcl 488780295
<img width="466" alt="edsgin__edsgcl 488780295-sms" src="https://user-images.githubusercontent.com/96776/30661223-286ae3a0-9df8-11e7-934f-50e8dce3d8a9.png">

## 9857307
<img width="472" alt="9857307-sms" src="https://user-images.githubusercontent.com/96776/30661224-288d730c-9df8-11e7-9ab3-1d83ab02b616.png">
