### PR TITLE
Update mastheads: Digital collections, SDR

### DIFF
--- a/app/views/catalog/mastheads/_digital_collections.html.erb
+++ b/app/views/catalog/mastheads/_digital_collections.html.erb
@@ -1,11 +1,18 @@
 <div id="masthead-container">
   <div id="masthead" class="digital-collections-masthead">
     <h1>Digital collections</h1>
-    <div>
-      These records describe the collections in the Stanford Digital Repository, including scholar-deposited collections. [<%= link_to("Find out more about SDR.", "https://library.stanford.edu/research/stanford-digital-repository")%>]
-      <p class="inline-links">
-        Search all digital collections for: <%= link_to('data', digital_collections_params_for('Dataset')) %> | <%= link_to('images', digital_collections_params_for('Image')) %> | <%= link_to('maps', digital_collections_params_for('Map')) %> | <%= link_to('all items', digital_collections_params_for) %>
-      </p>
+    <p>These results describe collections of digital content — archives, donations, and grouped materials — in the Stanford Digital Repository. Use <b>Explore this collection</b> to find and filter the items within each collection.</p>
+
+    <div class="flexgrid">
+      <div class="col">
+          <%= link_to 'All digital items', digital_collections_params_for %> <span>Find all items and collections in the SDR. Filter by images, maps, data, and more.</span>
+      </div>
+      <div class="col">
+        <%= link_to 'IIIF resources', search_catalog_path(f: {iiif_resources: ['available'] })  %> <span>Find IIIF-compatible items in the SDR.</span>
+      </div>
+      <div class="col">
+        <%= link_to("More about the SDR", "https://library.stanford.edu/research/stanford-digital-repository")%> <span>Stanford Libraries' managed repository for scholarly content of enduring value.</span>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/catalog/mastheads/_sdr.html.erb
+++ b/app/views/catalog/mastheads/_sdr.html.erb
@@ -1,11 +1,18 @@
 <div id="masthead-container">
   <div id="masthead" class="sdr-masthead">
     <h1>Stanford Digital Repository</h1>
-    <div>
-      The SDR is Stanford Libraries' managed repository for scholarly content of enduring value. It includes digitized content from our archival collections as well as research materials deposited by scholars.
-      <p class="inline-links">
-        Search SDR for: <%= link_to('data', digital_collections_params_for('Dataset')) %> | <%= link_to('images', digital_collections_params_for('Image')) %> | <%= link_to('maps', digital_collections_params_for('Map')) %> | <%= link_to('collections', search_catalog_path(collections_search_params)) %>
-      </p>
+    <p>These results include all digital items and collections from the SDR. Filter by <b>Resource type</b> to find images, maps, data, and more.</p>
+
+    <div class="flexgrid">
+      <div class="col">
+          <%= link_to('Digital collections', search_catalog_path(collections_search_params)) %> <span>Find collections of digital content — archives, donations, and grouped materials — in the SDR.</span>
+      </div>
+      <div class="col">
+        <%= link_to 'IIIF resources', search_catalog_path(f: {iiif_resources: ['available'] })  %> <span>Find IIIF-compatible items in the SDR.</span>
+      </div>
+      <div class="col">
+        <%= link_to("More about the SDR", "https://library.stanford.edu/research/stanford-digital-repository")%> <span>Stanford Libraries' managed repository for scholarly content of enduring value.</span>
+      </div>
     </div>
   </div>
 </div>

--- a/spec/features/access_points/digital_collections_spec.rb
+++ b/spec/features/access_points/digital_collections_spec.rb
@@ -8,10 +8,9 @@ describe 'Digital Collections Access Point' do
   it 'should include the digital collections masthead' do
     within(".digital-collections-masthead") do
       expect(page).to have_css('h1', text: 'Digital collections')
-      expect(page).to have_css('.inline-links a', text: 'data')
-      expect(page).to have_css('.inline-links a', text: 'images')
-      expect(page).to have_css('.inline-links a', text: 'maps')
-      expect(page).to have_css('.inline-links a', text: 'all items')
+      expect(page).to have_css('a', text: 'All digital items')
+      expect(page).to have_css('a', text: 'IIIF resources')
+      expect(page).to have_css('a', text: 'More about the SDR')
     end
   end
 end


### PR DESCRIPTION
Closes #2033

This PR updates the links and text for the Digital Collections and SDR mastheads.

## Before
![screen shot 2018-11-14 at 5 30 40 pm](https://user-images.githubusercontent.com/5402927/48523899-0e8e8f00-e833-11e8-9363-4446af7807aa.png)
![screen shot 2018-11-14 at 5 30 33 pm](https://user-images.githubusercontent.com/5402927/48523900-0f272580-e833-11e8-8d68-8f2042c99462.png)

## After
![screen shot 2018-11-14 at 5 29 21 pm](https://user-images.githubusercontent.com/5402927/48523901-0f272580-e833-11e8-8cc2-1e961008665c.png)
![screen shot 2018-11-14 at 5 29 17 pm](https://user-images.githubusercontent.com/5402927/48523902-0f272580-e833-11e8-835c-1110916ffc47.png)