### PR TITLE
Add a rake task to copy CJK tokenizer to local solr instance and use …

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You will need to update the configuration in `config/settings.yml` for various p
 
 Start Solr
 
-To start Solr, you can use the `solr_wrapper` command. However, if starting from a fresh instance, you may first need to run `rake searchworks:install` or `rake ci` so that the CJK tokenizer gets copied into the appropriate directory.
+To start Solr, you can use the `solr_wrapper` command. However, if starting from a fresh instance, you may first need to run `rake searchworks:install` or `rake ci` so that the CJK tokenizer gets copied into the appropriate directory.  There is also a separate task (`rake searchworks:copy_solr_dependencies`) available if you find that you need to clean solr and the CJK tokenizer is getting removed.
 
     $ solr_wrapper
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ task :ci => [:environment] do
 
     Rake::Task["db:migrate"].invoke
     SolrWrapper.wrap do |solr|
-      FileUtils.cp File.join(__dir__, 'config', 'solr_configs', 'CJKFilterUtils-v2.1.jar'), File.join(solr.instance_dir, 'contrib')
+      Rake::Task['searchworks:copy_solr_dependencies'].invoke
       solr.with_collection(name: 'blacklight-core') do
         Rake::Task["searchworks:fixtures"].invoke
         Rake::Task["searchworks:spec:without-data-integration"].invoke


### PR DESCRIPTION
…that in the two places we were previously calling a copy command directly.

Feel free to take it or leave it.  I was finding that I was ending up in a state where the CJK tokenizer was no longer available and solr_wrapper would bork.  I can run `searchworks:install` but that unnecessarily indexes fixtures (although in our SolrWrapper world, that task is effectively useless anyway). 🤷‍♂️  This way there is at least a targeted task, and we don't have the tokenizer copy logic/knowledge in two places. 