### PR TITLE
add support for importing an Article record into RefWorks

### DIFF
--- a/app/models/concerns/eds_export.rb
+++ b/app/models/concerns/eds_export.rb
@@ -1,6 +1,6 @@
 module EdsExport
   def self.extended(document)
-    document.will_export_as(:ris)
+    document.will_export_as(:ris, 'application/x-research-info-systems')
   end
 
   def export_as_ris

--- a/app/models/concerns/eds_export.rb
+++ b/app/models/concerns/eds_export.rb
@@ -1,0 +1,9 @@
+module EdsExport
+  def self.extended(document)
+    document.will_export_as(:ris)
+  end
+
+  def export_as_ris
+    self['eds_citation_exports']&.select { |e| e['id'] == 'RIS' }&.first&.[]('data')
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -36,6 +36,7 @@ class SolrDocument
 
   include Blacklight::Solr::Document
   include SchemaDotOrg
+  include EdsExport
 
   delegate :empty?, :blank?, to: :to_h
 
@@ -55,6 +56,10 @@ class SolrDocument
   extension_parameters[:marc_format_type] = :marcxml
   use_extension( Blacklight::Solr::Document::Marc) do |document|
     document.key?( :marcxml  ) || document.key?( :marcbib_xml  )
+  end
+
+  use_extension(EdsExport) do |document|
+    document.key?(:eds_citation_exports) && document['eds_citation_exports']&.select { |e| e['id'] == 'RIS' }.any?
   end
 
   sw_field_semantics = {

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -32,6 +32,9 @@
       <%= link_to t('blacklight.tools.refworks_html'), '', onclick: "event.preventDefault(); $(this).closest('form').submit();" %>
     <% end %>
   </li>
+  <li class="ris" role="presentation">
+    <%= link_to t('blacklight.tools.ris_html'), articles_ris_path(@document, :format => 'ris') %>
+  </li>
 <% end %>
 <% if @document.export_formats.keys.include?( :endnote ) %>
   <li class="endnote" role="presentation">

--- a/app/views/shared/record/_record_toolbar_tools_subset.html.erb
+++ b/app/views/shared/record/_record_toolbar_tools_subset.html.erb
@@ -25,6 +25,14 @@
     <% end %>
   </li>
 <% end %>
+<% if @document.export_formats.key?(:ris) %>
+  <li class="refworks" role="presentation">
+    <%= form_tag(refworks_export_url(filter: 'RIS Format')) do %>
+      <%= content_tag(:input, nil, type: :hidden, name: :ImportData, value: @document.export_as_ris) %>
+      <%= link_to t('blacklight.tools.refworks_html'), '', onclick: "event.preventDefault(); $(this).closest('form').submit();" %>
+    <% end %>
+  </li>
+<% end %>
 <% if @document.export_formats.keys.include?( :endnote ) %>
   <li class="endnote" role="presentation">
     <%= link_to t('blacklight.tools.endnote_html'), solr_document_path(@document, :format => 'endnote') %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -56,6 +56,7 @@ en:
       email_html: '<span class="glyphicon glyphicon-envelope"></span> email'
       refworks_html: '<span class="glyphicon glyphicon-share-alt sul-icon-refworks"></span> RefWorks'
       endnote_html: '<span class="glyphicon glyphicon-share-alt sul-icon-endnote"></span> EndNote'
+      ris_html: '<span class="glyphicon glyphicon-download-alt"></span> RIS download'
       printer_html: '<span class="glyphicon glyphicon-print"></span> printer'
       cite_entries: '<i class="fa fa-quote-left"></i> Cite %{current_range}'
       send_entries: '<i class=" fa fa-share-alt"></i> Send %{current_range} to <span class="caret"></span>'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,8 @@ Rails.application.routes.draw do
       concerns :exportable
     end
 
+    get 'articles/:id/ris' => 'articles#show', as: :articles_ris, constraints: ->(req) { req.format = :ris }
+
     post 'articles/:id/track' => 'articles#track', as: :track_articles
     get 'articles/:id/:type/fulltext' => 'articles#fulltext_link', as: :article_fulltext_link, constraints: { type: /[-\w]+/ }
   end

--- a/spec/features/article_record_toolbar_spec.rb
+++ b/spec/features/article_record_toolbar_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 RSpec.describe 'Article Record Toolbar', js: true do
   let(:previous_document) { SolrDocument.new(id: 1, eds_title: 'My Prev Title') }
-  let(:document) { SolrDocument.new(id: 2, eds_title: 'My Title') }
+  let(:document) do
+    SolrDocument.new(
+      id: 2,
+      eds_title: 'My Title',
+      eds_citation_exports: [{ 'id' => 'RIS', 'data' => 'TI  - CatZ N Bagelz' }]
+    )
+  end
   let(:next_document) { SolrDocument.new(id: 3, eds_title: 'My Next Title') }
 
   before do
@@ -19,6 +25,7 @@ RSpec.describe 'Article Record Toolbar', js: true do
       expect(page).to have_css('.btn-sul-toolbar', text: 'Send to')
       expect(page).to have_css('.sms', text: 'text', visible: false)
       expect(page).to have_css('.email', text: 'email', visible: false)
+      expect(page).to have_css('.refworks', text: 'RefWorks', visible: false)
       expect(page).to have_css('a[role="menuitem"]', text: 'printer', visible: false)
     end
   end

--- a/spec/features/article_record_toolbar_spec.rb
+++ b/spec/features/article_record_toolbar_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Article Record Toolbar', js: true do
       expect(page).to have_css('.sms', text: 'text', visible: false)
       expect(page).to have_css('.email', text: 'email', visible: false)
       expect(page).to have_css('.refworks', text: 'RefWorks', visible: false)
+      expect(page).to have_css('.ris', text: 'RIS download', visible: false)
       expect(page).to have_css('a[role="menuitem"]', text: 'printer', visible: false)
     end
   end

--- a/spec/models/concerns/eds_export_spec.rb
+++ b/spec/models/concerns/eds_export_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe EdsExport do
+  let(:document) do
+    SolrDocument.new(
+      id: '123',
+      eds_citation_exports: [{ 'id' => 'RIS', 'data' => 'TI  - CatZ N Bagelz' }]
+    )
+  end
+  let(:empty_document) do
+    SolrDocument.new(id: '456', eds_citation_exports: [])
+  end
+
+  describe '#will_export_as' do
+    it 'true when RIS citation is present' do
+      expect(document.export_formats.key?(:ris)).to be true
+    end
+
+    it 'nil when RIS citation is not available' do
+      expect(empty_document.export_formats.key?(:ris)).to be false
+    end
+  end
+
+  describe '#export_as_ris' do
+    it 'returns data when RIS citation is present' do
+      expect(document.export_as_ris).to eq 'TI  - CatZ N Bagelz'
+    end
+
+    it 'returns nil when RIS citation is not available' do
+      expect(empty_document.export_as_ris).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2058 

TODO:
 - [x] Figure out exporting an EDS doc to endnote

If you have a zotero plugin (and assuming Endnote /shrug) it will pickup the export and import it in automagically for you :magic:

### A Good Fixture edsdoj__edsdoj.fbd174b2ea714450a9ea97fce058c880

![ris refworks](https://user-images.githubusercontent.com/1656824/47458540-08a71000-d797-11e8-9bc0-10d062b9b47b.gif)
