### PR TITLE
Add optional OKComputer checks for New Relic performance alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Adds an OKComputer status check for degraded performance alerts from NewRelic (for the status dashboard) [#2051](https://github.com/sul-dlss/SearchWorks/pull/2051)
 ### Changed
 ### Removed
 ### Fixed

--- a/app/models/performance_alerts.rb
+++ b/app/models/performance_alerts.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class PerformanceAlerts
+  def initialize(policy_id:, http_client: Faraday, logger: Rails.logger)
+    @policy_id = policy_id
+    @http_client = http_client
+    @logger = logger
+  end
+
+  def open
+    alerts.select do |alert|
+      alert['opened_at'].present? && alert['closed_at'].blank?
+    end
+  end
+
+  class << self
+    alias for new
+  end
+
+  private
+
+  attr_reader :http_client, :logger, :policy_id
+
+  def alerts
+    violations.select do |violation|
+      violation.dig('links', 'policy_id').to_s == policy_id.to_s
+    end
+  end
+
+  def violations
+    @violations ||= begin
+                      JSON.parse(response)['violations'] || []
+                    rescue JSON::ParserError => e
+                      logger.warn("Unable to parse PerformanceCheck JSON with: #{e}")
+                      []
+                    end
+  end
+
+  def response
+    @response ||= begin
+                    connection.get do |req|
+                      req.url api_url
+                      req.headers['X-Api-Key'] = api_key
+                    end.body
+                  rescue Faraday::Error::ConnectionFailed => e
+                    logger.warn("PerformanceCheck API request failed with: #{e}")
+                    '{}'
+                  end
+  end
+
+  def connection
+    http_client.new
+  end
+
+  def api_url
+    settings.alert_url
+  end
+
+  def api_key
+    settings.api_key
+  end
+
+  def settings
+    Settings.NEW_RELIC_API
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,6 +47,13 @@ STANFORD_NETWORK:
   ranges: []
 BITLY:
   ACCESS_TOKEN: 'the_bitly_apikey'
+NEW_RELIC_API:
+  alert_url: 'https://api.newrelic.com/v2/alerts_violations.json'
+  api_key: the-api-key
+  policies:
+    - key: low_app_apdex_alert
+      label: application apdex low
+      id: 318894
 RECAPTCHA:
   SITE_KEY: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
   SECRET_KEY: 6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx

--- a/spec/models/performance_alerts_spec.rb
+++ b/spec/models/performance_alerts_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe PerformanceAlerts do
+  subject(:alerts) { described_class.new(policy_id: '12345') }
+
+  describe '#open' do
+    before do
+      expect(alerts).to receive(:violations).at_least(:once).and_return(
+        [
+          # Closed
+          {
+            'test_id' => '1',
+            'opened_at' => (Time.zone.now - 2.days).to_s,
+            'closed_at' => (Time.zone.now - 1.day).to_s,
+            'links' => { 'policy_id' => '12345' }
+          },
+          # Open
+          {
+            'test_id' => '2',
+            'opened_at' => Time.zone.now - 5.minutes,
+            'links' => { 'policy_id' => '12345' }
+          },
+          # Differnt policy id
+          {
+            'test_id' => '3',
+            'opened_at' => Time.zone.now - 10.minutes,
+            'links' => { 'policy_id' => 'not-the-right-id' }
+          }
+        ]
+      )
+    end
+
+    it 'is an array of open alerts that for the given policy' do
+      expect(alerts.open).to be_one
+      expect(alerts.open.first['test_id']).to eq '2'
+    end
+  end
+
+  describe 'errors' do
+    context 'when the API connection fails' do
+      let(:stub_http_client) do
+        Class.new do
+          def get(*)
+            raise Faraday::Error::ConnectionFailed, 'Raising a connection error from a test http client'
+          end
+        end
+      end
+
+      subject(:alerts) { described_class.new(policy_id: '12345', http_client: stub_http_client) }
+
+      it 'returns no alerts' do
+        expect(alerts.open).to be_blank
+      end
+    end
+
+    # We don't check in an API key so we should be getting a 401 from them by default
+    context 'when the API returns an unsuccessful response' do
+      it 'returns no alerts' do
+        expect(alerts.open).to be_blank
+      end
+    end
+
+    context 'when the API return unparsable JSON' do
+      before do
+        expect(alerts).to receive(:response).and_return('<html/>')
+      end
+
+      it 'returns no alerts' do
+        expect(alerts.open).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of sul-dlss/searchworks-status#5

If this seems reasonable, I'll submit a shared configs pr w/ the proper API key configured.

We can then add the relevant checks to the `searchworks-status` codebase to trigger the issue state for the appropriate services.