### PR TITLE
Update ebsco-eds to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+- Updated the EBSCO gem to 1.0.5 to address issues around records throwing errors when trying to sanitize HTML [#1704](https://github.com/sul-dlss/SearchWorks/issues/1704)
 ### Security
 
 ## [3.3.7] - 2018-11-06

--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'jquery-datatables-rails'
 gem 'roadie-rails', '~> 1.1'
 gem 'rubocop', '~> 0.36'
 gem 'rack-utf8_sanitizer'
-gem 'ebsco-eds', '1.0.3' # External vendor, upgrade requires testing
+gem 'ebsco-eds', '1.0.5' # External vendor, upgrade requires testing
 gem 'whenever' # manages cron jobs
 gem 'bitly' # For bit.ly
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-logic (~> 0.4, >= 0.4.0)
       dry-types (~> 0.13.1)
-    ebsco-eds (1.0.3)
+    ebsco-eds (1.0.5)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
       citeproc (>= 1.0.4, < 2.0)
@@ -573,7 +573,7 @@ DEPENDENCIES
   devise-guests
   devise-remote-user
   dlss-capistrano
-  ebsco-eds (= 1.0.3)
+  ebsco-eds (= 1.0.5)
   faraday (~> 0.10)
   font-awesome-rails
   honeybadger (~> 3.0)


### PR DESCRIPTION
This is related to #1704.  Not sure if it closes it or not, but it stops these records from throwing errors (and appears to no longer display the raw HTML as described in the ticket).

