### PR TITLE
Add the find it @ Stanford link to the online panel when an SFX link …

### DIFF
--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -19,10 +19,14 @@
     <% if document.access_panels.sfx? %>
       <% sfx_url = document.access_panels.sfx.links.first.href %>
       <% # Intentionally not encoding sfx_url here as the URLs from the catalog appear to already be encoded %>
-      <div data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: sfx_url) %>">
+      <div class='sfx-panel' data-behavior="sfx-panel" data-sfx-url="<%= sfx_data_path(url: sfx_url) %>">
         <div data-behavior="sfx-panel-body">
           <div class='loading-spinner'></div>
         </div>
+
+        <%= link_to(SfxData.url_without_sid(sfx_url)) do %>
+          See the full <span class='sfx-emphasis'>find it @ Stanford</span> menu
+        <% end %>
       </div>
 
       <% # duplicating this ul w/ the Google link until we get an answer on if it is okay to surpress it for SFX items %>

--- a/spec/features/access_panels/online_spec.rb
+++ b/spec/features/access_panels/online_spec.rb
@@ -53,6 +53,8 @@ feature "Online Access Panel" do
             expect(page).to have_css('li ul li', text: 'Statement 1')
             expect(page).to have_css('li ul li', text: 'Statement 2')
           end
+
+          expect(page).to have_link('See the full find it @ Stanford menu')
         end
       end
     end

--- a/spec/views/catalog/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_online.html.erb_spec.rb
@@ -35,6 +35,7 @@ describe "catalog/access_panels/_online.html.erb" do
         expect(rendered).to     have_css('.panel-online')
         expect(rendered).to_not have_link('Find full text')
         expect(rendered).to     have_css('[data-behavior="sfx-panel"]')
+        expect(rendered).to     have_link('See the full find it @ Stanford menu')
       end
     end
 


### PR DESCRIPTION
…is present.

Fixes #1977 

## Local fixture 57
_Note: Ignore the `Unable to connect to SFX` text.  This is because the local fixture points to a non-existent SFX url._
<img width="519" alt="fixture 57" src="https://user-images.githubusercontent.com/96776/46024165-0d46ae80-c09b-11e8-83b5-8a48b66598d2.png">
