### PR TITLE
Adds support for updated Hoover Archive requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - Now returning a 404 Not Found error when an article record is not found [#2133](https://github.com/sul-dlss/SearchWorks/pull/2133)
+- Updates the way that Hoover Archive records are requested and shown in the access panel [#2123](https://github.com/sul-dlss/SearchWorks/pull/2123)
 ### Removed
 ### Fixed
 - Updated the EBSCO gem to 1.0.5 to address issues around records throwing errors when trying to sanitize HTML [#1704](https://github.com/sul-dlss/SearchWorks/issues/1704)

--- a/app/assets/stylesheets/modules/availability-icons.scss
+++ b/app/assets/stylesheets/modules/availability-icons.scss
@@ -21,7 +21,8 @@ $noncirc-color: darkorange;
     @extend .fa-truck;
     color: $noncirc-color;
   }
-  .unavailable {
+  .unavailable,
+  .in_process {
     @extend .fa-times;
     color: #990000;
   }

--- a/app/views/catalog/access_panels/_location.html.erb
+++ b/app/views/catalog/access_panels/_location.html.erb
@@ -23,7 +23,15 @@
               <%= content_tag(:div, class: 'bound-with-note note-highlight') { render document.bound_with_note } %>
             <% else %>
               <% if location_level_request_link?(library, location) %>
-                <%= link_to_request_link(document: document, library: library, callnumber: location.items.first, class: 'btn btn-default btn-xs request-button pull-right') %>
+                <% if library.hoover_archive? %>
+                  <% if document.index_links.finding_aid.present? %>
+                    <%= link_to 'Request via Finding Aid', document.index_links.finding_aid.first.href, class: 'btn btn-default btn-xs request-button pull-right' %>
+                  <% else %>
+                    <div class='pull-right'>Not available to request</div>
+                  <% end %>
+                <% else %>
+                  <%= link_to_request_link(document: document, library: library, callnumber: location.items.first, class: 'btn btn-default btn-xs request-button pull-right') %>
+                <% end %>
               <% end %>
             <% end %>
             <% if location.mhld.present? %>

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1114,7 +1114,8 @@ module Constants
     'unavailable' => 'Unavailable',
     'noncirc' => 'In-library use',
     'unknown' => 'Unknown',
-    'noncirc_page' => 'In-library use'
+    'noncirc_page' => 'In-library use',
+    'in_process' => 'In process'
   }
   HIDE_1ST_IND = %w(760 762 765 767 770 772 773 774 775 776 777 780 785 786 787)
   HIDE_1ST_IND0 = %w(541 542 561 583 590)

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1249,12 +1249,12 @@ module Constants
 
   LIBRARY_INSTRUCTIONS = {
     'HOOVER' => {
-      heading: 'All items must be requested in advance',
-      text: 'Stanford ID holders may be able to check out some monographs marked "Available" next to the call number. "In-library use" call numbers are for reading-room use only.'
+      heading: 'Access',
+      text: 'Items must be requested in advance and viewed on-site.'
     },
     'HV-ARCHIVE' => {
-      heading: 'All items must be viewed on site',
-      text: "If there's a finding aid shown above, use the Online Archive of California link to request items. Otherwise, use the Request on-site access button below."
+      heading: 'Access',
+      text: 'Items must be requested in advance and viewed on-site.'
     },
     'RUMSEYMAP' => {
       heading: 'All items must be viewed on site',

--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -1,5 +1,6 @@
 require 'holdings/append_mhld'
 require 'holdings/callnumber'
+require 'holdings/in_process'
 require 'holdings/library'
 require 'holdings/location'
 require 'holdings/mhld'

--- a/lib/holdings/in_process.rb
+++ b/lib/holdings/in_process.rb
@@ -1,0 +1,23 @@
+class Holdings
+  class Status
+    ##
+    # Representing libraries that are in process
+    class InProcess
+      LIBRARIES = ['HV-ARCHIVE'].freeze
+
+      def initialize(callnumber)
+        @callnumber = callnumber
+      end
+
+      def in_process?
+        library_in_process?
+      end
+
+      private
+
+      def library_in_process?
+        LIBRARIES.include?(@callnumber.library)
+      end
+    end
+  end
+end

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -35,6 +35,10 @@ class Holdings
       @code == 'ZOMBIE'
     end
 
+    def hoover_archive?
+      @code == 'HV-ARCHIVE'
+    end
+
     def present?
       @items.any?(&:present?) ||
         (mhld.present? && mhld.any?(&:present?)) ||

--- a/lib/holdings/status.rb
+++ b/lib/holdings/status.rb
@@ -13,6 +13,8 @@ class Holdings
 
     def availability_class
       case
+      when in_process?
+        'in_process'
       when unavailable?
         'unavailable'
       when noncirc_page?
@@ -57,6 +59,10 @@ class Holdings
 
     def unknown?
       Holdings::Status::Unknown.new(@callnumber).unknown?
+    end
+
+    def in_process?
+      Holdings::Status::InProcess.new(@callnumber).in_process?
     end
 
     def as_json(*)

--- a/spec/lib/holdings/in_process_spec.rb
+++ b/spec/lib/holdings/in_process_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Holdings::Status::InProcess do
+  describe 'in_process libraries' do
+    let(:in_process_libraries) { %w[HV-ARCHIVE] }
+
+    it 'should identify any items as in_process' do
+      in_process_libraries.each do |library|
+        expect(Holdings::Status::InProcess.new(OpenStruct.new(library: library))).to be_in_process
+      end
+    end
+  end
+end

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -92,6 +92,12 @@ describe Holdings::Library do
       expect(zombie).to_not be_holding_library
     end
   end
+  describe '#hoover_archive?' do
+    let(:hv_archive) { Holdings::Library.new('HV-ARCHIVE') }
+    it 'is true' do
+      expect(hv_archive.hoover_archive?).to be true
+    end
+  end
   describe "#mhld" do
     let(:library) {Holdings::Library.new("GREEN")}
     it "should be an accessible attribute" do

--- a/spec/views/catalog/access_panels/_location.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_location.html.erb_spec.rb
@@ -286,4 +286,39 @@ describe "catalog/access_panels/_location.html.erb", js:true do
       expect(rendered).to have_css('p', text: 'Request items at least 2 days before you visit to allow retrieval from off-site storage. You can request at most 5 items per day.')
     end
   end
+  describe 'Hoover Archives' do
+    context 'when a finding aid is present' do
+      before do
+        assign(
+          :document,
+          SolrDocument.new(
+            id: '123',
+            item_display: ['123 -|- HV-ARCHIVE -|- STACKS -|- -|- -|- -|- -|- -|- ABC -|-'],
+            url_suppl: ['http://oac.cdlib.org/findaid/ark:/something-else']
+          )
+        )
+        render
+      end
+      it 'renders request via OAC finding aid' do
+        expect(rendered).to have_css 'a[href*="oac"]', text: 'Request via Finding Aid'
+      end
+    end
+    context 'without a finding aid' do
+      before do
+        assign(
+          :document,
+          SolrDocument.new(
+            id: '123',
+            item_display: ['123 -|- HV-ARCHIVE -|- STACKS -|- -|- -|- -|- -|- -|- ABC -|-']
+          )
+        )
+        render
+      end
+      it 'renders not available text' do
+        expect(rendered).to have_css '.panel-body .pull-right', text: 'Not available to request'
+        expect(rendered).to have_css '.availability-icon.in_process'
+        expect(rendered).to have_css '.status-text', text: 'In process'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2059 

This PR adds custom support for request links of Hoover Archives content in SearchWorks.

## 12314233 Item with OAC link
![screen shot 2018-11-07 at 3 39 49 pm](https://user-images.githubusercontent.com/1656824/48165632-64978b80-e2a3-11e8-9fa8-274aaf2e87c0.png)

## 12822793 Item without OAC link
![screen shot 2018-11-07 at 3 40 27 pm](https://user-images.githubusercontent.com/1656824/48165658-7842f200-e2a3-11e8-8427-e67dd24608ef.png)
