### PR TITLE
Remove comma from homepage bento Articles section

### DIFF
--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -15,7 +15,7 @@
         <div class="panel-body">
           <%= image_tag 'homepage/articles.jpg' %>
           <h3><%= link_to_unless article_search?, 'Articles+', articles_path %></h3>
-          <p class="hidden-xs">Search a combined index of 100s of databases, and connect directly to the article or resource.</p>
+          <p class="hidden-xs">Search a combined index of 100s of databases and connect directly to the article or resource.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
A little typo fix requested by @snydman and @jkeck.

## Before
![typo](https://user-images.githubusercontent.com/5402927/31145293-3560c210-a838-11e7-93da-b71c046aa891.png)

>Search a combined index of 100s of databases, and connect directly to the article or resource.

## After
![fixed](https://user-images.githubusercontent.com/5402927/31145299-3a13f2e6-a838-11e7-923e-e65d5326c90b.png)

>Search a combined index of 100s of databases and connect directly to the article or resource.