### PR TITLE
Fixes #2100 enable "SEE-OTHER" locations to display in results view

### DIFF
--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -43,7 +43,7 @@ class Holdings
     end
 
     def present_on_index?
-      any_items? || any_index_mhlds?
+      any_items? || any_index_mhlds? || @code == 'SEE-OTHER'
     end
 
     def sort

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -37,6 +37,9 @@ describe Holdings::Location do
         location_no_items_or_mhld.mhld = [mhld]
         expect(location_no_items_or_mhld).to be_present_on_index
       end
+      it 'should return true for a "SEE-OTHER" location' do
+        expect(described_class.new('SEE-OTHER')).to be_present_on_index
+      end
     end
   end
   describe '#location_level_request?' do


### PR DESCRIPTION
Fixes #2100 

Confirmed correct behavior in https://github.com/sul-dlss/SearchWorks/issues/2100#issuecomment-439478320

4082969

![screen shot 2018-11-16 at 11 08 15 am](https://user-images.githubusercontent.com/1656824/48639159-fa13d900-e98f-11e8-8f3b-2ff96a3305df.png)
