### PR TITLE
move refworks on showpage to use post form instead of callback url

### DIFF
--- a/app/assets/stylesheets/modules/record-toolbar.scss
+++ b/app/assets/stylesheets/modules/record-toolbar.scss
@@ -16,6 +16,21 @@
 
   .dropdown-menu {
     @include toolbar-dropdown;
+
+    .refworks {
+      padding: 3px 10px;
+
+      form a {
+        color: $dropdown-link-hover-color;
+
+        &:hover, &:focus, &:active {
+          text-decoration: none;
+        }
+      }
+      &:hover, &:focus, &:active {
+        background-color: $dropdown-link-hover-bg;
+      }
+    }
   }
 
   .record-toolbar-tools ul {

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -18,7 +18,11 @@
 <% end %>
 <% if @document.export_formats.keys.include?( :refworks_marc_txt ) %>
   <li class="refworks" role="presentation">
-    <%= link_to t('blacklight.tools.refworks_html'), refworks_export_url({url: polymorphic_url(url_for_document(@document), format: :refworks_marc_txt, only_path: false)})  %>
+    <%= form_tag(refworks_export_url) do %>
+      <% # TODO: Remove send when Blacklight::Marc exposes this as a public method %>
+      <%= content_tag(:input, nil, type: :hidden, name: :ImportData, value: @document.send(:export_as_refworks_marc_txt)) %>
+      <%= link_to t('blacklight.tools.refworks_html'), '', onclick: "event.preventDefault(); $(this).closest('form').submit();" %>
+    <% end %>
   </li>
 <% end %>
 <% if @document.export_formats.keys.include?( :endnote ) %>

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -19,7 +19,7 @@
 <% if @document.export_formats.keys.include?( :refworks_marc_txt ) %>
   <li class="refworks" role="presentation">
     <%= form_tag(refworks_export_url) do %>
-      <% # TODO: Remove send when Blacklight::Marc exposes this as a public method %>
+      <% # TODO: Remove send when Blacklight::Marc exposes this as a public method projectblacklight/blacklight-marc#64 %>
       <%= content_tag(:input, nil, type: :hidden, name: :ImportData, value: @document.send(:export_as_refworks_marc_txt)) %>
       <%= link_to t('blacklight.tools.refworks_html'), '', onclick: "event.preventDefault(); $(this).closest('form').submit();" %>
     <% end %>

--- a/spec/features/blacklight_customizations/record_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/record_toolbar_spec.rb
@@ -44,7 +44,7 @@ feature "Record Toolbar" do
     within '#content' do
       within 'div.navbar-collapse', visible: true do
         click_button 'Send to'
-        expect(page).to have_css('li a', text: 'RefWorks')
+        expect(page).to have_css('li form a', text: 'RefWorks')
         expect(page).to have_css('li a', text: 'EndNote')
       end
     end


### PR DESCRIPTION
This resolves an issue where RefWorks import failed on non-latin like
languages (e.g Russian, Sanskrit). Fixes #1944

### Fixtures to check (failures in current prod):
 - 12786465 Sanskrit
 - 12422691 Russian

One thing I have found is that some records will get imported into RefWorks, but the citation is kind of crappy. I think this is a different issue that could be addressed elsewhere.

![refworks](https://user-images.githubusercontent.com/1656824/47302919-e7e88a00-d5df-11e8-8a2f-ffd5269b9793.gif)
