### PR TITLE
move away from mods parsing in search results

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -62,7 +62,8 @@ module RecordHelper
     link_to(name, search_catalog_path(q: "\"#{name}\"", search_field: 'search_author'))
   end
 
-  # We need this to remove the ending ":" from the role labels
+  # We need this to remove the ending ":" from the role labels only in data from
+  # mods_display
   def sanitize_mods_name_label(label)
     label.sub(/:$/, '')
   end

--- a/app/models/concerns/mods_data.rb
+++ b/app/models/concerns/mods_data.rb
@@ -17,4 +17,18 @@ module ModsData
     return nil unless self["modsxml"]
     @prettified_mods ||= CodeRay::Duo[:xml, :div].highlight(self["modsxml"]).html_safe
   end
+
+  ##
+  # Convenience accessors and parsers for mods_display content already indexed
+
+  ##
+  # A ModsDisplay::Values object dumped while indexing. The object is needed
+  # as there is there is some necessary display logic.
+  def mods_display_name
+    fetch(:author_struct, [])
+  end
+
+  def mods_abstract
+    fetch(:summary_display, [])
+  end
 end

--- a/app/views/catalog/_mods_search_results_document_fields.html.erb
+++ b/app/views/catalog/_mods_search_results_document_fields.html.erb
@@ -3,8 +3,13 @@
     <% if document[:vern_title_display].present? %>
       <li><%= document[:vern_title_display].html_safe %></li>
     <% end %>
-
-    <% if document.mods.name.present? && document.mods.name.first.values.present? %>
+    <% if document.mods_display_name.present? %>
+      <li>
+        <% name = document.mods_display_name.first %>
+        <%= link_to_mods_name(name['link']) %> <%= name['post_text'] %>
+      </li>
+      <%# TODO: Remove this elsif block after new mods index is in place %>
+    <% elsif document.mods.name.present? && document.mods.name.first.values.present? %>
       <li>
         <% name = document.mods.name.first %>
         <%= link_to_mods_name(name.values.first) %> (<%= sanitize_mods_name_label(name.label) %>)

--- a/app/views/catalog/_summary_data.html.erb
+++ b/app/views/catalog/_summary_data.html.erb
@@ -44,13 +44,16 @@
     <% end %>
   <% end %>
 
-<% elsif document.respond_to?(:mods) && document.mods.present? %>
-  <% if document.mods.abstract.present? %>
-    <%= document.mods.abstract.map(&:values).join('<br/>').html_safe %>
-  <% end %>
+<% elsif document.mods_abstract.present? %>
+    <%= document.mods_abstract.join('<br/>').html_safe %>
 
 <% elsif document[:summary_display].present? %>
   <div>
     <%= document[:summary_display].join('<br/>').html_safe %>
   </div>
+<%# TODO: Remove this elsif block after new mods index is in place %>
+<% elsif document.respond_to?(:mods) && document.mods.present? %>
+  <% if document.mods.abstract.present? %>
+    <%= document.mods.abstract.map(&:values).join('<br/>').html_safe %>
+  <% end %>
 <% end %>

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -869,6 +869,7 @@
         author_meeting_display,       vern_author_meeting_display,
         author_person_display,        vern_author_person_display,
         author_person_full_display,   vern_author_person_full_display,
+        author_struct:[json],
         bookplates_display,
         collection,
         collection_type,

--- a/spec/fixtures/solr_documents/31.yml
+++ b/spec/fixtures/solr_documents/31.yml
@@ -11,3 +11,5 @@
 :pub_date: 2010
 :beginning_year_isi: 2010
 :imprint_display: 2010
+:summary_display:
+  - Nunc venenatis et odio ac elementum. Nulla ornare faucibus laoreet

--- a/spec/fixtures/solr_documents/47.yml
+++ b/spec/fixtures/solr_documents/47.yml
@@ -3,3 +3,8 @@
 :format_main_ssim: "Archive/Manuscript"
 :modsxml: <%= mods_everything %>
 :collection_type: Digital Collection
