### PR TITLE
Allow both article and catalog records to be selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added the ability to add Articles+ records to selection lists [#2094](https://github.com/sul-dlss/SearchWorks/pull/2094)
 ### Changed
 ### Removed
 ### Fixed

--- a/app/assets/javascripts/recent-selections.js
+++ b/app/assets/javascripts/recent-selections.js
@@ -63,12 +63,13 @@ Blacklight.onLoad(function(){
           }
         },
         updateList: function(html){
-          var list = $('[data-attribute="added-list"]');
-          if (list.length === 0) {
-            $("ul#show-list").prepend(html);
-          }else{
-            list.html(html);
+          var addedListItems = $('ul#show-list li[data-attribute="added-list"]');
+
+          if (addedListItems.length > 0) {
+            addedListItems.remove(); // Clear out any existing items for replacing
           }
+
+          $("ul#show-list").prepend(html);
         }
     };
 

--- a/app/assets/javascripts/recent-selections.js
+++ b/app/assets/javascripts/recent-selections.js
@@ -38,12 +38,7 @@ Blacklight.onLoad(function(){
           var element = this.element;
           var url = $(element).data('url');
           $(element).on('show.bs.dropdown', function(){
-            if (plugin.updated){
-              plugin.getRecentSelections(url);
-            }
-          });
-          $('input.toggle_bookmark').on('change', function(){
-            plugin.updated = true;
+            plugin.getRecentSelections(url);
           });
         },
 
@@ -57,23 +52,20 @@ Blacklight.onLoad(function(){
           request.done(function(html){
             plugin.updateLinks(html);
             plugin.updateList(html);
-            plugin.updated = false;
           });
         },
 
         updateLinks: function(html){
           if ($.trim(html) == '') {
-            $('li#show-list').addClass('disabled');
             $('li#clear-list').addClass('disabled');
           } else {
-            $('li#show-list').removeClass('disabled');
             $('li#clear-list').removeClass('disabled');
           }
         },
         updateList: function(html){
           var list = $('[data-attribute="added-list"]');
           if (list.length === 0) {
-            $("li#show-list").append(html);
+            $("ul#show-list").prepend(html);
           }else{
             list.html(html);
           }

--- a/app/assets/stylesheets/modules/bookmarks.scss
+++ b/app/assets/stylesheets/modules/bookmarks.scss
@@ -26,3 +26,10 @@ label {
     }
   }
 }
+
+.selections-nav {
+  h2 {
+    border-bottom: 0;
+    display: inline;
+  }
+}

--- a/app/assets/stylesheets/modules/record-toolbar.scss
+++ b/app/assets/stylesheets/modules/record-toolbar.scss
@@ -16,21 +16,7 @@
 
   .dropdown-menu {
     @include toolbar-dropdown;
-
-    .refworks {
-      padding: 3px 10px;
-
-      form a {
-        color: $dropdown-link-hover-color;
-
-        &:hover, &:focus, &:active {
-          text-decoration: none;
-        }
-      }
-      &:hover, &:focus, &:active {
-        background-color: $dropdown-link-hover-bg;
-      }
-    }
+    @include refworks-form;
   }
 
   .record-toolbar-tools ul {
@@ -71,7 +57,7 @@
     }
   }
 
-  .navbar-nav.navbar-right form {
+  .navbar-nav.navbar-right form.bookmark_toggle {
     padding-left: 10px;
   }
 }

--- a/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
+++ b/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
@@ -10,6 +10,7 @@
 
   .dropdown-menu {
     @include toolbar-dropdown;
+    @include refworks-form;
   }
 
   .page_links {

--- a/app/assets/stylesheets/searchworks-mixins.scss
+++ b/app/assets/stylesheets/searchworks-mixins.scss
@@ -21,6 +21,26 @@
   }
 }
 
