### PR TITLE
Restore A-Z filter for Databases masthead + update styling

### DIFF
--- a/app/assets/stylesheets/modules/mastheads.scss
+++ b/app/assets/stylesheets/modules/mastheads.scss
@@ -15,7 +15,46 @@
     }
   }
 
-  p a, li a {
-    font-size: 1.1em;
+  .flexgrid {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    margin: 10px 0;
+
+    .col {
+      border-left: 3px $beige-30-percent solid;
+      flex: 1;
+      margin-left: 10px;
+      padding: 10px;
+      a {
+        display: block;
+      }
+    }
+
+    div:first-of-type {
+      margin-left: 0;
+    }
+  }
+
+  @media only screen and (max-width: 576px) {
+    .flexgrid {
+      flex-direction: column;
+
+      .col {
+        a {
+          font-size: 1.4em;
+        }
+      }
+
+      div:first-of-type {
+        margin-left: 10px;
+      }
+    }
+  }
+
+  .database-prefix {
+    h2 {
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,7 +5,22 @@ class SearchBuilder < Blacklight::SearchBuilder
   include CJKQuery
 
   self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
+  self.default_processor_chain += [:database_prefix_search]
   self.default_processor_chain += [:modify_params_for_cjk, :modify_params_for_cjk_advanced]
+
+  def database_prefix_search(solr_params)
+    if page_location.access_point.databases? && blacklight_params[:prefix]
+      if blacklight_params[:prefix] == "0-9"
+        query = ("0".."9").map do |number|
+          "title_sort:#{number}*"
+        end.join(" OR ")
+      else
+        query = "title_sort:#{blacklight_params[:prefix]}*"
+      end
+      solr_params[:qt] = blacklight_config.lucene_req_handler
+      solr_params[:q] = [query, blacklight_params[:q]].compact.join(" AND ")
+    end
+  end
 
   def modifiable_params_keys
     %w[q search search_author search_title subject_terms series_search pub_search isbn_search]

--- a/app/views/catalog/_database_prefix.html.erb
+++ b/app/views/catalog/_database_prefix.html.erb
@@ -1,0 +1,12 @@
+<div class="database-prefix">
+  <ul class="pagination">
+    <li class="<%= 'active' unless params[:prefix] %>">
+      <%= link_to "Show all", params.merge(prefix: nil, page: nil)  %>
+    </li>
+    <% facets_prefix_options.each do |prefix_option| %>
+      <li class="<%= 'active' if params[:prefix] == prefix_option.downcase %>">
+        <%= link_to prefix_option, params.merge(prefix: prefix_option.downcase, page: nil) %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/catalog/_database_prefix.html.erb
+++ b/app/views/catalog/_database_prefix.html.erb
@@ -1,4 +1,5 @@
 <div class="database-prefix">
+  <h2>Filter by database title</h2>
   <ul class="pagination">
     <li class="<%= 'active' unless params[:prefix] %>">
       <%= link_to "Show all", params.merge(prefix: nil, page: nil)  %>

--- a/app/views/catalog/mastheads/_databases.html.erb
+++ b/app/views/catalog/mastheads/_databases.html.erb
@@ -1,13 +1,20 @@
 <div id="masthead-container">
   <div id="masthead" class="databases-masthead">
     <h1>Databases</h1>
+    <p>Find a topic-specific database for in-depth research.</p>
     <p>Licensed resources are for the non-profit educational use of Stanford University. Use of these resources is governed by copyright law and individual license agreements. Systematic downloading, distributing, or retaining substantial portions of information is prohibited.</p>
-    <p>
-      <%= link_to "Selected article databases", selected_databases_path %> |
-      <%= link_to "Find articles", "https://library.stanford.edu/guides/find-articles" %> |
-      <%= link_to "Connect from off campus", "https://library.stanford.edu/using/connect-campus" %> |
-      <%= link_to "Report a connection problem", "https://library.stanford.edu/ask/email/connection-problems" %>
-    </p>
+    <div class="flexgrid">
+      <div class="col">
+        <%= link_to 'Articles+', articles_path %> <span>Search a combined index of 100s of databases.</span>
+      </div>
+      <div class="col">
+        <%= link_to 'Selected article databases', selected_databases_path %> <span>Not sure where to start? Try one of these.</span>
+      </div>
+      <div class="col">
+        <%= link_to 'Connecting to e-resources', 'https://library.stanford.edu/using/connecting-e-resources' %>
+        <%= link_to 'Report a connection problem', 'https://library.stanford.edu/ask/email/connection-problems' %>
+      </div>
+    </div>
     <%= render "catalog/database_prefix" %>
   </div>
 </div>

--- a/app/views/catalog/mastheads/_databases.html.erb
+++ b/app/views/catalog/mastheads/_databases.html.erb
@@ -8,5 +8,6 @@
       <%= link_to "Connect from off campus", "https://library.stanford.edu/using/connect-campus" %> |
       <%= link_to "Report a connection problem", "https://library.stanford.edu/ask/email/connection-problems" %>
     </p>
+    <%= render "catalog/database_prefix" %>
   </div>
 </div>

--- a/app/views/catalog/mastheads/_selected_databases.html.erb
+++ b/app/views/catalog/mastheads/_selected_databases.html.erb
@@ -1,14 +1,18 @@
 <div id="masthead-container">
   <div id="masthead" class="selected-databases-masthead">
     <h1>Selected article databases</h1>
-    <ul>
-      <li>
-        See our guides about <a href="https://library.stanford.edu/guides/find-articles">finding articles</a>, <a href="https://library.stanford.edu/guides/find-newspapersnewspaper-articles">newspapers</a>, and <a href="https://library.stanford.edu/guides/find-online-reference">reference information</a>.
-      </li>
-      <li>
-        For more specific resources, see the Subject pages associated with our <a href="https://library.stanford.edu/people">Subject Librarians</a>.
-      </li>
-    </ul>
-    <p class="inline-links"><%= link_to "All databases", databases_path %> | <%= link_to "Connect from off campus", "https://library.stanford.edu/using/connect-campus" %> | <%= link_to "Report a connection problem", "https://library.stanford.edu/ask/email/connection-problems" %></p>
+    <p>Start your research with one of our selected databases below. <%= link_to 'Learn more about finding articles.', 'https://library.stanford.edu/guides/find-articles' %></p>
+    <div class="flexgrid">
+      <div class="col">
+        <%= link_to 'Articles+', articles_path %> <span>Search a combined index of 100s of databases.</span>
+      </div>
+      <div class="col">
+        <%= link_to 'Databases', databases_path %> <span>Find a topic-specific database for in-depth research.</span>
+      </div>
+      <div class="col">
+        <%= link_to 'Connecting to e-resources', 'https://library.stanford.edu/using/connecting-e-resources' %>
+        <%= link_to 'Report a connection problem', 'https://library.stanford.edu/ask/email/connection-problems' %>
+      </div>
+    </div>
   </div>
 </div>

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -8,8 +8,8 @@ feature "Databases Access Point" do
     expect(page).to have_title("Databases in SearchWorks catalog")
     within("#masthead") do
       expect(page).to have_css("h1", text: "Databases")
-      expect(page).to have_css("a", text: "Find articles")
-      expect(page).to have_css("a", text: "Connect from off campus")
+      expect(page).to have_css("a", text: "Articles+")
+      expect(page).to have_css("a", text: "Connecting to e-resources")
       expect(page).to have_css("a", text: "Report a connection problem")
     end
   end
@@ -22,7 +22,7 @@ feature "Databases Access Point" do
     end
   end
   scenario "database topics should be present" do
-    expect(page).to have_css('dt', text: "Database topics")
+    expect(page).to have_css('dt', text: "Database topic")
     expect(page).to have_css('dd a', text: "Biology")
   end
 

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -25,4 +25,15 @@ feature "Databases Access Point" do
     expect(page).to have_css('dt', text: "Database topics")
     expect(page).to have_css('dd a', text: "Biology")
   end
+
+  scenario 'databases should be able to be prefix filtered' do
+    expect(page).to have_css('h2', text: '8 catalog results')
+
+    within '.database-prefix' do
+      click_link 'S'
+    end
+
+    expect(page).to have_css('h2', text: '4 catalog results')
+    expect(page).to have_css('h3', text: /Selected Database \d/, count: 4)
+  end
 end

--- a/spec/features/access_points/selected_databases_spec.rb
+++ b/spec/features/access_points/selected_databases_spec.rb
@@ -8,8 +8,9 @@ feature "Selected Databases Access Point" do
     expect(page).to have_title("Databases in SearchWorks catalog")
     within("#masthead") do
       expect(page).to have_css("h1", text: "Selected article databases")
-      expect(page).to have_css("a", text: "All databases")
-      expect(page).to have_css("a", text: "Connect from off campus")
+      expect(page).to have_css("a", text: "Articles+")
+      expect(page).to have_css("a", text: "Databases")
+      expect(page).to have_css("a", text: "Connecting to e-resources")
       expect(page).to have_css("a", text: "Report a connection problem")
     end
   end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -5,10 +5,35 @@ describe SearchBuilder do
   let(:blacklight_params) { {} }
   let(:solr_params) { {} }
   let(:scope) { double(blacklight_config: CatalogController.blacklight_config)}
-
+  
   before do
     # silly hack to avoid refactoring these tests
     allow(blacklight_params).to receive(:dup).and_return(blacklight_params)
+  end
+  
+  describe "#database_prefix_search" do
+    before do
+      allow(search_builder).to receive(:page_location).and_return(instance_double(SearchWorks::PageLocation, access_point: double(databases?: true)))
+    end
+    it "should handle 0-9 filters properly" do
+      blacklight_params[:prefix] = "0-9"
+      search_builder.database_prefix_search(solr_params)
+      (0..9).to_a.each do |number|
+        expect(solr_params[:q]).to match /title_sort:#{number}\*/
+      end
+      expect(solr_params[:q]).to match /^title_sort:0\*.*title_sort:9\*$/
+    end
+    it "should handle alpha filters properly" do
+      blacklight_params[:prefix] = "B"
+      search_builder.database_prefix_search(solr_params)
+      expect(solr_params[:q]).to eq "title_sort:B*"
+    end
+    it "should AND user supplied queries" do
+      blacklight_params[:prefix] = "B"
+      blacklight_params[:q] = "My Query"
+      search_builder.database_prefix_search(solr_params)
+      expect(solr_params[:q]).to eq "title_sort:B* AND My Query"
+    end
   end
 
   describe "advanced search" do


### PR DESCRIPTION
Closes #1658

This PR:
- Partially reverts #1953 and restores the A - Z filter for Databases (see discussion with @jvine in #1658)
- Updates text and styling for the [Databases](https://searchworks.stanford.edu/databases) and [Selected Databases](https://searchworks.stanford.edu/selected_databases) mastheads

<img width="323" alt="selected_databases_mobile" src="https://user-images.githubusercontent.com/5402927/45911545-a5a61000-bdc9-11e8-9549-180d1c9cb29f.png">
<img width="999" alt="selected_databases_wide" src="https://user-images.githubusercontent.com/5402927/45911546-a5a61000-bdc9-11e8-91bd-952422cf489f.png">
<img width="318" alt="databases_mobile" src="https://user-images.githubusercontent.com/5402927/45911547-a5a61000-bdc9-11e8-8717-2f1d29081ac1.png">
<img width="1188" alt="databses_wide" src="https://user-images.githubusercontent.com/5402927/45911548-a5a61000-bdc9-11e8-80d3-f4870d6390f2.png">

