### PR TITLE
Add headings to managed PURL/digital serial partials and move metadat…

### DIFF
--- a/app/views/catalog/_managed_purl_embed.html.erb
+++ b/app/views/catalog/_managed_purl_embed.html.erb
@@ -1,4 +1,7 @@
 <div class="managed-purl row">
+  <div class="col-md-12">
+    <h2>Digital content</h2>
+  </div>
   <div class="col-md-4">
     <div class="panel panel-default managed-purl-panel ">
       <div class="managed-purl-heading">

--- a/app/views/catalog/_show_marc.html.erb
+++ b/app/views/catalog/_show_marc.html.erb
@@ -2,21 +2,24 @@
 
 <% if document.marc_links.managed_purls.many? %>
   <% add_purl_embed_header(document) %>
-  <%= render 'catalog/managed_purl_embed' %>
-  <div class='upper-record-metadata row'>
-    <div class="col-md-8 col-md-offset-4">
-      <%= render 'catalog/record/marc_upper_metadata_items' %>
-    </div>
+
+  <div class='upper-record-metadata'>
+    <%= render 'catalog/record/marc_upper_metadata_items' %>
   </div>
+
+  <%= render 'catalog/managed_purl_embed' %>
 <% elsif document.druid %>
   <% add_purl_embed_header(document) %>
-  <div class='upper-record-metadata row'>
-    <div class="col-md-7 purl-embed-viewer">
+
+  <div class="upper-record-metadata col-md-12">
+    <%= render 'catalog/record/marc_upper_metadata_items' %>
+  </div>
+
+  <div class="purl-embed-viewer row">
+    <div class="col-md-12">
+      <h2>Digital content</h2>
       <div data-behavior="purl-embed" data-embed-url="<%= embed_path(document.druid) %>"></div>
       <%= iiif_drag_n_drop(document.iiif_manifest) if document.iiif_manifest %>
-    </div>
-    <div class="col-md-5">
-      <%= render 'catalog/record/marc_upper_metadata_items' %>
     </div>
   </div>
 <% else %>


### PR DESCRIPTION
…a above embed content.

Closes #2106 

## 9613050
<img width="1006" alt="9613050" src="https://user-images.githubusercontent.com/96776/48181234-8ad91d80-e2db-11e8-95e2-66e78ca03a2e.png">

## 1071767
<img width="1242" alt="1071767" src="https://user-images.githubusercontent.com/96776/48181235-8ad91d80-e2db-11e8-9b20-b474b8f21aa3.png">

There is one issue I'm noticing for normal managed PURL records (e.g. does not have multiple), which may have already existed and is just more obvious w/ the new design, is some odd right-column alignment.

<img width="268" alt="screen shot 2018-11-07 at 10 22 31 pm" src="https://user-images.githubusercontent.com/96776/48181317-da1f4e00-e2db-11e8-91e4-ff92d486725e.png">

If anybody wants to take a look at that with, that would be great.  We could also split that off into a separate issue.