+@mixin refworks-form {
+  .refworks {
+    form {
+      padding: 3px 20px;
+
+      a {
+        color: $dropdown-link-hover-color;
+
+        &:hover, &:focus, &:active {
+          text-decoration: none;
+        }
+      }
+    }
+
+    &:hover, &:focus, &:active {
+      background-color: $dropdown-link-hover-bg;
+    }
+  }
+}
+
 @mixin h1-show-title-font {
   font-family: 'dejavu_sansextralight';
   letter-spacing: -.03em;

--- a/app/controllers/article_selections_controller.rb
+++ b/app/controllers/article_selections_controller.rb
@@ -1,0 +1,58 @@
+class ArticleSelectionsController < ApplicationController
+  include Blacklight::Catalog
+  include Blacklight::Configurable
+  include Blacklight::SearchContext
+  include Blacklight::SearchHelper
+  include Blacklight::TokenBasedUser
+
+  copy_blacklight_config_from(ArticlesController)
+
+  before_action :verify_user
+
+  blacklight_config.http_method = Blacklight::Engine.config.bookmarks_http_method
+  blacklight_config.add_results_collection_tool(:clear_bookmarks_widget)
+
+  blacklight_config.show.document_actions[:bookmark].if = false if blacklight_config.show.document_actions[:bookmark]
+  blacklight_config.show.document_actions[:sms].if = false if blacklight_config.show.document_actions[:sms]
+
+
+  def index
+    @bookmarks = token_or_current_or_guest_user.bookmarks.where(record_type: 'article')
+    bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
+
+    eds_params = {
+      guest:          session['eds_guest'],
+      session_token:  session['eds_session_token']
+    }
+
+    if bookmark_ids.present?
+      @response, @document_list = fetch(bookmark_ids)
+    else
+      @document_list = []
+    end
+
+    respond_to do |format|
+      format.html { render 'bookmarks/index' }
+      format.rss  { render :layout => false }
+      format.atom { render :layout => false }
+      format.json do
+        render json: render_search_results_as_json
+      end
+
+      additional_response_formats(format)
+      document_export_formats(format)
+    end
+  end
+
+  def _prefixes
+    @_prefixes ||= super + ['articles', 'catalog']
+  end
+
+  protected
+
+  def verify_user
+    unless current_or_guest_user or (action == "index" and token_or_current_or_guest_user)
+      flash[:notice] = I18n.t('blacklight.bookmarks.need_login') and raise Blacklight::Exceptions::AccessDenied
+    end
+  end
+end

--- a/app/controllers/article_selections_controller.rb
+++ b/app/controllers/article_selections_controller.rb
@@ -4,6 +4,7 @@ class ArticleSelectionsController < ApplicationController
   include Blacklight::SearchContext
   include Blacklight::SearchHelper
   include Blacklight::TokenBasedUser
+  include SelectionsCount
 
   copy_blacklight_config_from(ArticlesController)
 
@@ -30,6 +31,9 @@ class ArticleSelectionsController < ApplicationController
     else
       @document_list = []
     end
+
+    @catalog_count = selections_counts.catalog
+    @article_count = selections_counts.articles
 
     respond_to do |format|
       format.html { render 'bookmarks/index' }

--- a/app/controllers/article_selections_controller.rb
+++ b/app/controllers/article_selections_controller.rb
@@ -52,6 +52,16 @@ class ArticleSelectionsController < ApplicationController
     @_prefixes ||= super + ['articles', 'catalog']
   end
 
+  # Overridden Blacklight helper method to generate a "start"
+  # for bookmarks similar to what the solr response provides
+  def document_counter_with_offset idx, offset = nil
+    offset ||= ((@bookmarks.current_page - 1) * @bookmarks.limit_value) if @bookmarks
+    offset ||= 0
+
+    idx + 1 + offset
+  end
+  helper_method :document_counter_with_offset
+
   protected
 
   def paged_bookmarks

--- a/app/controllers/article_selections_controller.rb
+++ b/app/controllers/article_selections_controller.rb
@@ -18,7 +18,7 @@ class ArticleSelectionsController < ApplicationController
 
 
   def index
-    @bookmarks = token_or_current_or_guest_user.bookmarks.where(record_type: 'article')
+    @bookmarks = paged_bookmarks
     bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
 
     eds_params = {
@@ -53,6 +53,13 @@ class ArticleSelectionsController < ApplicationController
   end
 
   protected
+
+  def paged_bookmarks
+    token_or_current_or_guest_user
+      .bookmarks.where(record_type: 'article')
+      .page(params[:page])
+      .per(params[:per_page] || 20)
+  end
 
   def verify_user
     unless current_or_guest_user or (action == "index" and token_or_current_or_guest_user)

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -2,6 +2,7 @@
 
 class BookmarksController < CatalogController
   include Blacklight::Bookmarks
+  include SelectionsCount
 
   # Overidden from Blacklight to add our tabbed interface
   def index
@@ -9,6 +10,9 @@ class BookmarksController < CatalogController
     bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
 
     @response, @document_list = fetch(bookmark_ids)
+
+    @catalog_count = selections_counts.catalog
+    @article_count = selections_counts.articles
 
     respond_to do |format|
       format.html { }

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,4 +1,8 @@
-Blacklight::BookmarksController.class_eval do
+# frozen_string_literal: true
+
+class BookmarksController < CatalogController
+  include Blacklight::Bookmarks
+
   def clear
     if current_or_guest_user.bookmarks.clear
       flash[:success] = I18n.t('blacklight.bookmarks.clear.success')

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -3,6 +3,26 @@
 class BookmarksController < CatalogController
   include Blacklight::Bookmarks
 
+  # Overidden from Blacklight to add our tabbed interface
+  def index
+    @bookmarks = token_or_current_or_guest_user.bookmarks.where(record_type: 'catalog')
+    bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
+
+    @response, @document_list = fetch(bookmark_ids)
+
+    respond_to do |format|
+      format.html { }
+      format.rss  { render :layout => false }
+      format.atom { render :layout => false }
+      format.json do
+        render json: render_search_results_as_json
+      end
+
+      additional_response_formats(format)
+      document_export_formats(format)
+    end
+  end
+
   def clear
     if current_or_guest_user.bookmarks.clear
       flash[:success] = I18n.t('blacklight.bookmarks.clear.success')

--- a/app/controllers/concerns/selections_count.rb
+++ b/app/controllers/concerns/selections_count.rb
@@ -1,0 +1,8 @@
+module SelectionsCount
+  def selections_counts
+    @selections_counts ||= Struct.new(:catalog, :articles).new(
+      current_or_guest_user.bookmarks.where(record_type: 'catalog').count,
+      current_or_guest_user.bookmarks.where(record_type: 'article').count
+    )
+  end
+end

--- a/app/controllers/recent_selections_controller.rb
+++ b/app/controllers/recent_selections_controller.rb
@@ -1,9 +1,11 @@
 class RecentSelectionsController < ApplicationController
+  include SelectionsCount
+
   def index
     redirect_to(root_url) unless request.xhr?
 
-    @catalog_count = current_or_guest_user.bookmarks.where(record_type: 'catalog').count
-    @article_count = current_or_guest_user.bookmarks.where(record_type: 'article').count
+    @catalog_count = selections_counts.catalog
+    @article_count = selections_counts.articles
 
     respond_to do |format|
       format.html do

--- a/app/controllers/recent_selections_controller.rb
+++ b/app/controllers/recent_selections_controller.rb
@@ -1,20 +1,14 @@
 class RecentSelectionsController < ApplicationController
-
-  include Blacklight::SearchHelper
-  include Blacklight::SearchContext
   def index
-    _, @recent_selections =
-      fetch(
-        current_or_guest_user.bookmarks.last(3).map(&:document_id)
-      )
-    if request.xhr?
-      respond_to do |format|
-        format.html do
-          render recent_selections: @recent_selections, layout: false
-        end
+    redirect_to(root_url) unless request.xhr?
+
+    @catalog_count = current_or_guest_user.bookmarks.where(record_type: 'catalog').count
+    @article_count = current_or_guest_user.bookmarks.where(record_type: 'article').count
+
+    respond_to do |format|
+      format.html do
+        render layout: false
       end
-    else
-      redirect_to root_url
     end
   end
 end

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -6,6 +6,10 @@ module ArticleHelper
     controller_name == 'articles'
   end
 
+  def article_selections?
+    controller_name == 'article_selections'
+  end
+
   def facet_options_presenter
     @facet_options ||= FacetOptionsPresenter.new(params: params, context: self)
   end

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,9 +1,7 @@
 module BookmarksHelper
 
   def bookmarks?
-    if params[:controller] == 'bookmarks'
-      true
-    end
+    %w[bookmarks article_selections].include? params[:controller]
   end
 
   #Similar to BL page_entries_info /app/helpers/blacklight/catalog_helper_behavior.rb

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -12,6 +12,17 @@ module Eds
       end
     end
 
+    def find_by_ids(ids, eds_params = {})
+      eds_session = Eds::Session.new(eds_params.update(caller: 'bl-repo-find-by-ids'))
+      results = eds_session.solr_retrieve_list(list: ids)
+      blacklight_config.response_model.new(
+        results,
+        {},
+        document_model: blacklight_config.document_model,
+        blacklight_config: blacklight_config
+      )
+    end
+
     private
 
     def eds_search(search_builder = {}, eds_params = {})

--- a/app/services/eds/search_service.rb
+++ b/app/services/eds/search_service.rb
@@ -36,15 +36,8 @@ module Eds
     # Retrieve a set of documents by id
     # @param [Array] ids
     # @param [HashWithIndifferentAccess] extra_controller_params
-    def fetch_many(ids, extra_controller_params)
-      extra_controller_params ||= {}
-
-      query = search_builder
-              .with(user_params)
-              .where(blacklight_config.document_model.unique_key => ids)
-              .merge(extra_controller_params)
-              .merge(fl: '*')
-      solr_response = @repository.search(query, @eds_params)
+    def fetch_many(ids, extra_controller_params = {})
+      solr_response = @repository.find_by_ids(ids, @eds_params)
 
       [solr_response, solr_response.documents]
     end

--- a/app/views/article_selections/_results_pagination.html.erb
+++ b/app/views/article_selections/_results_pagination.html.erb
@@ -1,0 +1,9 @@
+<% if show_pagination? and @bookmarks.total_pages > 1 %>
+ <div class="row record-padding">
+  <div class="col-md-12">
+    <div class="pagination">
+      <%= paginate @bookmarks, outer_window: 2, theme: 'blacklight' %>
+    </div>
+  </div>
+ </div>
+<% end %>

--- a/app/views/article_selections/_sort_widget.html.erb
+++ b/app/views/article_selections/_sort_widget.html.erb
@@ -1,0 +1,1 @@
+<% # intentionally left blank to remove sort from article selections UI %>

--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -5,7 +5,7 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>
-      <%= link_to t('blacklight.tools.email_html'),  email_article_selections_path(sort: params[:sort], per_page: params[:per_page], id: @response.documents.map {|doc| doc.id}), id: "emailLink", data: {ajax_modal: "trigger"} %>
+      <%= link_to t('blacklight.tools.email_html'),  email_articles_path(sort: params[:sort], per_page: params[:per_page], id: @response.documents.map {|doc| doc.id}), id: "emailLink", data: {ajax_modal: "trigger"} %>
     </li>
 
     <% if @response.documents.any? {|d| d.export_formats.key?(:ris) } %>

--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -1,7 +1,7 @@
 <span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
 <div id="tools-dropdown" class="btn-group">
   <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
-    <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@response)).html_safe %>
+    <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@bookmarks)).html_safe %>
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>

