### PR TITLE
use Google web font loader to reduce render blocking script and preve…

### DIFF
--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -21,8 +21,6 @@
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= stylesheet_link_tag 'print', media: 'print' %>
     <link href="https://www.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
-    <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" %>
-    <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Crimson+Text:400" %>
     <%= javascript_include_tag "application" %>
     <!--[if lte IE 8]><%= javascript_include_tag 'flot/excanvas.min' %><![endif]-->
     <%= csrf_meta_tags %>
@@ -99,5 +97,17 @@
         })();
       </script>
     <% end %>
+    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
+    <script>
+      WebFont.load({
+        google: {
+          families: ['Source Sans Pro:300,400,700', 'Crimson Text:400']
+        }
+      });
+    </script>
+    <noscript>
+      <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" %>
+      <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Crimson+Text:400" %>
+    </noscript>
   </body>
 </html>


### PR DESCRIPTION
…nt FOIT

In working on https://github.com/sul-dlss/searchworks-status/pull/79 it seems that Google has a newish web font loader aimed to preventing [FOIT](https://css-tricks.com/fout-foit-foft/).