### PR TITLE
tracks external link clicks using Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Adds the ability to track outbound links for usage analysis [#2135](https://github.com/sul-dlss/SearchWorks/pull/2135)
 ### Changed
 - Now returning a 404 Not Found error when an article record is not found [#2133](https://github.com/sul-dlss/SearchWorks/pull/2133)
 - Updates the way that Hoover Archive records are requested and shown in the access panel [#2123](https://github.com/sul-dlss/SearchWorks/pull/2123)

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -60,5 +60,21 @@ Blacklight.onLoad(function(){
   $('.iiif-dnd').on('dragstart', function(e) {
     var manifest = $(e.currentTarget).data().manifest;
     window._gaq.push(['_trackEvent', 'IIIF DnD', 'dragged', manifest]);
-  })
+  });
+
+  // Track external link clicks
+  $('a[href]:not([href^="/"],[href^="#"])').on('click', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    var _this = this;
+    var link = $(e.currentTarget);
+    try {
+      if (link[0].host !== window.location.host) {
+        window._gaq.push(['_trackEvent', 'External link', 'clicked', link.attr('href')]);
+      }
+    }
+    finally {
+      window.location.href = _this.href;
+    }
+  });
 });


### PR DESCRIPTION
Fixes #2114 

The URL will be reported which i think is sufficient to accomplish: 

> the kind of page the link was clicked from (home page, results, record view, Selected databases, no results)