--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -1,0 +1,28 @@
+<span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
+<div id="tools-dropdown" class="btn-group">
+  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown">
+    <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@response)).html_safe %>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li>
+      <%= link_to t('blacklight.tools.email_html'),  email_article_selections_path(sort: params[:sort], per_page: params[:per_page], id: @response.documents.map {|doc| doc.id}), id: "emailLink", data: {ajax_modal: "trigger"} %>
+    </li>
+
+    <% if @response.documents.any? {|d| d.export_formats.key?(:ris) } %>
+      <li class="refworks" role="presentation">
+        <%= form_tag(refworks_export_url(filter: 'RIS Format')) do %>
+          <%= content_tag(:input, nil, type: :hidden, name: :ImportData, value: @response.documents.map(&:export_as_ris).join) %>
+          <%= link_to t('blacklight.tools.refworks_html'), '', onclick: "event.preventDefault(); $(this).closest('form').submit();" %>
+        <% end %>
+      </li>
+
+      <li class="ris" role="presentation">
+        <%= link_to t('blacklight.tools.ris_html'), params.except(:host, :port).merge(format: 'ris') %>
+      </li>
+    <% end %>
+
+    <li role="presentation">
+      <a role="menuitem" tabindex="-1" href="javascript:if(window.print)window.print()"><%= t('blacklight.tools.printer_html') %></a>
+    </li>
+  </ul>
+</div>

--- a/app/views/articles/_bookmark_control.html.erb
+++ b/app/views/articles/_bookmark_control.html.erb
@@ -1,4 +1,29 @@
 <%
-  # intentionally left blank to prevent the bookmark partial from
-  # rendering until we can hook that behavior up for article records
+  # Overridden from Blacklight for articles to inject custom parameters
 %>
+
+<% if current_or_guest_user %>
+  <%-
+  # Note these two forms are pretty similar but for different :methods, classes, and labels.
+  # but it was simpler to leave them seperate instead of DRYing them, got confusing trying that.
+  # the data-doc-id attribute is used by our JS that converts to a checkbox/label.
+  -%>
+  <% unless bookmarked? document %>
+
+      <%= form_tag( bookmark_path( document ), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>
+      <%= hidden_field_tag('bookmarks[][document_id]', document.id) %>
+      <%= hidden_field_tag('bookmarks[][record_type]', 'article') %>
+      <%= hidden_field_tag('bookmarks[][document_type]', document.class) %>
+        <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_add btn btn-default") %>
+      <% end %>
+
+  <% else %>
+
+      <%= form_tag( bookmark_path( document ), :method => :delete, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>
+        <%= submit_tag(t('blacklight.bookmarks.remove.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_remove btn btn-default") %>
+      <% end %>
+
+  <% end %>
+<% else %>
+  &nbsp;
+<% end %>

--- a/app/views/articles/_email_form.html.erb
+++ b/app/views/articles/_email_form.html.erb
@@ -1,9 +1,10 @@
-<%= form_tag email_article_path(@documents.id), :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
+<%= form_tag email_articles_path, :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
   <%= render :partial=>'shared/email_form' %>
 
   <%=hidden_field_tag :type, 'brief' %>
-  <!-- TODO: update after article selections  -->
-  <%=hidden_field_tag "id[]", @documents.id %>
+  <% Array.wrap(@documents).each do |doc| %>
+    <%= hidden_field_tag "id[]", doc.id %>
+  <% end %>
   <%- if params[:sort] -%>
     <%= hidden_field_tag "sort", params[:sort] %>
   <%- end -%>

--- a/app/views/articles/_search_header.html.erb
+++ b/app/views/articles/_search_header.html.erb
@@ -5,6 +5,9 @@
       <%= render partial: 'catalog/view_type_group' %>
       <%= render partial: 'sort_widget' %>
       <%= render partial: 'shared/per_page_widget' %>
+      <% unless bookmarks? %>
+        <%= render partial: 'select_all_widget' %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,8 +1,15 @@
 <% @page_title = t 'blacklight.search.masthead_title', title: t('blacklight.bookmarks.page_heading'), application_name: "#{I18n.t('blacklight.application_name')} catalog" %>
 <h1>Selection lists</h1>
 
-<%= link_to(pluralize(@catalog_count, 'catalog items'), bookmarks_path, class: "btn #{'btn-danger' unless article_selections?}") %>
-<%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: "btn #{'btn-danger' if article_selections?}") %>
+<nav class="selections-nav">
+  <% if article_selections? %>
+    <%= link_to(pluralize(@catalog_count, 'catalog items'), bookmarks_path, class: 'btn btn-lg') %>
+    <h2><%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: 'btn btn-lg btn-primary', 'aria-current': 'page') %></h2>
+  <% else %>
+    <h2><%= link_to(pluralize(@catalog_count, 'catalog items'), bookmarks_path, class: 'btn btn-lg btn-primary', 'aria-current': 'page') %></h2>
+    <%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: 'btn btn-lg') %>
+  <% end %>
+</nav>
 
 <div id="content" class="col-md-12">
   <% if current_or_guest_user.blank? %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,5 +1,8 @@
 <% @page_title = t 'blacklight.search.masthead_title', title: t('blacklight.bookmarks.page_heading'), application_name: "#{I18n.t('blacklight.application_name')} catalog" %>
-<h1 class="sr-only"><%= t('blacklight.bookmarks.page_heading') %></h1>
+<h1>Selection lists</h1>
+
+<%= link_to('catalog items', bookmarks_path, class: "btn #{'btn-danger' if controller_name != 'article_selections'}") %>
+<%= link_to('articles+ items', article_selections_path, class: "btn #{'btn-danger' if controller_name == 'article_selections'}") %>
 
 <div id="content" class="col-md-12">
   <div class="row">

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,8 +1,8 @@
 <% @page_title = t 'blacklight.search.masthead_title', title: t('blacklight.bookmarks.page_heading'), application_name: "#{I18n.t('blacklight.application_name')} catalog" %>
 <h1>Selection lists</h1>
 
-<%= link_to(pluralize(@catalog_count, 'catalog items'), bookmarks_path, class: "btn #{'btn-danger' if controller_name != 'article_selections'}") %>
-<%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: "btn #{'btn-danger' if controller_name == 'article_selections'}") %>
+<%= link_to(pluralize(@catalog_count, 'catalog items'), bookmarks_path, class: "btn #{'btn-danger' unless article_selections?}") %>
+<%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: "btn #{'btn-danger' if article_selections?}") %>
 
 <div id="content" class="col-md-12">
   <% if current_or_guest_user.blank? %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,18 +5,6 @@
 <%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: "btn #{'btn-danger' if controller_name == 'article_selections'}") %>
 
 <div id="content" class="col-md-12">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="search_num_of_results">