+:author_struct:
+  - '{"link":"J. Smith","search":"\"J. Smith\"","post_text":"(Author)"}'
+  - '{"link":"B. Smith","search":"\"B. Smith\"","post_text":"(Producer)"}'
+:summary_display:
+  - This collection of Virtual Objects is really important.

--- a/spec/views/catalog/_index_mods.html.erb_spec.rb
+++ b/spec/views/catalog/_index_mods.html.erb_spec.rb
@@ -10,7 +10,11 @@ describe "catalog/_index_mods.html.erb" do
         collection_with_title: ['12345 -|- Collection Title'],
         modsxml: mods_everything,
         physical: ["The Physical Extent"],
-        imprint_display: ["Imprint Statement"]
+        imprint_display: ["Imprint Statement"],
+        author_struct: [
+          { 'link' => 'J. Smith', 'search' => '"J. Smith"', 'post_text' => '(Author)' },
+          { 'link' => 'B. Smith', 'search' => '"B. Smith"', 'post_text' => '(Producer)' },
+        ]
       )
     )
     expect(view).to receive(:show_presenter).and_return(presenter)

--- a/spec/views/catalog/_index_mods_collection.html.erb_spec.rb
+++ b/spec/views/catalog/_index_mods_collection.html.erb_spec.rb
@@ -7,7 +7,11 @@ describe "catalog/_index_mods_collection.html.erb" do
       SolrDocument.new(
         id: 'abc123',
         modsxml: mods_everything,
-        physical: ["The Physical Extent"]
+        physical: ["The Physical Extent"],
+        author_struct: [
+          { 'link' => 'J. Smith', 'search' => '"J. Smith"', 'post_text' => '(Author)' },
+          { 'link' => 'B. Smith', 'search' => '"B. Smith"', 'post_text' => '(Producer)' },
+        ]
       )
     )
     render

--- a/spec/views/preview/_show_mods.html.erb_spec.rb
+++ b/spec/views/preview/_show_mods.html.erb_spec.rb
@@ -12,7 +12,12 @@ describe "preview/_show_mods.html.erb" do
     display_type: ["image"],
     item_display: [ "123 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123" ],
     isbn_display: [ 123 ],
-    imprint_display: ["Imprint Statement"]
+    imprint_display: ["Imprint Statement"],
+    author_struct: [
+      { 'link' => 'J. Smith', 'search' => '"J. Smith"', 'post_text' => '(Author)' },
+      { 'link' => 'B. Smith', 'search' => '"B. Smith"', 'post_text' => '(Producer)' },
+    ],
+    summary_display: ['Nunc venenatis et odio ac elementum. Nulla ornare faucibus laoreet']
   ) }
 
   before do


### PR DESCRIPTION
In conjunction with https://github.com/sul-dlss/searchworks_traject_indexer/pull/224 this fixes #1987 

~~This approach could be controversial, so I'll outline my rationale:~~

~~To keep current functionality we would need to create/invent a custom data structure that should be understood by both the indexer and SearchWorks. This seemed potentially brittle given that the mods logic could change and without knowing if we have changing future requirements. Though this approach assumes that the content is indexed and displayed with the same version of the ModsDisplay gem.~~

~~If the ModsDisplay gem is updated in SearchWorks, the change will also need to happen in the indexer. Need to discuss w/ @jvine about the ModsDisplay updates and how the name may change.~~

## UPDATE 11/13/2018

This PR is updated now to be backwards compatible with an index that does not yet have the new fields. As these new fields are added, the view will look for those fields instead of parsing the mods. Finally, after the entire new index is in place, we can remove the TODO blocks.

Local example: http://127.0.0.1:3000/catalog?utf8=%E2%9C%93&search_field=search&q=47

![screen shot 2018-11-13 at 1 07 57 pm](https://user-images.githubusercontent.com/1656824/48440183-74045200-e745-11e8-9371-2a89feac7d70.png)
