### PR TITLE
remove explicit width to accomodate different text for class

### DIFF
--- a/app/assets/stylesheets/modules/online-resource-links.scss
+++ b/app/assets/stylesheets/modules/online-resource-links.scss
@@ -27,5 +27,4 @@ ul.links {
   letter-spacing: 0;
   padding: 2px 7px;
   vertical-align: middle;
-  width: 55px;
 }


### PR DESCRIPTION
Fixes #2111 

Added in https://github.com/sul-dlss/SearchWorks/commit/e6dbd6f90da1c2d9972c9733a9c73b200fc92abe

I don't think the explicit width is necessary here.

### After

![screen shot 2018-11-12 at 9 22 44 am](https://user-images.githubusercontent.com/1656824/48360480-88b8eb00-e65c-11e8-839a-5afe585c06d6.png)
![screen shot 2018-11-12 at 9 21 45 am](https://user-images.githubusercontent.com/1656824/48360481-88b8eb00-e65c-11e8-92b4-5e721b59f5e2.png)
