### PR TITLE
modify finding aid logic to support `ark:` with optional `findaid` fi…

### DIFF
--- a/app/models/concerns/index_links.rb
+++ b/app/models/concerns/index_links.rb
@@ -41,7 +41,7 @@ module IndexLinks
     end
 
     def link_is_finding_aid?(link_field)
-      link_field =~ %r{oac\.cdlib\.org\/findaid}
+      link_field =~ %r{oac\.cdlib\.org(\/findaid)?\/ark:}
     end
 
     def link_fields

--- a/spec/fixtures/solr_documents/29.yml
+++ b/spec/fixtures/solr_documents/29.yml
@@ -14,4 +14,4 @@
 :url_fulltext:
   - "https://purl.stanford.edu/29"
 :url_suppl:
-  - "http://oac.cdlib.org/findaid/something-else"
+  - "http://oac.cdlib.org/findaid/ark:/something-else"

--- a/spec/models/concerns/index_links_spec.rb
+++ b/spec/models/concerns/index_links_spec.rb
@@ -14,7 +14,12 @@ describe IndexLinks do
   end
   let(:finding_aid_document) do
     SolrDocument.new(
-      url_suppl: ['http://oac.cdlib.org/findaid/something-else']
+      url_suppl: ['http://oac.cdlib.org/findaid/ark:/something-else']
+    )
+  end
+  let(:finding_aid_document_alternate_format) do
+    SolrDocument.new(
+      url_suppl: ['http://oac.cdlib.org/ark:/abc123']
     )
   end
   let(:managed_purl_document) do
@@ -57,6 +62,7 @@ describe IndexLinks do
   describe 'SearchWorks::Links' do
     let(:index_links) { solr_document.index_links }
     let(:finding_aid_links) { finding_aid_document.index_links }
+    let(:finding_aid_links_alternate) { finding_aid_document_alternate_format.index_links }
     let(:managed_purl_links) { managed_purl_document.index_links }
     let(:sfx_links) { sfx_document.index_links }
     let(:ezproxy_links) { ezproxy_document.index_links }
@@ -83,9 +89,10 @@ describe IndexLinks do
     end
     it 'should identify finding aid links' do
       expect(finding_aid_links.all.first).to be_finding_aid
+      expect(finding_aid_links_alternate.all.first).to be_finding_aid
       expect(finding_aid_links.finding_aid.length).to eq 1
       expect(finding_aid_links.finding_aid.first.html).to match(
-        %r{<a href='.*oac\.cdlib\.org\/findaid\/something-else'>Online Archive of California<\/a>}
+        %r{<a href='.*oac\.cdlib\.org\/findaid\/ark:\/something-else'>Online Archive of California<\/a>}
       )
     end
 

--- a/spec/views/catalog/_index_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_index_marc.html.erb_spec.rb
@@ -61,7 +61,7 @@ describe "catalog/_index_marc.html.erb" do
       allow(view).to receive(:document).and_return(
         SolrDocument.new(
           marcxml: metadata1,
-          url_fulltext: ['http://oac.cdlib.org/findaid/12345']
+          url_fulltext: ['http://oac.cdlib.org/findaid/ark:/12345']
         )
       )
       render

--- a/spec/views/catalog/access_panels/_location.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_location.html.erb_spec.rb
@@ -264,7 +264,7 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       assign(:document, SolrDocument.new(
         id: '123',
         item_display: ['123 -|- SPEC-COLL -|- STACKS -|- -|- -|- -|- -|- -|- ABC -|-'],
-        url_suppl: ["http://oac.cdlib.org/findaid/something-else"]
+        url_suppl: ["http://oac.cdlib.org/findaid/ark:/something-else"]
       ))
       render
     end


### PR DESCRIPTION
…xes #2069
fixes #2069 

See: http://rubular.com/r/KwYKcEA9aK

Based on the intent of the ticket, I've removed backwards compatibility for these finding aid links. Not sure if that is needed or not.