-        <div class='results-heading'>
-          <h2>
-            <%= "#{@response.total_count} #{t('blacklight.bookmarks.selection_title').pluralize(@response.documents.length)}" %>
-          </h2>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <% if current_or_guest_user.blank? %>
     <h2><%= t('blacklight.bookmarks.need_login') %></h2>
   <% elsif @document_list.blank? %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,8 +1,8 @@
 <% @page_title = t 'blacklight.search.masthead_title', title: t('blacklight.bookmarks.page_heading'), application_name: "#{I18n.t('blacklight.application_name')} catalog" %>
 <h1>Selection lists</h1>
 
-<%= link_to('catalog items', bookmarks_path, class: "btn #{'btn-danger' if controller_name != 'article_selections'}") %>
-<%= link_to('articles+ items', article_selections_path, class: "btn #{'btn-danger' if controller_name == 'article_selections'}") %>
+<%= link_to(pluralize(@catalog_count, 'catalog items'), bookmarks_path, class: "btn #{'btn-danger' if controller_name != 'article_selections'}") %>
+<%= link_to(pluralize(@article_count, 'articles+ items'), article_selections_path, class: "btn #{'btn-danger' if controller_name == 'article_selections'}") %>
 
 <div id="content" class="col-md-12">
   <div class="row">

--- a/app/views/catalog/_search_bar_selections_widget.html.erb
+++ b/app/views/catalog/_search_bar_selections_widget.html.erb
@@ -4,7 +4,7 @@
   </a>
   <ul id="show-list" class="dropdown-menu dropdown-fixed-width recent-selections">
     <li id="clear-list" class= <%= disabled_class_for_no_selections(current_or_guest_user.bookmarks.length)%>>
-      <%= link_to "Clear list", clear_bookmarks_path, method: :delete, data: { confirm: t('blacklight.bookmarks.clear.action_confirm') } %>
+      <%= link_to "Clear all lists", clear_bookmarks_path, method: :delete, data: { confirm: t('searchworks.bookmarks.clear_all.action_confirm') } %>
     </li>
   </ul>
 </li>

--- a/app/views/catalog/_search_bar_selections_widget.html.erb
+++ b/app/views/catalog/_search_bar_selections_widget.html.erb
@@ -2,10 +2,7 @@
   <a class="dropdown-toggle" data-toggle="dropdown" href="#">
     Selections (<span data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>)<span class="caret"></span>
   </a>
-  <ul class="dropdown-menu dropdown-fixed-width recent-selections">
-    <li id="show-list" class= <%= disabled_class_for_current_page(selections_path)%> <%= disabled_class_for_no_selections(current_or_guest_user.bookmarks.length) %>>
-      <%= link_to "Show list", selections_path %>
-    </li>
+  <ul id="show-list" class="dropdown-menu dropdown-fixed-width recent-selections">
     <li id="clear-list" class= <%= disabled_class_for_no_selections(current_or_guest_user.bookmarks.length)%>>
       <%= link_to "Clear list", clear_bookmarks_path, method: :delete, data: { confirm: t('blacklight.bookmarks.clear.action_confirm') } %>
     </li>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -2,11 +2,16 @@
 <div id="sortAndPerPage" class="clearfix sul-toolbar">
   <div class="container-fluid">
     <%= render partial: "paginate_compact", object: ivar_to_paginate %>
