### PR TITLE
Change online panel heading text

### DIFF
--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -12,7 +12,7 @@
       <% if document.is_a_database? %>
         Search this database
       <% else %>
-        Available online
+        Also available at
       <% end %>
     </h3>
   </div>

--- a/spec/features/access_panels/online_books_spec.rb
+++ b/spec/features/access_panels/online_books_spec.rb
@@ -10,7 +10,7 @@ feature 'Record view', js: true do
 
       within 'div.panel-online' do
         expect(page).to have_css('div.panel-heading', visible: true)
-        expect(page).to have_css('h3', text: 'Available online', visible: true)
+        expect(page).to have_css('h3', text: 'Also available at', visible: true)
         within('.google-preview') do
           expect(page).to have_css('a.full-view', text: '(Full view)', visible: true)
           expect(page).to have_css("img[src='/assets/gbs_preview_button.gif']")

--- a/spec/features/access_panels/online_spec.rb
+++ b/spec/features/access_panels/online_spec.rb
@@ -44,7 +44,7 @@ feature "Online Access Panel" do
 
       within('.panel-online') do
         within('.panel-heading') do
-          expect(page).to have_content('Available online')
+          expect(page).to have_content('Also available at')
         end
 
         within('.panel-body') do

--- a/spec/integration/external-data/access_panels_spec.rb
+++ b/spec/integration/external-data/access_panels_spec.rb
@@ -33,7 +33,7 @@ describe "Access Panels", feature: true, :"data-integration" => true do
 
       within(".panel-online") do
         within(".panel-heading") do
-          expect(page).to have_content("Available online")
+          expect(page).to have_content('Also available at')
         end
         within(".panel-body") do
           expect(page).to have_css("a", text: "purl.stanford.edu")

--- a/spec/views/catalog/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_online.html.erb_spec.rb
@@ -16,7 +16,7 @@ describe "catalog/access_panels/_online.html.erb" do
       assign(:document, SolrDocument.new(marcxml: simple_856))
       render
       expect(rendered).to have_css(".panel-online")
-      expect(rendered).to have_css(".panel-heading", text: "Available online")
+      expect(rendered).to have_css('.panel-heading', text: 'Also available at')
       expect(rendered).to have_css("ul.links li a", text: "Link text")
     end
     it "should add the stanford-only class to Stanford only resources" do


### PR DESCRIPTION
Part of #2024 

### `panel-online ` section 
- [x] Change `<h3>Available online</h3>` to `<h3>Also available at</h3>`

## Before
![screen shot 2018-11-14 at 1 41 26 pm](https://user-images.githubusercontent.com/5402927/48514450-30781980-e813-11e8-9b2e-8423409f786f.png)

## After
![screen shot 2018-11-14 at 1 41 42 pm](https://user-images.githubusercontent.com/5402927/48514449-30781980-e813-11e8-96cb-4a3d780dd515.png)


