### PR TITLE
ensure that one url is sent in the encoded url (not an array)

### DIFF
--- a/app/models/concerns/iiif_concern.rb
+++ b/app/models/concerns/iiif_concern.rb
@@ -2,6 +2,6 @@
 # Module that provides SolrDocument IIIF specific methods
 module IiifConcern
   def iiif_manifest
-    fetch(:iiif_manifest_url_ssim, nil)
+    fetch(:iiif_manifest_url_ssim, []).first
   end
 end

--- a/spec/views/catalog/_show_mods.html.erb_spec.rb
+++ b/spec/views/catalog/_show_mods.html.erb_spec.rb
@@ -16,10 +16,10 @@ describe 'catalog/_show_mods.html.erb' do
     end
     context 'with a iiif manifest' do
       let(:document) do
-        SolrDocument.new(druid: 'abc123', modsxml: mods_001, iiif_manifest_url_ssim: 'example.com')
+        SolrDocument.new(druid: 'abc123', modsxml: mods_001, iiif_manifest_url_ssim: ['example.com'])
       end
       it 'includes IIIF Drag n Drop link' do
-        expect(rendered).to have_css 'a.iiif-dnd'
+        expect(rendered).to have_css 'a.iiif-dnd[href="https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?manifest=example.com"]'
       end
     end
   end


### PR DESCRIPTION
This fixes an issue where the IIIF manifest url could be encoded as
an array.