+
     <div id="search-results-toolbar" class="search-widgets pull-right">
       <% if bookmarks? %>
         <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(controller_name == 'bookmarks' ? :citation_solr_documents : :citation_articles, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
         <%= render "tool_dropdown" %>
+        <%= link_to clear_bookmarks_path(type: controller_name == 'article_selections' ? 'article' : 'catalog'), method: :delete, class: 'btn btn-sul-toolbar', data: { confirm: t("searchworks.bookmarks.#{controller_name == 'article_selections' ? 'article' : 'catalog'}.clear.action_confirm") } do %>
+          <i class="fa fa-times" aria-hidden="true"></i> Clear list
+        <% end %>
       <% end %>
+
       <%= render partial: 'view_type_group' %>
       <%= render partial: 'sort_widget' %>
       <%= render partial: 'shared/per_page_widget' %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,9 +1,10 @@
+<% ivar_to_paginate = controller_name == 'article_selections' ? @bookmarks : @response %>
 <div id="sortAndPerPage" class="clearfix sul-toolbar">
   <div class="container-fluid">
-    <%= render partial: "paginate_compact", object: @response %>
+    <%= render partial: "paginate_compact", object: ivar_to_paginate %>
     <div id="search-results-toolbar" class="search-widgets pull-right">
       <% if bookmarks? %>
-        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(@response)).html_safe, polymorphic_path(controller_name == 'bookmarks' ? :citation_solr_documents : :citation_articles, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(controller_name == 'bookmarks' ? :citation_solr_documents : :citation_articles, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
         <%= render "tool_dropdown" %>
       <% end %>
       <%= render partial: 'view_type_group' %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,13 +1,13 @@
-<% ivar_to_paginate = controller_name == 'article_selections' ? @bookmarks : @response %>
+<% ivar_to_paginate =  article_selections? ? @bookmarks : @response %>
 <div id="sortAndPerPage" class="clearfix sul-toolbar">
   <div class="container-fluid">
     <%= render partial: "paginate_compact", object: ivar_to_paginate %>
 
     <div id="search-results-toolbar" class="search-widgets pull-right">
       <% if bookmarks? %>
-        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(controller_name == 'bookmarks' ? :citation_solr_documents : :citation_articles, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(article_selections? ? :citation_articles : :citation_solr_documents, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
         <%= render "tool_dropdown" %>
-        <%= link_to clear_bookmarks_path(type: controller_name == 'article_selections' ? 'article' : 'catalog'), method: :delete, class: 'btn btn-sul-toolbar', data: { confirm: t("searchworks.bookmarks.#{controller_name == 'article_selections' ? 'article' : 'catalog'}.clear.action_confirm") } do %>
+        <%= link_to clear_bookmarks_path(type:  article_selections? ? 'article' : 'catalog'), method: :delete, class: 'btn btn-sul-toolbar', data: { confirm: t("searchworks.bookmarks.#{article_selections? ? 'article' : 'catalog'}.clear.action_confirm") } do %>
           <i class="fa fa-times" aria-hidden="true"></i> Clear list
         <% end %>
       <% end %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -3,8 +3,8 @@
     <%= render partial: "paginate_compact", object: @response %>
     <div id="search-results-toolbar" class="search-widgets pull-right">
       <% if bookmarks? %>
-        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(@response)).html_safe, citation_solr_documents_path(:sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
-        <%= render "bookmarks/tool_dropdown" %>
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(@response)).html_safe, polymorphic_path(controller_name == 'bookmarks' ? :citation_solr_documents : :citation_articles, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
+        <%= render "tool_dropdown" %>
       <% end %>
       <%= render partial: 'view_type_group' %>
       <%= render partial: 'sort_widget' %>

--- a/app/views/recent_selections/index.html.erb
+++ b/app/views/recent_selections/index.html.erb
@@ -1,11 +1,9 @@
 <% if @catalog_count || @article_count %>
-  <span data-attribute="added-list">
-    <li class="dropdown-list-title text-muted">
-      <%= link_to("Catalog selections (#{@catalog_count})", bookmarks_path) %>
-    </li>
-    <li class="dropdown-list-title text-muted">
-      <%= link_to("Articles+ selections (#{@article_count})", article_selections_path) %>
-    </li>
-    <li class="divider"></li>
-  </span>
+  <li data-attribute="added-list">
+    <%= link_to("Catalog selections (#{@catalog_count})", bookmarks_path) %>
+  </li>
+  <li data-attribute="added-list">
+    <%= link_to("Articles+ selections (#{@article_count})", article_selections_path) %>
+  </li>
+  <li class="divider" data-attribute="added-list"></li>
 <% end %>

--- a/app/views/recent_selections/index.html.erb
+++ b/app/views/recent_selections/index.html.erb
@@ -1,12 +1,7 @@
-<% if @recent_selections.present? %>
+<% if @catalog_count || @article_count %>
   <span data-attribute="added-list">
-    <li class="divider"></li>
-    <li class="dropdown-header">Recently Added</li>
-    <% @recent_selections.each do |selection| %>
-      <li class="dropdown-list-title text-muted">
-        <%= get_main_title selection %>
-      <li>
-    <% end %>
+    <li class="dropdown-list-title text-muted">Catalog selections (<%= @catalog_count %>)</li>
+    <li class="dropdown-list-title text-muted">Articles+ selections (<%= @article_count %>)</li>
     <li class="divider"></li>
   </span>
 <% end %>

--- a/app/views/recent_selections/index.html.erb
+++ b/app/views/recent_selections/index.html.erb
@@ -1,7 +1,11 @@
 <% if @catalog_count || @article_count %>
   <span data-attribute="added-list">
-    <li class="dropdown-list-title text-muted">Catalog selections (<%= @catalog_count %>)</li>
-    <li class="dropdown-list-title text-muted">Articles+ selections (<%= @article_count %>)</li>
+    <li class="dropdown-list-title text-muted">
+      <%= link_to("Catalog selections (#{@catalog_count})", bookmarks_path) %>
+    </li>
+    <li class="dropdown-list-title text-muted">
+      <%= link_to("Articles+ selections (#{@article_count})", article_selections_path) %>
+    </li>
     <li class="divider"></li>
   </span>
 <% end %>

--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -1,7 +1,7 @@
 <div class="modal-body">
   <%= render :partial=>'/flash_msg' %>
   <div class="form-group">
-    <% unless controller.controller_name == 'articles' # TODO: full record for articles %>
+    <% unless %w[articles article_selections].include? controller.controller_name # TODO: full record for articles %>
       <div class="col-sm-10 col-sm-offset-2">
         <%= radio_button_tag :type, 'brief', true %> <%= label_tag(:type_brief,  "<strong>Brief record</strong> (title, library & call number, bookmark)".html_safe) %><br/>
         <%= radio_button_tag :type, 'full' %> <%= label_tag(:type_full, "<strong>Full record</strong>".html_safe) %>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -30,7 +30,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li class="navbar-link">
             <%= link_to feedback_path(type: 'connection'), data: {toggle:"collapse", target:"#connection-form"}, class: 'connection-problem' do %>
-              Report a connection problem
+              Connection problem?
             <% end %>
           </li>
           <%= render_search_bar_selections_widget %>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -33,6 +33,7 @@
               Report a connection problem
             <% end %>
           </li>
+          <%= render_search_bar_selections_widget %>
         </ul>
       <% end %>
     </div>

--- a/app/views/shared/record/_record_toolbar.html.erb
+++ b/app/views/shared/record/_record_toolbar.html.erb
@@ -32,7 +32,7 @@
           </ul>
         </li>
         <li>
-          <%= render(:partial => 'bookmark_control', :locals => {:document=> @document}) unless article_search? %>
+          <%= render(:partial => 'bookmark_control', :locals => {:document=> @document}) %>
         </li>
       </ul>
     </div>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -18,6 +18,8 @@ en:
           FT1:
             tip: Stanford subscribes to the full text, or it's available via open access.
     bookmarks:
+      clear_all:
+        action_confirm: 'Clear all your selection lists?'
       article:
         clear:
           action_confirm: Clear your articles+ selections?

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -17,6 +17,13 @@ en:
             tip: Limit your search to scholarly content. Includes University presses.
           FT1:
             tip: Stanford subscribes to the full text, or it's available via open access.
+    bookmarks:
+      article:
+        clear:
+          action_confirm: Clear your articles+ selections?
+      catalog:
+        clear:
+          action_confirm: Clear your catalog selections?
     search:
       form:
         q:
@@ -26,6 +33,8 @@ en:
       articles:
         label: articles+
         description_html: <span class="h3">articles+</span> <span class="help-block">journal articles &amp; other e-resources</span>
+      articles_selections:
+        label: articles+
       catalog:
         label: catalog
         description_html: <span class="h3">catalog</span> <span class="help-block">books, media &amp; more in the Stanford Libraries' collections</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,11 +20,13 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :bookmarks do
-    concerns :exportable
+  constraints(id: /[^\/]+/) do # EDS identifier rules (e.g., db__acid) where acid has all sorts of different punctuation
+    resources :bookmarks do
+      concerns :exportable
 
-    collection do
-      delete 'clear'
+      collection do
+        delete 'clear'
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,12 @@ Rails.application.routes.draw do
       collection do
         delete 'clear'
       end
+
+      collection do
+        resources :article_selections, path: :articles do
+          concerns :exportable
+        end
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   constraints(id: /[^\/]+/) do # EDS identifier rules (e.g., db__acid) where acid has all sorts of different punctuation
-    resources :bookmarks do
+    resources :bookmarks, path: :selections do
       concerns :exportable
 
       collection do
@@ -66,8 +66,6 @@ Rails.application.routes.draw do
   resources :preview, only: :show
 
   resources :availability, only: :index
-
-  get "selections" => "bookmarks#index"
 
   resources :recent_selections, only: :index
 

--- a/db/migrate/20181026204943_add_type_column_and_index_to_bookmarks.rb
+++ b/db/migrate/20181026204943_add_type_column_and_index_to_bookmarks.rb
@@ -1,0 +1,6 @@
+class AddTypeColumnAndIndexToBookmarks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookmarks, :record_type, :string, default: 'catalog'
+    add_index :bookmarks, :record_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140513170559) do
+ActiveRecord::Schema.define(version: 2018_10_26_204943) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20140513170559) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "document_type"
+    t.string "record_type", default: "catalog"
+    t.index ["record_type"], name: "index_bookmarks_on_record_type"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 

--- a/spec/controllers/recent_selections_controller_spec.rb
+++ b/spec/controllers/recent_selections_controller_spec.rb
@@ -2,11 +2,17 @@ require "spec_helper"
 
 describe RecentSelectionsController do
   describe "#index" do
-    it "should get the document" do
-      @controller.stub_chain(:current_or_guest_user, :bookmarks).and_return([OpenStruct.new({document_id: "1"})])
+    let(:user) { User.create!(email: 'example@stanford.edu', password: 'totallysecurepassword') }
+    let!(:cat_bookmark1) { Bookmark.create!(document_id: '1', user: user) }
+    let!(:cat_bookmark2) { Bookmark.create!(document_id: '2', user: user) }
+    let!(:article_bookmark) { Bookmark.create!(document_id: 'abc__1', user: user, record_type: 'article') }
+
+    it 'returns the counts of article and catalog bookmarks' do
+      @controller.stub_chain(:current_or_guest_user, :bookmarks).and_return(Bookmark.all)
       get :index, xhr: true
-      expect(response).to render_template("index")
-      expect(assigns[:recent_selections]).to_not be_nil
+      expect(response).to render_template('index')
+      expect(assigns(:catalog_count)).to eq 2
+      expect(assigns(:article_count)).to eq 1
     end
   end
 end

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -42,7 +42,7 @@ feature 'Article Searching' do
       expect(page).to have_css('a', text: /Library services/)
       expect(page).not_to have_css('a', text: /Advanced search/)
       expect(page).not_to have_css('a', text: /Course reserves/)
-      expect(page).not_to have_css('a', text: /Selections/)
+      expect(page).to have_css('a', text: /Selections \(\d+\)/)
     end
   end
 

--- a/spec/features/blacklight_customizations/bookmarks_path_spec.rb
+++ b/spec/features/blacklight_customizations/bookmarks_path_spec.rb
@@ -4,7 +4,8 @@ feature "Selections Path" do
 
   scenario "should render bookmarks page" do
     visit bookmarks_path
-    expect(page).to have_css("h2", text: "0 selections")
+    expect(page).to have_css('h2', text: '0 catalog items')
+    expect(page).to have_css('a', text: '0 articles+ items')
     expect(page).to have_css("h3", text: "You have no bookmarks")
   end
 
@@ -15,7 +16,8 @@ feature "Selections Path" do
     page.all('label.toggle_bookmark')[1].click
     expect(page).to have_css("label.toggle_bookmark span", text: "Selected", count: 2)
     visit bookmarks_path
-    expect(page).to have_css("h2", text: "2 selections")
+    expect(page).to have_css('h2', text: '2 catalog items')
+    expect(page).to have_css('a', text: '0 articles+ items')
     within "#documents" do
       expect(page).to have_css("h3.index_title a", count: 2)
     end

--- a/spec/features/blacklight_customizations/bookmarks_path_spec.rb
+++ b/spec/features/blacklight_customizations/bookmarks_path_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature "Selections Path" do
 
   scenario "should render bookmarks page" do
-    visit selections_path
+    visit bookmarks_path
     expect(page).to have_css("h2", text: "0 selections")
     expect(page).to have_css("h3", text: "You have no bookmarks")
   end
@@ -14,7 +14,7 @@ feature "Selections Path" do
     page.all('label.toggle_bookmark')[0].click
     page.all('label.toggle_bookmark')[1].click
     expect(page).to have_css("label.toggle_bookmark span", text: "Selected", count: 2)
-    visit selections_path
+    visit bookmarks_path
     expect(page).to have_css("h2", text: "2 selections")
     within "#documents" do
       expect(page).to have_css("h3.index_title a", count: 2)

--- a/spec/features/blacklight_customizations/emailing_records_spec.rb
+++ b/spec/features/blacklight_customizations/emailing_records_spec.rb
@@ -72,7 +72,7 @@ describe "Emailing Records", type: :feature, js: true do
           end
         end
 
-        expect(URI(find('#email_form')['action']).path).to eq(email_article_path(document))
+        expect(URI(find('#email_form')['action']).path).to eq(email_articles_path)
 
         within('.modal-dialog') do
           fill_in 'to', with: 'email@example.com'

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -19,7 +19,8 @@ describe "Search toolbar", js: true, feature: true do
     describe "show list" do
       it "should navigate to selections page" do
         visit bookmarks_path
-        expect(page).to have_css("h2", text: "0 selections")
+        expect(page).to have_css('h2', text: '0 catalog items')
+        expect(page).to have_css('a', text: '0 articles+ items')
         expect(page).to have_css("h3", text: "You have no bookmarks")
       end
     end
@@ -46,7 +47,7 @@ describe "Search toolbar", js: true, feature: true do
         click_link "Selections"
         expect(page).to have_css("label.toggle_bookmark", text: "Selected", count: 1)
         click_link "Selections"
-        click_link "Clear list"
+        click_link "Clear all lists"
         expect(page).to have_css("div.alert.alert-success", text: "Your selections have been deleted.")
         expect(page).to have_css("h2", text: "Refine your results")
       end

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -18,7 +18,7 @@ describe "Search toolbar", js: true, feature: true do
   describe "Selections dropdown" do
     describe "show list" do
       it "should navigate to selections page" do
-        visit selections_path
+        visit bookmarks_path
         expect(page).to have_css("h2", text: "0 selections")
         expect(page).to have_css("h3", text: "You have no bookmarks")
       end

--- a/spec/features/skip_to_nav_spec.rb
+++ b/spec/features/skip_to_nav_spec.rb
@@ -30,7 +30,7 @@ feature "Skip-to Navigation" do
     fill_in 'q', with: '20'
     find('button#search').trigger('click')
     find(:css, '#toggle_bookmark_20').set(true)
-    visit selections_path
+    visit bookmarks_path
 
     within "#skip-link" do
       expect(page).to have_css("a[href='#search_field']", text: "Skip to search")

--- a/spec/features/tabbed_selections_spec.rb
+++ b/spec/features/tabbed_selections_spec.rb
@@ -66,4 +66,42 @@ RSpec.describe 'Tabbed selections UI', type: :feature do
       expect(page).to have_css('.document', count: 3)
     end
   end
+
+  describe 'clearing lists' do
+    it 'clears article lists' do
+      visit '/selections/articles'
+
+      within('#sortAndPerPage') do
+        click_link 'Clear list'
+      end
+
+      expect(page).to have_css('.btn', text: '3 catalog items')
+      expect(page).to have_css('.btn', text: '0 articles+ items')
+    end
+
+    it 'clears catalog lists' do
+      visit '/selections'
+
+      within('#sortAndPerPage') do
+        click_link 'Clear list'
+      end
+
+      expect(page).to have_css('.btn', text: '0 catalog items')
+      expect(page).to have_css('.btn', text: '4 articles+ items')
+    end
+
+    it 'clears both lists' do
+      visit '/selections'
+
+      expect(page).to have_css('.btn', text: '3 catalog items')
+      expect(page).to have_css('.btn', text: '4 articles+ items')
+
+      within('#search-subnavbar ul.recent-selections') do
+        click_link 'Clear list'
+      end
+
+      expect(page).to have_css('.btn', text: '0 catalog items')
+      expect(page).to have_css('.btn', text: '0 articles+ items')
+    end
+  end
 end

--- a/spec/features/tabbed_selections_spec.rb
+++ b/spec/features/tabbed_selections_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Tabbed selections UI', type: :feature do
+  let(:user) { User.create!(email: 'example@stanford.edu', password: 'totallysecurepassword') }
+  before do
+    StubArticleService::SAMPLE_RESULTS.map do |article|
+      Bookmark.create!(document_id: article.id, user: user, record_type: 'article')
+    end
+
+    %w[1 2 3].each do |doc_id|
+      Bookmark.create!(document_id: doc_id, user: user)
+    end
+
+    stub_current_user(user: user)
+    stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+  end
+
+  describe 'selections drop down', js: true do
+    it 'renders a drop down with counts for each type of record selection' do
+      visit '/'
+
+      within('#search-subnavbar') do
+        expect(page).to have_css('li a', text: 'Selections (7)')
+        find('li a', text: 'Selections (7)').trigger('click')
+
+        within('ul.recent-selections') do
+          expect(page).to have_css('li a', text: 'Catalog selections (3)')
+          expect(page).to have_css('li a', text: 'Articles+ selections (4)')
+        end
+      end
+    end
+  end
+
+  describe 'article records' do
+    it 'renders selected articles' do
+      visit '/selections/articles'
+
+      expect(page).to have_css('.btn', text: '3 catalog items')
+      expect(page).to have_css('.btn', text: '4 articles+ items')
+      expect(page).to have_css('.document', count: 4)
+    end
+
+    it 'paginates articles' do
+      visit '/selections/articles?per_page=2'
+      expect(page).to have_css('h2', text: '4 selections')
+      expect(page).to have_css('.document-counter', text: '1.')
+      expect(page).to have_css('.document-counter', text: '2.')
+      expect(page).to have_css('#citeLink', text: '1 - 2')
+
+      visit '/selections/articles?per_page=2&page=2'
+      expect(page).to have_css('h2', text: '4 selections')
+      expect(page).to have_css('.document-counter', text: '3.')
+      expect(page).to have_css('.document-counter', text: '4.')
+      expect(page).to have_css('#citeLink', text: '3 - 4')
+    end
+  end
+
+  describe 'catalog records' do
+    it 'renders selected catalog documents' do
+      visit '/selections'
+
+      expect(page).to have_css('.btn', text: '3 catalog items')
+      expect(page).to have_css('.btn', text: '4 articles+ items')
+      expect(page).to have_css('.document', count: 3)
+    end
+  end
+end

--- a/spec/features/tabbed_selections_spec.rb
+++ b/spec/features/tabbed_selections_spec.rb
@@ -44,13 +44,11 @@ RSpec.describe 'Tabbed selections UI', type: :feature do
 
     it 'paginates articles' do
       visit '/selections/articles?per_page=2'
-      expect(page).to have_css('h2', text: '4 selections')
       expect(page).to have_css('.document-counter', text: '1.')
       expect(page).to have_css('.document-counter', text: '2.')
       expect(page).to have_css('#citeLink', text: '1 - 2')
 
       visit '/selections/articles?per_page=2&page=2'
-      expect(page).to have_css('h2', text: '4 selections')
       expect(page).to have_css('.document-counter', text: '3.')
       expect(page).to have_css('.document-counter', text: '4.')
       expect(page).to have_css('#citeLink', text: '3 - 4')
@@ -97,7 +95,7 @@ RSpec.describe 'Tabbed selections UI', type: :feature do
       expect(page).to have_css('.btn', text: '4 articles+ items')
 
       within('#search-subnavbar ul.recent-selections') do
-        click_link 'Clear list'
+        click_link 'Clear all lists'
       end
 
       expect(page).to have_css('.btn', text: '0 catalog items')

--- a/spec/helpers/bookmarks_helper_spec.rb
+++ b/spec/helpers/bookmarks_helper_spec.rb
@@ -22,6 +22,12 @@ describe BookmarksHelper do
       params[:controller] = "bookmarks"
       expect(helper.bookmarks?).to be_truthy
     end
+
+    it 'should return true if in the article_selections controller' do
+      params[:controller] = 'article_selections'
+      expect(helper.bookmarks?).to be_truthy
+    end
+
     it "should return false if not bookmarks controller" do
       params[:controller] = "catalog"
       expect(helper.bookmarks?).to be_falsey

--- a/spec/services/eds/search_service_spec.rb
+++ b/spec/services/eds/search_service_spec.rb
@@ -13,46 +13,53 @@ RSpec.describe Eds::SearchService do
   subject(:instance) { described_class.new(blacklight_config) }
   subject(:user_params) { {} }
 
-  before do
-    stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
-    stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first])
-  end
+  context 'with a single document' do
+    before do
+      stub_article_service(type: :single, docs: [StubArticleService::SAMPLE_RESULTS.first])
+    end
 
