### PR TITLE
Add system status link to feedback form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Adds links to the SearchWorks status dashboard [#2027](https://github.com/sul-dlss/SearchWorks/pull/2027)
+- Adds links to the SearchWorks status dashboard [#2027](https://github.com/sul-dlss/SearchWorks/pull/2027) [#2032](https://github.com/sul-dlss/SearchWorks/pull/2032)
 ### Changed
 - Changed the way that bound with items are displayed. Bound with call numbers are removed from search results. On a show page, the notes are formatted in a more pleasant way while the live lookup data information is removed. [#1345](https://github.com/sul-dlss/SearchWorks/pull/1345)
 - Changes the "zero results" page in the following ways: change copy of headings, simplifies formatting of list elements, adds mini-bento search results for alternate search backends, adds more options for search results, moves the chat link and adds live hours. [#2014](https://github.com/sul-dlss/SearchWorks/pull/2014)

--- a/app/assets/stylesheets/modules/feedback-form.scss
+++ b/app/assets/stylesheets/modules/feedback-form.scss
@@ -1,5 +1,9 @@
 .librarian-chat{
-  padding-bottom: 30px;
+  padding-bottom: 25px;
+}
+
+.check-status {
+  padding-bottom: 25px;
 }
 
 .quick-report{
@@ -8,8 +12,6 @@
 
 .btn-quick-report{
   white-space: normal;
-  max-width: 100px;
-  font-size: $font-size-small;
 }
 
 .cancel-link .btn .btn-link {
@@ -19,6 +21,11 @@
 
 #feedback-form{
   border-bottom: 3px solid $sul-toolbar-border;
+  margin-top: 25px;
+
+  div.col-sm-4 {
+    margin-top: 25px;
+  }
 }
 
 .feedback-alert {

--- a/app/assets/stylesheets/modules/image-icons.scss
+++ b/app/assets/stylesheets/modules/image-icons.scss
@@ -11,6 +11,7 @@
 
 .image-icon-message-available {
   background-image: asset-url('message-available.png');
+  vertical-align: bottom;
 }
 
 .image-icon-ask-us {

--- a/app/views/shared/feedback_forms/_chat_with_librarian.html.erb
+++ b/app/views/shared/feedback_forms/_chat_with_librarian.html.erb
@@ -1,9 +1,6 @@
 <div class="librarian-chat">
-  <p>
-    Need help right now?
-  </p>
   <div data-library-h3lp data-jid="ic@chat.libraryh3lp.com">
-    <span class="image-icon image-icon-message-away"></span>
     <%= link_to "Chat with a librarian", "https://library.stanford.edu/ask" %>
+    <span class="image-icon image-icon-message-away"></span>
   </div>
 </div>

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -9,6 +9,9 @@
   </div>
   <div class="col-sm-4">
     <%= render "shared/feedback_forms/chat_with_librarian" if on_campus_or_su_affiliated_user? %>
+    <div class="check-status">
+      <%= link_to 'Check system status', 'http://searchworks-status.stanford.edu' %>
+    </div>
     <%= render "shared/quick_reports/form", layout: nil %>
   </div>
 </div>


### PR DESCRIPTION
Fixes #2032 

This PR adds adds a link to the Searchworks status dashboard to the feedback form. Minor styling and wording changes are included as well.

## No chat, results view (one link)
<img width="634" alt="logged_out" src="https://user-images.githubusercontent.com/5402927/46694786-96dd9c80-cbc2-11e8-8987-cde37591ba34.png">

## All three options (user is on campus or logged in, record view)
<img width="785" alt="logged_in_single_record" src="https://user-images.githubusercontent.com/5402927/46694788-96dd9c80-cbc2-11e8-8abc-29fe81408698.png">

## No chat, record view (link + button)
<img width="638" alt="logged_out_single_record" src="https://user-images.githubusercontent.com/5402927/46695537-aeb62000-cbc4-11e8-90a3-7ff35d170115.png">




