### PR TITLE
Remove document accessor from json response.

### DIFF
--- a/lib/holdings/callnumber.rb
+++ b/lib/holdings/callnumber.rb
@@ -136,7 +136,7 @@ class Holdings
     end
 
     def as_json(*)
-      methods = (public_methods(false) - [:as_json, :status, :current_location])
+      methods = (public_methods(false) - [:as_json, :status, :current_location, :document])
       callnumber_info = methods.each_with_object({}) do |meth, obj|
         obj[meth.to_sym] = send(meth) if method(meth).arity == 0
       end


### PR DESCRIPTION
document was added as an accessor in 02f4d26d34c227e065a23c77b278fe48b901f02e.
However, when we render availability as json this puts a SolrDocument in every item in the holdings.
For records with a lot of items this blows that json response's size up to a huge amount.