### PR TITLE
Use the date_range from the EDS response when the pub year field is…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+- Fixed a bug in Article Search where the date slider facet would disappear for some Databases [#1721](https://github.com/sul-dlss/SearchWorks/issues/1721)
 ### Security
 
 ## [3.3.3] - 2018-09-26

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -23,7 +23,7 @@ module Eds
         results = eds_session.solr_retrieve_list(list: bl_params['q']['id'])
       else
         # Regular search
-        results = eds_session.search(bl_params).to_solr
+        results = eds_results_with_date_range(eds_session.search(bl_params).to_solr)
       end
       blacklight_config.response_model.new(results,
                                            bl_params,
@@ -40,6 +40,22 @@ module Eds
                                            params,
                                            document_model: blacklight_config.document_model,
                                            blacklight_config: blacklight_config)
+    end
+
+    # Some data providers in EDS don't have the data that populates the pub_year_tisim field
+    # (although we can query against the data), so this forces the pub_year_tisim field to be populated
+    # when the response from EDS still contains date range data.
+    # https://github.com/sul-dlss/SearchWorks/issues/1721
+    def eds_results_with_date_range(results)
+      return results if results.dig('facet_counts', 'facet_fields', 'pub_year_tisim').present?
+      return results unless results.key?('date_range')
+
+      results['facet_counts']['facet_fields']['pub_year_tisim'] = [
+        results['date_range'][:minyear],
+        results['date_range'][:maxyear]
+      ]
+
+      results
     end
   end
 end


### PR DESCRIPTION
…not available.

Closes #1721 

## Before
<img width="953" alt="before" src="https://user-images.githubusercontent.com/96776/46125220-ff00ab80-c1dc-11e8-8691-671872877678.png">

## After
<img width="849" alt="after" src="https://user-images.githubusercontent.com/96776/46125295-569f1700-c1dd-11e8-89fb-f089a048d55a.png">

