### PR TITLE
Title sort Database A-Z filter results

### DIFF
--- a/app/views/catalog/_database_prefix.html.erb
+++ b/app/views/catalog/_database_prefix.html.erb
@@ -6,7 +6,7 @@
     </li>
     <% facets_prefix_options.each do |prefix_option| %>
       <li class="<%= 'active' if params[:prefix] == prefix_option.downcase %>">
-        <%= link_to prefix_option, params.merge(prefix: prefix_option.downcase, page: nil) %>
+        <%= link_to prefix_option, params.merge(prefix: prefix_option.downcase, page: nil,sort: 'title') %>
       </li>
     <% end %>
   </ul>

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -35,5 +35,9 @@ feature "Databases Access Point" do
 
     expect(page).to have_css('h2', text: '4 catalog results')
     expect(page).to have_css('h3', text: /Selected Database \d/, count: 4)
+
+    within '#sort-dropdown' do
+      expect(page).to have_content('Sort by title')
+    end
   end
 end


### PR DESCRIPTION
Fixes #1978 🤞

After #1953 was merged, the default sort for the `/databases` page is relevance.
This PR explicitly adds a `&sort=title` param to the `/databases` A-Z filter links.

## Before
[Stage](https://searchworks-stage.stanford.edu/catalog?utf8=%E2%9C%93&f%5Bformat_main_ssim%5D%5B%5D=Database&prefix=c&search_field=search&q=government) (Relevance sort by default) - `/?f%5Bformat_main_ssim%5D%5B%5D=Database&prefix=c`

## After
Local dev - `/?f%5Bformat_main_ssim%5D%5B%5D=Database&prefix=c&sort=title`