### PR TITLE
Only use WebFont loader if it is available.

### DIFF
--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -108,11 +108,13 @@
     <% end %>
     <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
     <script>
-      WebFont.load({
-        google: {
-          families: ['Source Sans Pro:300,400,700', 'Crimson Text:400']
-        }
-      });
+      if(typeof(WebFont) !== 'undefined') {
+        WebFont.load({
+          google: {
+            families: ['Source Sans Pro:300,400,700', 'Crimson Text:400']
+          }
+        });  
+      }
     </script>
     <noscript>
       <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" %>


### PR DESCRIPTION
I'm seeing some failing tests locally w/o this.