### PR TITLE
Enable bento links

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -5,10 +5,6 @@
   }
 }
 
-.bento-search-panel {
-  display: none;
-}
-
 .article-home-page {
   .home-settings {
     label {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,10 +109,10 @@ module ApplicationHelper
   end
 
   def link_to_bento_search
-    mapped_params = { q: params[:q] }
+    query_string = params[:q].present? ? "?#{{ q: params[:q] }.to_query}" : nil
     link_to(
       t('searchworks.search_dropdown.bento.description_html'),
-      'https://library.stanford.edu/all'
+      "https://library.stanford.edu/all/#{query_string}"
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -108,11 +108,11 @@ module ApplicationHelper
     )
   end
 
-  # TODO: add bento link, see issue #1695
   def link_to_bento_search
+    mapped_params = { q: params[:q] }
     link_to(
       t('searchworks.search_dropdown.bento.description_html'),
-      'https://library.stanford.edu/'
+      'https://library.stanford.edu/all'
     )
   end
 

--- a/app/views/catalog/_search_targets_widget.html.erb
+++ b/app/views/catalog/_search_targets_widget.html.erb
@@ -11,12 +11,15 @@
       <span class="caret"></span>
     </h1>
   </a>
-   <ul class="dropdown-menu" role="menu">
-     <li class="<%= 'active' unless article_search? %>">
-       <%= link_to_catalog_search %>
-     </li>
-     <li class="<%= 'active' if article_search? %>">
-       <%= link_to_article_search %>
-     </li>
+  <ul class="dropdown-menu" role="menu">
+    <li>
+      <%= link_to_bento_search %>
+    </li>
+    <li class="<%= 'active' unless article_search? %>">
+      <%= link_to_catalog_search %>
+    </li>
+    <li class="<%= 'active' if article_search? %>">
+      <%= link_to_article_search %>
+    </li>
   </ul>
 </div>

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -43,7 +43,7 @@
     <div class="col-md-12 home-page-bento bento-search-panel">
       <div class="panel panel-default">
         <div class="panel-body text-center">
-          <h3><%= link_to 'All of the above', root_path %></h3>
+          <h3><%= link_to 'All of the above', 'https://library.stanford.edu/all' %></h3>
           <p class="hidden-xs">Get an overview of what’s available in all these sources for your search topic.</p>
         </div>
       </div>

--- a/app/views/shared/_search_context_sidebar.html.erb
+++ b/app/views/shared/_search_context_sidebar.html.erb
@@ -10,7 +10,6 @@
           <%= link_to_article_search %>
         <% end %>
         <%= link_to_library_website_search %>
-        <%# TODO: add bento search, issue #1695 %>
         <%= link_to_bento_search %>
       </div>
     </div>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -14,7 +14,7 @@ feature 'Article Searching' do
         expect(page).to have_css('li.active', text: /catalog/)
         expect(page).not_to have_css('li.active a', text: /articles/)
 
-        click_link 'articles'
+        click_link 'articles+'
       end
 
       expect(page).to have_current_path(articles_path) # the landing page for Article Search

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -30,7 +30,9 @@ feature "Home Page" do
     expect(page).to have_css(".navbar-text.search-target", text: "catalog")
   end
   scenario "there should be no more link on any facets" do
-    expect(page).to_not have_css('a', text: /more/)
+    within ('.home-page-facets') do
+      expect(page).to_not have_css('a', text: /more/)
+    end
   end
   scenario "should have the library facet hidden by default", js: true do
     within(".blacklight-building_facet") do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -152,12 +152,14 @@ describe ApplicationHelper do
     end
   end
 
-  # TODO: Add bento search link, see issue #1695
   describe '#link_to_bento_search' do
     subject(:result) { Capybara.string(helper.link_to_bento_search) }
-    xit 'passes query to bento search params' do
-      params[:q] = 'my query'
-      expect(result).to have_link(text: /all/ )
+    it 'passes query to bento search params' do
+      controller.params = { q: 'my query' }
+      expect(result).to have_link(
+        text: /all/,
+        href: 'https://library.stanford.edu/all/?q=my+query'
+      )
     end
   end
 

--- a/spec/views/shared/_home_page_bento.html.erb_spec.rb
+++ b/spec/views/shared/_home_page_bento.html.erb_spec.rb
@@ -14,6 +14,11 @@ describe 'shared/_home_page_bento.html.erb' do
       expect(rendered).to have_css('h3', text: 'Catalog')
       expect(rendered).not_to have_css('h3 a', text: 'Catalog')
     end
+
+    it 'links to Bento section' do
+      render
+      expect(rendered).to have_css('h3', text: 'All of the above')
+    end
   end
 
   context 'articles controller' do
@@ -28,6 +33,11 @@ describe 'shared/_home_page_bento.html.erb' do
       render
       expect(rendered).to have_css('h3', text: 'Articles+')
       expect(rendered).not_to have_css('h3 a', text: 'Articles+')
+    end
+
+    it 'links to Bento section' do
+      render
+      expect(rendered).to have_css('h3', text: 'All of the above')
     end
   end
 end


### PR DESCRIPTION
Closes #1695 

This PR:
- directs 'All' links to https://library.stanford.edu/all" and passes simple search queries
- adds 'All' to the search dropdown
- adds 'All of the above' search to home page mini bento

## Homepage mini bento
### Before
![mini_bento_before](https://user-images.githubusercontent.com/5402927/30718715-a830c2ac-9ed5-11e7-8cfa-684603406815.png)
### After
![mini_bento_after](https://user-images.githubusercontent.com/5402927/30718718-a838885c-9ed5-11e7-8279-87c889cf0093.png)

## Search context dropdown
### Before
![search_dropdown_before](https://user-images.githubusercontent.com/5402927/30718716-a8339ae0-9ed5-11e7-8fa8-ef266aaccf00.png)
### After
![search_dropdown_after](https://user-images.githubusercontent.com/5402927/30721032-e4a0f618-9ede-11e7-82e9-f4f6777f0da8.png)
