### PR TITLE
Restyle record metadata and panel headers 

### DIFF
--- a/app/assets/stylesheets/modules/record-metadata-section.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.scss
@@ -2,6 +2,10 @@
   .section {
     padding-bottom: 0;
   }
+
+  h3 {
+    color: $smoke;
+  }
 }
 
 .record-metadata, .upper-record-metadata {

--- a/app/views/articles/_show_default.html.erb
+++ b/app/views/articles/_show_default.html.erb
@@ -26,9 +26,9 @@
               <div class='section'>
                 <div class='section-heading'>
                   <% mini_map_sections[section_name.downcase] = true %>
-                  <h2 id="<%= section_name.downcase %>">
+                  <h3 id="<%= section_name.downcase %>">
                     <%= section_name -%>
-                  </h2>
+                  </h3>
                 </div>
             <% end -%>
               <div class='section-body'>

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -1,5 +1,6 @@
 <% document ||= @document %>
 <% if document.access_panels.library_locations? %>
+  <h2>At the library</h2>
   <div data-live-lookup-id="<%= document[:id] %>" data-live-lookup-url="<%= availability_index_path %>">
     <% document.access_panels.library_locations.libraries.each do |library| %>
       <div class="panel panel-default access-panel panel-library-location" <%= "data-hours-route='#{hour_path(library.code)}'".html_safe if library.holding_library? %>>

--- a/app/views/catalog/record/_marc_metadata_sections.html.erb
+++ b/app/views/catalog/record/_marc_metadata_sections.html.erb
@@ -23,7 +23,7 @@
 <% if contributors.present? %>
   <div class="section" id="<%= t('record_side_nav.contributors.id') %>" data-side-nav-class="<%= t('record_side_nav.contributors.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.contributors.icon').html_safe %> Creators/Contributors</h2>
+      <h3><%= t('record_side_nav.contributors.icon').html_safe %> Creators/Contributors</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -36,7 +36,7 @@
 <% if contents_summary.present? %>
   <div class="section" id="<%= t('record_side_nav.contents_summary.id') %>" data-side-nav-class="<%= t('record_side_nav.contents_summary.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.contents_summary.icon').html_safe %> Contents/Summary</h2>
+      <h3><%= t('record_side_nav.contents_summary.icon').html_safe %> Contents/Summary</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -49,7 +49,7 @@
 <% if subjects.present? %>
   <div class="section" id="<%= t('record_side_nav.subjects.id') %>" data-side-nav-class="<%= t('record_side_nav.subjects.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.subjects.icon').html_safe %> Subjects</h2>
+      <h3><%= t('record_side_nav.subjects.icon').html_safe %> Subjects</h3>
     </div>
     <div class="section-body">
       <%= subjects %>
@@ -60,7 +60,7 @@
 <% if bibliography.present? %>
   <div class="section" id="<%= t('record_side_nav.bibliography_info.id') %>" data-side-nav-class="<%= t('record_side_nav.bibliography_info.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.bibliography_info.icon').html_safe %> Bibliographic information</h2>
+      <h3><%= t('record_side_nav.bibliography_info.icon').html_safe %> Bibliographic information</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -73,7 +73,7 @@
 <% if Settings.BOOKPLATES && document.bookplates.present? %>
   <div class="section">
     <div class="section-heading">
-      <h2>Acquired with support from</h2>
+      <h3>Acquired with support from</h3>
     </div>
     <div class="section-body row container-fluid">
       <% document.bookplates.each_slice(2).each do |bookplates| %>

--- a/app/views/catalog/record/_metadata_panels.html.erb
+++ b/app/views/catalog/record/_metadata_panels.html.erb
@@ -1,4 +1,3 @@
-<h2 class="sr-only">Access</h2>
 <div class="metadata-panels">
   <%= render "catalog/access_panels/online" %>
   <%= render "catalog/access_panels/course_reserve" %>

--- a/app/views/catalog/record/_mods_metadata_sections.html.erb
+++ b/app/views/catalog/record/_mods_metadata_sections.html.erb
@@ -24,7 +24,7 @@
 <% if contributors.present? %>
   <div class="section" id="<%= t('record_side_nav.contributors.id') %>" data-side-nav-class="<%= t('record_side_nav.contributors.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.contributors.icon').html_safe %> Creators/Contributors</h2>
+      <h3><%= t('record_side_nav.contributors.icon').html_safe %> Creators/Contributors</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -37,7 +37,7 @@
 <% if abstract_contents.present? %>
   <div class="section" id="<%= t('record_side_nav.abstract_contents.id') %>" data-side-nav-class="<%= t('record_side_nav.abstract_contents.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.abstract_contents.icon').html_safe %> Abstract/Contents</h2>
+      <h3><%= t('record_side_nav.abstract_contents.icon').html_safe %> Abstract/Contents</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -50,7 +50,7 @@
 <% if subjects.present? %>
   <div class="section" id="<%= t('record_side_nav.subjects.id') %>" data-side-nav-class="<%= t('record_side_nav.subjects.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.subjects.icon').html_safe %> Subjects</h2>
+      <h3><%= t('record_side_nav.subjects.icon').html_safe %> Subjects</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -63,7 +63,7 @@
 <% if bibliography.present? %>
   <div class="section" id="<%= t('record_side_nav.bibliography_info.id') %>" data-side-nav-class="<%= t('record_side_nav.bibliography_info.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.bibliography_info.icon').html_safe %> Bibliographic information</h2>
+      <h3><%= t('record_side_nav.bibliography_info.icon').html_safe %> Bibliographic information</h3>
     </div>
     <div class="section-body">
       <dl>
@@ -76,7 +76,7 @@
 <% if access_conditions.present? %>
   <div class="section" id="<%= t('record_side_nav.access_conditions.id') %>" data-side-nav-class="<%= t('record_side_nav.access_conditions.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.access_conditions.icon').html_safe %> Access conditions </h2>
+      <h3><%= t('record_side_nav.access_conditions.icon').html_safe %> Access conditions </h3>
     </div>
     <div class="section-body">
       <dl>

--- a/app/views/catalog/record/_record_metadata_default.html.erb
+++ b/app/views/catalog/record/_record_metadata_default.html.erb
@@ -5,6 +5,7 @@
     <%= render "catalog/record/metadata_panels" %>
   </div>
   <div class="record-sections col-md-8">
+    <h2>Description</h2>
     <% if document.respond_to?(:to_marc) %>
       <%= render "catalog/record/marc_metadata_sections" %>
     <% elsif document.respond_to?(:mods) %>

--- a/spec/features/bookplates_spec.rb
+++ b/spec/features/bookplates_spec.rb
@@ -5,7 +5,7 @@ describe 'Bookplates' do
     it 'displays bookplate data when present' do
       visit solr_document_path('45')
 
-      expect(page).to have_css('h2', text: 'Acquired with support from')
+      expect(page).to have_css('h3', text: 'Acquired with support from')
       expect(page).to have_css('.bookplate', count: 2)
 
       within(first('.bookplate')) do

--- a/spec/features/file_collection_spec.rb
+++ b/spec/features/file_collection_spec.rb
@@ -16,8 +16,8 @@ feature "File Collection" do
     visit solr_document_path('31')
 
     expect(page).to have_css("h1", text: "File Collection1") # Title
-    expect(page).to have_css("h2", text: "Subjects")
-    expect(page).to have_css("h2", text: "Bibliographic information")
-    expect(page).to have_css("h2", text: "Access conditions")
+    expect(page).to have_css('h3', text: "Subjects")
+    expect(page).to have_css('h3', text: "Bibliographic information")
+    expect(page).to have_css('h3', text: "Access conditions")
   end
 end

--- a/spec/features/image_collection_spec.rb
+++ b/spec/features/image_collection_spec.rb
@@ -18,9 +18,9 @@ feature "Image Collection", js: true do
     visit solr_document_path('29')
 
     expect(page).to have_css("h1", text: "Image Collection1") # Title
-    expect(page).to have_css("h2", text: "Subjects")
-    expect(page).to have_css("h2", text: "Bibliographic information")
-    expect(page).to have_css("h2", text: "Access conditions")
+    expect(page).to have_css('h3', text: "Subjects")
+    expect(page).to have_css('h3', text: "Bibliographic information")
+    expect(page).to have_css('h3', text: "Access conditions")
 
     expect(page).to have_css(".image-filmstrip")
 

--- a/spec/features/merged_file_collection_spec.rb
+++ b/spec/features/merged_file_collection_spec.rb
@@ -22,8 +22,8 @@ feature "Merged File Collections", js: true do
       expect(page).to have_css("a", text: /File Item/, count: 3)
     end
 
-    expect(page).to have_css('h2', text: 'Contents/Summary')
-    expect(page).to have_css('h2', text: 'Subjects')
-    expect(page).to have_css('h2', text: 'Bibliographic information')
+    expect(page).to have_css('h3', text: 'Contents/Summary')
+    expect(page).to have_css('h3', text: 'Subjects')
+    expect(page).to have_css('h3', text: 'Bibliographic information')
   end
 end

--- a/spec/features/merged_image_collections_spec.rb
+++ b/spec/features/merged_image_collections_spec.rb
@@ -39,8 +39,8 @@ feature "Merged Image Collections", js: true do
       end
     end
 
-    expect(page).to have_css('h2', text: 'Contents/Summary')
-    expect(page).to have_css('h2', text: 'Subjects')
-    expect(page).to have_css('h2', text: 'Bibliographic information')
+    expect(page).to have_css('h3', text: 'Contents/Summary')
+    expect(page).to have_css('h3', text: 'Subjects')
+    expect(page).to have_css('h3', text: 'Bibliographic information')
   end
 end

--- a/spec/features/merged_image_spec.rb
+++ b/spec/features/merged_image_spec.rb
@@ -18,8 +18,8 @@ feature "Merged Images" do
       expect(page).to have_css(".panel-body a", text: "Merged Image Collection1")
     end
     # Metadata sections
-    expect(page).to have_css("h2", text: "Contents/Summary")
-    expect(page).to have_css("h2", text: "Subjects")
-    expect(page).to have_css("h2", text: "Bibliographic information")
+    expect(page).to have_css('h3', text: "Contents/Summary")
+    expect(page).to have_css('h3', text: "Subjects")
+    expect(page).to have_css('h3', text: "Bibliographic information")
   end
 end

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -142,8 +142,8 @@ describe SearchWorksRecordMailer do
       end
 
       it 'should include Subjects and Bibliographic information from both MARC and MODS records' do
-        expect(mail.body).to have_css('h2', text: 'Subjects', count: 2)
-        expect(mail.body).to have_css('h2', text: 'Bibliographic information', count: 2)
+        expect(mail.body).to have_css('h3', text: 'Subjects', count: 2)
+        expect(mail.body).to have_css('h3', text: 'Bibliographic information', count: 2)
       end
 
       it 'should include the HTML markup for MARC records' do
@@ -184,7 +184,7 @@ describe SearchWorksRecordMailer do
         end
         let(:mail) { SearchWorksRecordMailer.full_email_record([bookplate_document], params, url_params) }
         it 'renders the bookplate data successfully' do
-          expect(mail.body).to have_css('h2', text: 'Acquired with support from')
+          expect(mail.body).to have_css('h3', text: 'Acquired with support from')
           expect(mail.body).to have_css('.media-body', text: /BOOKPLATE-TEXT/)
         end
       end

--- a/spec/views/catalog/record/_marc_metadata_sections.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_metadata_sections.html.erb_spec.rb
@@ -12,9 +12,9 @@ describe "catalog/record/_marc_metadata_sections.html.erb" do
     end
 
     it "should display correct sections" do
-      expect(rendered).to have_css("h2", text: "Contributors")
-      expect(rendered).to have_css("h2", text: "Contents/Summary")
-      expect(rendered).to have_css("h2", text: "Bibliographic information")
+      expect(rendered).to have_css('h3', text: "Contributors")
+      expect(rendered).to have_css('h3', text: "Contents/Summary")
+      expect(rendered).to have_css('h3', text: "Bibliographic information")
     end
 
     it "should have side nav content handles" do

--- a/spec/views/catalog/record/_mods_metadata_sections.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_metadata_sections.html.erb_spec.rb
@@ -11,11 +11,11 @@ describe "catalog/record/_mods_metadata_sections.html.erb" do
     end
 
     it "should display correct sections" do
-      expect(rendered).to have_css("h2", text: "Contributors")
-      expect(rendered).to have_css("h2", text: "Abstract/Contents")
-      expect(rendered).to have_css("h2", text: "Subjects")
-      expect(rendered).to have_css("h2", text: "Bibliographic information")
-      expect(rendered).to have_css("h2", text: "Access conditions")
+      expect(rendered).to have_css('h3', text: "Contributors")
+      expect(rendered).to have_css('h3', text: "Abstract/Contents")
+      expect(rendered).to have_css('h3', text: "Subjects")
+      expect(rendered).to have_css('h3', text: "Bibliographic information")
+      expect(rendered).to have_css('h3', text: "Access conditions")
     end
 
     it "should have side nav content handles" do


### PR DESCRIPTION
Part of #2024

## Acceptance criteria
- [x] In the `record-sections` section, add `<h2>Description</h2>` at the top
- [x] Change all other `<h2>`s in that section to `<h3>` (Creators, Contents, Subjects, Bib Info, Bookplates)
- [x] Remove `<h2 class="sr-only">Access</h2>` from the `record-panels` section. (More specific headings will replace it in the column.)
- [x] Add `<h2>At the library</h2>` above the first `panel-library-location`

## TODOs
- [x] update tests
- [x] get clarity on Article metadata headers

## Current state
### SDR item
![sdr-item](https://user-images.githubusercontent.com/5402927/48094619-7e63a080-e1c7-11e8-9da5-3a0ea37781da.png)

### Article
![article](https://user-images.githubusercontent.com/5402927/48094620-7e63a080-e1c7-11e8-9fc2-6e2c7f5a9c18.png)

### MARC
![marc](https://user-images.githubusercontent.com/5402927/48094621-7e63a080-e1c7-11e8-8057-421b8764991c.png)

