### PR TITLE
Only notify HB of full text link errors when the user is not a guest.

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -185,7 +185,7 @@ class ArticlesController < ApplicationController
     url = extract_fulltext_link(document, params[:type])
     redirect_to url if url.present?
   rescue => e
-    Honeybadger.notify(e) if defined? Honeybadger
+    Honeybadger.notify(e) if defined?(Honeybadger) && !session['eds_guest']
     flash[:error] = flash_message_for_link_error
     redirect_back fallback_location: articles_path
   end

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe ArticlesController do
           expect(error_message).to have_content('Log in to try the download again')
           expect(response).to have_http_status(:found) # redirects back
         end
+
+        it 'does not send an exception to Honeybadger (because this can be expected)' do
+          expect(Honeybadger).not_to receive(:notify)
+
+          get :fulltext_link, params: { id: '123', type: :pdf }
+        end
       end
 
       context 'when the user is not in guest mode' do
@@ -86,6 +92,12 @@ RSpec.describe ArticlesController do
           expect(error_message).to have_content 'We don\'t know the source of the error.'
           expect(error_message).to have_css('a', text: 'please report it as a connection problem')
           expect(response).to have_http_status(:found) # redirects back
+        end
+
+        it 'sends and exception notification' do
+          expect(Honeybadger).to receive(:notify)
+
+          get :fulltext_link, params: { id: '123', type: :pdf }
         end
       end
     end


### PR DESCRIPTION
An error can be expected to be thrown in the case of a guest user (due to data that EDS returns).

Fixes #1765 