### PR TITLE
Upgrade to EDS v1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'jquery-datatables-rails'
 gem 'roadie-rails', '~> 1.1'
 gem 'rubocop', '~> 0.36'
 gem 'rack-utf8_sanitizer'
-gem 'ebsco-eds', '0.3.19.pre' # Pin to 0.3.19.pre to fix an error in prod for now.
+gem 'ebsco-eds', '1.0.1' # External vendor, upgrade requires testing
 gem 'whenever' # manages cron jobs
 gem 'bitly' # For bit.ly
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-logic (~> 0.4, >= 0.4.0)
       dry-types (~> 0.13.1)
-    ebsco-eds (0.3.19.pre)
+    ebsco-eds (1.0.1)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)
@@ -573,7 +573,7 @@ DEPENDENCIES
   devise-guests
   devise-remote-user
   dlss-capistrano
-  ebsco-eds (= 0.3.19.pre)
+  ebsco-eds (= 1.0.1)
   faraday (~> 0.10)
   font-awesome-rails
   honeybadger (~> 3.0)


### PR DESCRIPTION
Closes #1950 🤞

See: https://github.com/ebsco/edsapi-ruby/commit/813110c43e20320aab1e53ce8769ba8a1b74d089

We'll want to deploy to stage first and test this out. We'll be discussing release management and GitHub workflow at our next meeting with EBSCO.