### PR TITLE
Remove GoogleBook link for items that have SFX data in the Online panel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to add Articles+ records to selection lists [#2094](https://github.com/sul-dlss/SearchWorks/pull/2094)
 ### Changed
 ### Removed
+- Removed the Google Book link from the Available Online panel when we have and SFX link [#2185](https://github.com/sul-dlss/SearchWorks/pull/2185)
 ### Fixed
 ### Security
 

--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -28,18 +28,6 @@
           See the full <span class='sfx-emphasis'>find it @ Stanford</span> menu
         <% end %>
       </div>
-
-      <% # duplicating this ul w/ the Google link until we get an answer on if it is okay to surpress it for SFX items %>
-      <ul class="links" data-long-list data-list-type="online">
-        <li>
-          <div class="row google-books <%= css_class %>">
-            <div class="col-lg-12 col-md-12 google-preview">
-              <%= image_tag "gbs_preview_button.gif", alt:"" %>
-              <a href="" class="full-view">(Full view)</a>
-            </div>
-          </div>
-        </li>
-      </ul>
     <% elsif document.access_panels.online? %>
       <ul class="links" data-long-list data-list-type="online">
         <% if document.access_panels.online? %>


### PR DESCRIPTION
Closes #2072 

## 3195844 (before)
<img width="384" alt="3195844-before" src="https://user-images.githubusercontent.com/96776/48654927-de2b2a00-e9c5-11e8-86d9-992ca976ca37.png">

## 3195844 (after)
<img width="388" alt="3195844-after" src="https://user-images.githubusercontent.com/96776/48654926-de2b2a00-e9c5-11e8-8f4c-15f96b3a002a.png">


