### PR TITLE
Switch from using jQuery.text() to jQuery.html() when replacing…

### DIFF
--- a/app/assets/javascripts/backend_lookup.js
+++ b/app/assets/javascripts/backend_lookup.js
@@ -30,9 +30,9 @@ Blacklight.onLoad(function(){
     }
 
     function updateLink(count, el){
-      var linkText = $(el).text();
+      var linkText = $(el).html();
       linkText += "... <strong>found " + count + " results</strong>";
-      $(el).html(linkText)
+      $(el).html(linkText);
     }
     Plugin.prototype = {
 

--- a/spec/features/zero_results_spec.rb
+++ b/spec/features/zero_results_spec.rb
@@ -37,6 +37,14 @@ feature "Zero results" do
     end
   end
 
+  scenario 'it does not replace query string in a way that will execute js', js: true do
+    expect do
+      accept_alert do
+        visit '/?f[building_facet][]=Engineering (Terman)&search_field=title&q=><script>alert%28"BAD%20JUJU"%29<%2Fscript>'
+      end
+    end.to raise_error(Capybara::ModalNotFound)
+  end
+
   context 'article search' do
     before { stub_article_service(docs: []) }
 


### PR DESCRIPTION
… backend lookup link content.

### Given the following example:
```javascript
var linkContent = "&gt;&lt;script&gt;alert(&quot;BAD JUJU&quot;)&lt;/script&gt;";
var $linkNode = $('<span>' + linkContent + '</span>');
var newLinkContent = $linkNode.text();
newLinkContent += ' other string';
$linkNode.html(); // Does not include unescaped javascript
$linkNode.html(newLinkContent);
$linkNode.html(); // Includes unescaped javascript
```

Using `var newLinkContent = $linkNode.html();` instead of of `var newLinkContent = $linkNode.text();` (effectively what this PR does) maintains the escaped javascript after rendering to the page.