### PR TITLE
Update Yewno proxy link

### DIFF
--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -33,7 +33,7 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/yewno.jpg' %>
-          <h3><%= link_to 'Yewno', 'https://stanford.idm.oclc.org/login?url=https://yewno.com/edu' %></h3>
+          <h3><%= link_to 'Yewno', 'https://stanford.idm.oclc.org/login?url=https://discover.yewno.com' %></h3>
           <p class="hidden-xs">Explore concepts and connections, and understand interdisciplinary subjects, in a graph interface.</p>
         </div>
       </div>


### PR DESCRIPTION
Fixes #1866 

This PR updates our Yewno proxy link after a change in their domain name structure.

From the Yewno team:
> How long do I have to update my yewno.com/edu instances and widget to discover.yewno.com on my website or other locations?
> 
> We will guide users to discover.yewno.com for up to 30 days, but you should update your instances as soon as possible to mitigate any gap in coverage when the 30-day date is reached.
> 
> Do I have to whitelist the new discover.yewno.com domain name? 
> a. If you previously whitelisted *yewno.com, then no, you do not have to whitelist the new domain name. If you previously whitelisted yewno.com/edu, then yes, you have to whitelist the new discover.yewno.com domain name.