### PR TITLE
Remove word "links" from the email form

### DIFF
--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -3,7 +3,7 @@
   <div class="form-group">
     <% unless controller.controller_name == 'articles' # TODO: full record for articles %>
       <div class="col-sm-10 col-sm-offset-2">
-        <%= radio_button_tag :type, 'brief', true %> <%= label_tag(:type_brief,  "<strong>Brief record</strong> (title, library & call number, links, bookmark)".html_safe) %><br/>
+        <%= radio_button_tag :type, 'brief', true %> <%= label_tag(:type_brief,  "<strong>Brief record</strong> (title, library & call number, bookmark)".html_safe) %><br/>
         <%= radio_button_tag :type, 'full' %> <%= label_tag(:type_full, "<strong>Full record</strong>".html_safe) %>
       </div>
     <% end %>


### PR DESCRIPTION
Fixes #1993