### PR TITLE
adds zero results action tracking

### DIFF
--- a/app/assets/javascripts/alternate_catalog.js
+++ b/app/assets/javascripts/alternate_catalog.js
@@ -38,6 +38,7 @@
           var facetHtml = createFacets(response.response.facets, data.alternateCatalog);
           $facets.html(facetHtml);
           $body.show();
+          $el.trigger('alternateResultsLoaded', $body);
         } else {
           $title.text('No additional results were found in');
           $body.find('a.btn').remove();

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -74,5 +74,39 @@ Blacklight.onLoad(function(){
     ga('send', 'event', 'External link', 'clicked', this.href, {
       'transport': 'beacon'
     });
+    if ($('.zero-results').length > 0) {
+      ga('send', 'event', 'Zero results', 'clicked', this.href, {
+        'transport': 'beacon'
+      });
+    }
+  });
+
+  $('a[data-track="zero-results-remove-limit"]').on('click', function(e) {
+    ga('send', 'event', 'Zero results', 'clicked-remove-limit', this.href, {
+      'transport': 'beacon'
+    });
+  });
+
+  $('a[data-track="zero-results-search-all-fields"]').on('click', function(e) {
+    ga('send', 'event', 'Zero results', 'clicked-search-all-fields', this.href, {
+      'transport': 'beacon'
+    });
+  });
+
+  // When an alternate catalog is loaded, track those link clicks
+  $('[data-alternate-catalog]').on('alternateResultsLoaded', function(event) {
+    $(event.currentTarget).find('a').on('click', function(e) {
+      var eventCategory = $('.zero-results').length > 0 ? 'Zero results' : 'Alternate Results';
+      ga('send', 'event', eventCategory, 'clicked-alternate-results', this.href, {
+        'transport': 'beacon'
+      });
+    });
+  });
+
+  // Just track when a zero results page gets loaded
+  $('.zero-results').each(function() {
+    ga('send', 'event', 'Zero results', 'loaded', this.href, {
+      'transport': 'beacon'
+    });
   });
 });

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -15,7 +15,7 @@
         <% if @search_modifier.has_filters? && @search_modifier.has_query? %>
           <li>
             <%= t 'blacklight.search.zero_results.limit_fields' %>
-            <%= link_to searchworks_search_action_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_filters))}"} do %>
+            <%= link_to searchworks_search_action_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", track: 'zero-results-remove-limit', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_filters))}"} do %>
               <%= content_tag :span, "#{search_field_label(params)} > #{params[:q]}", class: 'btn btn-zero-results', role: 'button' %>
             <% end %>
           </li>
@@ -23,7 +23,7 @@
         <% if @search_modifier.fielded_search? %>
           <li>
             <%= t 'blacklight.search.zero_results.search_fields' %>
-            <%= link_to searchworks_search_action_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_fielded_search_and_filters))}"} do %>
+            <%= link_to searchworks_search_action_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", track: 'zero-results-search-all-fields', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_fielded_search_and_filters))}"} do %>
               <%= content_tag :span, "#{params[:q]}", class: 'btn btn-zero-results', role: 'button' %>
             <% end %>
           </li>


### PR DESCRIPTION
Fixes #2115 

This PR handles the following cases:

 - Adds an additional event category for when an external link is clicked from a zero results page
 - Adds an event for when both the "remove limits" and "search all fields" links are clicked
 - When "alternate results" content is added to page, track when those links are clicked - both on zero-results page and in normal search results.
 - Track when a zero results page gets loaded