### PR TITLE
Don't allow the FixtureIndexer to run unless the collection we are…

### DIFF
--- a/lib/fixtures_indexer.rb
+++ b/lib/fixtures_indexer.rb
@@ -6,16 +6,35 @@ class FixturesIndexer
   include Marc856Fixtures
   include MarcMetadataFixtures
   include ModsFixtures
+
   def self.run
     FixturesIndexer.new.run
   end
+
   def initialize
+    validate!
+
     @solr = Blacklight.default_index.connection
   end
+
+  def validate!
+    return true if configured_solr_wrapper_collection == configured_blacklight_collection
+
+    raise(
+      ArgumentError,
+      <<-LONGTEXT.strip_heredoc
+        You are trying to index to the "#{configured_blacklight_collection}" collection,
+        which is not the same as what is configured in .solr_wrapper.yml (#{configured_solr_wrapper_collection}).
+        You may be running the inexer against a remote collection, which is not advisable.
+      LONGTEXT
+    )
+  end
+
   def run
     index
     commit
   end
+
   def fixtures
     @fixtures ||= file_list.map do |file|
       fixture_template = ERB.new(File.read(file))
@@ -23,15 +42,26 @@ class FixturesIndexer
       YAML::load rendered_template
     end
   end
+
   def file_list
     @file_list ||= Dir["#{Rails.root}/spec/fixtures/solr_documents/*.yml"]
   end
 
   private
+
   def index
     @solr.add fixtures
   end
+
   def commit
     @solr.commit
+  end
+
+  def configured_solr_wrapper_collection
+    SolrWrapper.instance.config.options[:collection]['name']
+  end
+
+  def configured_blacklight_collection
+    Blacklight.default_index.connection.uri.path.match(%r{/([\w+-]+)/?$}).captures.first
   end
 end


### PR DESCRIPTION
…indexing to is the same as what is configured in .solr_wrapper.yml.

¯\\_(ツ)_/¯ Up for alternate solutions here.