### PR TITLE
Sanitize summaries in search results.

### DIFF
--- a/app/views/catalog/_accordion_section_summary.html.erb
+++ b/app/views/catalog/_accordion_section_summary.html.erb
@@ -8,10 +8,10 @@
       <span class="glyphicon glyphicon-chevron-right"></span>
     </button>
     <div class="snippet <%= id %>-summary-snippet" data-behavior="trunk8">
-      <%= summary_data %>
+      <%= sanitize summary_data %>
     </div>
     <div class="details <%= id %>-summary" aria-expanded="false">
-      <%= summary_data %>
+      <%= sanitize summary_data %>
     </div>
   </div>
 

--- a/spec/views/catalog/_accordion_section_summary.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_summary.html.erb_spec.rb
@@ -4,6 +4,12 @@ describe "catalog/_accordion_section_summary.html.erb" do
   include MarcMetadataFixtures
   include ModsFixtures
 
+  it 'sanitizes summary content' do
+    allow(view).to receive(:document).and_return(SolrDocument.new(summary_display: ['Text <br> needs to be sanitized']))
+    render
+    expect(rendered).to have_css('.accordion-section.summary .snippet', text: /Text  needs to be sanitized/)
+  end
+
   describe "Index Summary" do
     summary_text = 'Nunc venenatis et odio ac elementum. Nulla ornare faucibus laoreet. Nullam tincidunt a nisi eu pretium'
 


### PR DESCRIPTION
This was being caused by data in the summary.

## Before
<img width="790" alt="dataset-old" src="https://user-images.githubusercontent.com/96776/37735087-3b5b4c60-2d0a-11e8-9fde-70811bbb46d6.png">


## After <img width="808" alt="dataset-new" src="https://user-images.githubusercontent.com/96776/37735088-3b71670c-2d0a-11e8-94a9-4490ddc9a70e.png">
