### PR TITLE
Update translation for location code RET-REF

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -538,7 +538,7 @@ module Constants
     'RESEARCH' => 'Research',
     'RESERVES' => 'Reserves',
     'RESV-DESKS' => 'Ask at circulation desk',
-    'RET-REF' => 'Reference',
+    'RET-REF' => 'Retired Reference',
     'ROB-STOR' => 'Robinson Collection',
     'ROBINSON' => 'Robinson Collection',
     'RUM-LOAN' => 'In Map Center: Ask at service desk',


### PR DESCRIPTION
Closes #1633 

This PR changes the translation for the `RET-REF` location from "Reference" to "Retired Reference".