-  it '#search_results' do
-    results = instance.search_results(user_params)
-    expect(results.length).to eq 2
-    expect(results[0]).to be_an(Blacklight::Solr::Response)
-    expect(results[1]).to eq StubArticleService::SAMPLE_RESULTS
-  end
+    it '#fetch_one' do
+      results = instance.fetch(StubArticleService::SAMPLE_RESULTS.first.id)
+      expect(results.length).to eq 2
+      expect(results[0]).to be_an(Blacklight::Solr::Response)
+      expect(results[1].id).to eq StubArticleService::SAMPLE_RESULTS.first.id
+    end
 
-  describe '#fetch' do
-    context 'with a single id' do
+    describe '#fetch' do
       it 'returns a single result' do
         results = instance.fetch('a')
         expect(results[1].id).to eq StubArticleService::SAMPLE_RESULTS.first.id
         expect(results[1]).to be_an SolrDocument
       end
     end
-    context 'with multiple ids' do
-      it 'returns a single result' do
+  end
+
+  context 'with multiple documents' do
+    before do
+      stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
+    end
+
+    it '#search_results' do
+      results = instance.search_results(user_params)
+      expect(results.length).to eq 2
+      expect(results[0]).to be_an(Blacklight::Solr::Response)
+      expect(results[1]).to eq StubArticleService::SAMPLE_RESULTS
+    end
+
+
+    it '#fetch_many' do
+      results = instance.fetch_many(StubArticleService::SAMPLE_RESULTS.map(&:id), {})
+      expect(results.length).to eq 2
+      expect(results[0]).to be_an(Blacklight::Solr::Response)
+      expect(results[1].count).to eq StubArticleService::SAMPLE_RESULTS.count
+    end
+
+    describe '#fetch' do
+      it 'returns an array of results' do
         results = instance.fetch(%w[a b])
         expect(results[1].count).to eq StubArticleService::SAMPLE_RESULTS.count
         expect(results[1]).to be_an Array
       end
     end
