### PR TITLE
Trap and return early when itemsRow is NaN or 0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
       rails (> 3.2.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     parslet (1.8.0)
     poltergeist (1.17.0)

--- a/app/assets/javascripts/jquery.preview-gallery.js
+++ b/app/assets/javascripts/jquery.preview-gallery.js
@@ -121,6 +121,16 @@
         var previewDivs = $('.preview-container');
         var previewIndex = previewDivs.index($previewTarget) + 1;
         $itemsPerRow = itemsPerRow();
+        /* 
+        / If $itemsPerRow is NaN or 0 we should return here. If not we are going 
+        / to have a bad time with an infinite while loop. This only manifests
+        / on the show page when using the "back" button to get back to a show
+        / page using the browse nearby feature.
+        */
+        if ($itemsPerRow === NaN || $itemsPerRow === 0) {
+          return;
+        }
+
         if (previewIndex % $itemsPerRow !== 0){
           while (previewIndex % $itemsPerRow !== 0){
             previewIndex++;


### PR DESCRIPTION
Fixes an issue where when navigating off a show page and then pressing
back instantiates the previewGallery, causing an infinite loop which
will crash the browser.