### PR TITLE
add styling and sanitzing for mhld display styles

### DIFF
--- a/app/assets/stylesheets/modules/librarian-view.scss
+++ b/app/assets/stylesheets/modules/librarian-view.scss
@@ -1,0 +1,3 @@
+#marc_view .field {
+  word-break: break-all;
+}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -40,6 +40,7 @@
 @import 'modules/image-collection-filmstrip';
 @import 'modules/image-icons';
 @import 'modules/item-preview';
+@import 'modules/librarian-view';
 @import 'modules/license-icons';
 @import 'modules/managed_purl_panel';
 @import 'modules/mastheads';

--- a/lib/holdings/mhld.rb
+++ b/lib/holdings/mhld.rb
@@ -48,7 +48,7 @@ class Holdings
     end
 
     def sanitize_mhld_data(data)
-      CGI.escape_html(data).gsub('),', '), ').gsub('-', '-<wbr/>').html_safe if data.present?
+      CGI.escape_html(data).gsub('),', '), ').gsub(/,\s?/, ', ').gsub('-', '-<wbr/>').html_safe if data.present?
     end
   end
 end

--- a/spec/lib/holdings/mhld_spec.rb
+++ b/spec/lib/holdings/mhld_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Holdings::MHLD do
   let(:mhld_display) { 'GREEN -|- STACKS -|- mhld public note -|- mhld library has -|- mhld latest received' }
-  let(:special_mhld) { 'GREEN -|- STACKS -|- (public),(note) -|- library-has-with-hyphens and <html> entities -|- ' }
+  let(:special_mhld) { 'GREEN -|- STACKS -|- (public),(note),no.17,no.14 -|- library-has-with-hyphens and <html> entities -|- ' }
   let(:zombie_mhld) { 'PHYSICS -|- STACKS -|- mhld public note -|- mhld library has -|- mhld latest received' }
 
   it 'should return the correct elements from the MHLD combined field' do
@@ -22,6 +22,10 @@ describe Holdings::MHLD do
 
   it "should replace '),(' with '), ('" do
     expect(Holdings::MHLD.new(special_mhld).public_note).to match(/\), \(/)
+  end
+
+  it "should replace ',' with ', '" do
+    expect(Holdings::MHLD.new(special_mhld).public_note).to match(/no\.17, no\.14/)
   end
 
   it 'should append <wbr/> to hyphens' do


### PR DESCRIPTION
Fixes #2021 in a two-prong approach.

### CKEY 8838463

Uses preferred approach for access panel styling:

![screen shot 2018-10-08 at 9 02 46 am](https://user-images.githubusercontent.com/1656824/46617002-f2cbf680-cad8-11e8-8e92-488264b2f18d.png)

Uses preferred approach for librarian view as I suspect we do not want to sanitize this data:

![screen shot 2018-10-08 at 9 03 36 am](https://user-images.githubusercontent.com/1656824/46617049-0ecf9800-cad9-11e8-8b33-4836d3e12cd8.png)