-  end
-
-  it '#fetch_one' do
-    results = instance.fetch(StubArticleService::SAMPLE_RESULTS.first.id)
-    expect(results.length).to eq 2
-    expect(results[0]).to be_an(Blacklight::Solr::Response)
-    expect(results[1].id).to eq StubArticleService::SAMPLE_RESULTS.first.id
-  end
-
-  it '#fetch_many' do
-    results = instance.fetch_many(StubArticleService::SAMPLE_RESULTS.map(&:id), {})
-    expect(results.length).to eq 2
-    expect(results[0]).to be_an(Blacklight::Solr::Response)
-    expect(results[1].count).to eq StubArticleService::SAMPLE_RESULTS.count
   end
 end

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -60,6 +60,9 @@ module StubArticleService
       allow_any_instance_of(Eds::Repository).to receive(:search).and_return(
         StubArticleResponse.new(docs)
       )
+      allow_any_instance_of(Eds::Repository).to receive(:find_by_ids).and_return(
+        StubArticleResponse.new(docs)
+      )
     when :single
       raise "Single document response requsted but #{docs.length} provided." if docs.many?
       allow_any_instance_of(Eds::Repository).to receive(:find).and_return(

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -68,6 +68,9 @@ module StubArticleService
       allow_any_instance_of(Eds::Repository).to receive(:find).and_return(
         StubArticleResponse.new([docs.first])
       )
+      allow_any_instance_of(Eds::Repository).to receive(:find_by_ids).and_return(
+        StubArticleResponse.new([docs.first])
+      )
     when :error
       allow_any_instance_of(Eds::Repository).to receive(:search).and_raise(EBSCO::EDS::BadRequest)
     else

--- a/spec/views/catalog/access_panels/_location.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_location.html.erb_spec.rb
@@ -42,7 +42,7 @@ describe "catalog/access_panels/_location.html.erb", js:true do
     end
 
     it 'should display the callnumber without live lookup' do
-      expect(rendered).to have_css 'td', 'ABC 123'
+      expect(rendered).to have_css 'td', text: 'ABC 123'
       expect(rendered).to_not have_css 'td[data-live-lookup-id]'
     end
   end

--- a/spec/views/preview/_show_mods.html.erb_spec.rb
+++ b/spec/views/preview/_show_mods.html.erb_spec.rb
@@ -41,7 +41,7 @@ describe "preview/_show_mods.html.erb" do
   end
 
   it 'should display summary section' do
-    expect(rendered).to have_css('dt', 'Description')
+    expect(rendered).to have_css('dt', text: 'Summary')
     expect(rendered).to have_css('dd', text: /Nunc venenatis et odio ac elementum. Nulla ornare faucibus laoreet/)
   end
 

--- a/spec/views/recent_selections/index.html.erb_spec.rb
+++ b/spec/views/recent_selections/index.html.erb_spec.rb
@@ -2,11 +2,13 @@ require "spec_helper"
 
 describe "recent_selections/index.html.erb" do
   before do
-    document = SolrDocument.new(title_display: "Testing 123")
-    assign(:recent_selections, [document])
+    assign(:catalog_count, 500)
+    assign(:article_count, 45)
     render
   end
-  it "should have the title" do
-    expect(rendered).to have_css("li", text: "Testing 123")
+
+  it 'has the counts' do
+    expect(rendered).to have_css('li a', text: 'Catalog selections (500)')
+    expect(rendered).to have_css('li a', text: 'Articles+ selections (45)')
   end
 end


### PR DESCRIPTION
Closes #1885 

### TODO
- [x] Address issue with paginating articles
  * We may need a change to the EBSCO gem to handle selections differently. Currently waiting to hear back.  If this isn't going to be possible, we may need to remove certain things from the Article Selections list UI such as sort.
- [x] Address routing/partial overriding for Article selections (particularly for things in `Send to` drop down)
- [x] Add selection counts to tabs
- [ ] Evaluate performance of rendering Article selections (hitting the API 20 times to build a page seems like it may be problematic)
- [x] Add addl. tests as needed
- [x] Update CHANGELOG

## Selections drop down
<img width="335" alt="drop-down" src="https://user-images.githubusercontent.com/96776/48295723-8d568700-e443-11e8-9b07-767d63d80585.png">

## Catalog selections
<img width="1312" alt="catalog-selections" src="https://user-images.githubusercontent.com/96776/48295722-8d568700-e443-11e8-856a-ea88c691cc44.png">

## Article selections
<img width="1219" alt="article-selections" src="https://user-images.githubusercontent.com/96776/48295721-8d568700-e443-11e8-9f45-764c89e05f1e.png">


