### PR TITLE
Don't display article metadata for restricted articles.

### DIFF
--- a/app/views/articles/_show_default.html.erb
+++ b/app/views/articles/_show_default.html.erb
@@ -1,3 +1,5 @@
+<% return if document.eds_restricted? %>
+
 <% mini_map_sections = {} %>
 
 <div class="article-record-metadata row">

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -150,4 +150,25 @@ feature 'Article Record Display' do
       end
     end
   end
+
+  context 'when a document is restricted' do
+    let(:document) do
+      SolrDocument.new(
+        id: 'abc123',
+        'eds_title' => 'This title is unavailable for guests, please login to see more information.',
+        'eds_publication_type' => 'Metadata Content'
+      )
+    end
+
+    it 'does not render metadata' do
+      visit article_path(document[:id])
+
+      expect(page).to have_css(
+        'h1',
+        text: 'This title is not available for guests. Log in to see the title and access the article.'
+      )
+      expect(page).not_to have_css('.article-record-metadata')
+      expect(page).not_to have_content('Metadata Content')
+    end
+  end
 end


### PR DESCRIPTION
Closes #1758 

## eoh__1643501 (before)
<img width="1188" alt="eoh__1643501-before" src="https://user-images.githubusercontent.com/96776/30711545-edb8d4bc-9ebd-11e7-8d38-e9500b11d094.png">

## eoh__1643501 (after)
<img width="1204" alt="eoh__1643501-after" src="https://user-images.githubusercontent.com/96776/30711544-eda664b2-9ebd-11e7-913d-a9172d7c1999.png">

