### PR TITLE
do not show Google Books section if managed purls are present

### DIFF
--- a/app/views/catalog/_accordion_section_online.html.erb
+++ b/app/views/catalog/_accordion_section_online.html.erb
@@ -30,9 +30,11 @@
           </li>
         <% end %>
       <% end %>
-      <li class="google-books <%= css_class %>">
-        <a href="" class="full-view">Google Books (Full view)</a></li>
-      </li>
+      <% if document[:managed_purl_urls].blank? %>
+        <li class="google-books <%= css_class %>">
+          <a href="" class="full-view">Google Books (Full view)</a></li>
+        </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
@@ -4,29 +4,50 @@ describe "catalog/_accordion_section_online.html.erb" do
   include Marc856Fixtures
 
   describe "Accordion section - Online" do
-
-    before do
-      assign(:document,
-        SolrDocument.new(
-          id: "12345",
-          isbn_display: [ 123 ],
-          marcbib_xml: stanford_only_856
+    context 'regular sirsi record' do
+      before do
+        assign(:document,
+          SolrDocument.new(
+            id: "12345",
+            isbn_display: [ 123 ],
+            marcbib_xml: stanford_only_856
+          )
         )
-      )
-      render
-    end
+        render
+      end
 
-    it "should include the online accordion and text" do
-      expect(rendered).to have_css('.accordion-section.online')
-      expect(rendered).to have_css('.accordion-section.online button.header[aria-expanded="false"]', text: "Online")
-      expect(rendered).to have_css('.details[aria-expanded="false"] .google-books')
-      expect(rendered).to have_css('.details a', text: "Google Books (Full view)")
+      it "should include the online accordion and text" do
+        expect(rendered).to have_css('.accordion-section.online')
+        expect(rendered).to have_css('.accordion-section.online button.header[aria-expanded="false"]', text: "Online")
+        expect(rendered).to have_css('.details[aria-expanded="false"] .google-books')
+        expect(rendered).to have_css('.details a', text: "Google Books (Full view)")
+      end
+      it 'should include the first link in the snippet' do
+        expect(rendered).to have_css('.snippet span.stanford-only a', text: 'Link text', count: 1)
+      end
+      it "should include the links" do
+        expect(rendered).to have_css('ul.links span.stanford-only a', text: 'Link text', count: 4)
+      end
     end
-    it 'should include the first link in the snippet' do
-      expect(rendered).to have_css('.snippet span.stanford-only a', text: 'Link text', count: 1)
-    end
-    it "should include the links" do
-      expect(rendered).to have_css('ul.links span.stanford-only a', text: 'Link text', count: 4)
+    context 'managed purl record' do
+      before do
+        assign(
+          :document,
+          SolrDocument.new(
+            id: '12345',
+            isbn_display: [123],
+            marcbib_xml: many_managed_purl_856,
+            managed_purl_urls: [
+              'https://purl.stanford.edu/ct493wg6431',
+              'https://purl.stanford.edu/zg338xh5248'
+            ]
+          )
+        )
+        render
+      end
+      it 'does not display Google Books link' do
+        expect(rendered).not_to have_css '.details a', text: 'Google Books (Full view)'
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1945 

A good fixture search: http://127.0.0.1:3000/catalog?utf8=%E2%9C%93&search_field=search&q=9238380

The logic I'm using here based off of the linked tickets are whether or not the item has managed purls. Happy to add additional changes to that based off of any cases I may be missing.