### PR TITLE
Separate SDR item online panel

### DIFF
--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -12,7 +12,7 @@
       <% if document.is_a_database? %>
         Search this database
       <% else %>
-        Also available at
+        Available online
       <% end %>
     </h3>
   </div>

--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -11,6 +11,8 @@
     <h3>
       <% if document.is_a_database? %>
         Search this database
+      <% elsif document.druid %>
+        Also available at
       <% else %>
         Available online
       <% end %>

--- a/spec/features/access_panels/online_books_spec.rb
+++ b/spec/features/access_panels/online_books_spec.rb
@@ -10,7 +10,7 @@ feature 'Record view', js: true do
 
       within 'div.panel-online' do
         expect(page).to have_css('div.panel-heading', visible: true)
-        expect(page).to have_css('h3', text: 'Also available at', visible: true)
+        expect(page).to have_css('h3', text: 'Available online', visible: true)
         within('.google-preview') do
           expect(page).to have_css('a.full-view', text: '(Full view)', visible: true)
           expect(page).to have_css("img[src='/assets/gbs_preview_button.gif']")

--- a/spec/features/access_panels/online_spec.rb
+++ b/spec/features/access_panels/online_spec.rb
@@ -44,7 +44,7 @@ feature "Online Access Panel" do
 
       within('.panel-online') do
         within('.panel-heading') do
-          expect(page).to have_content('Also available at')
+          expect(page).to have_content('Available online')
         end
 
         within('.panel-body') do

--- a/spec/integration/external-data/access_panels_spec.rb
+++ b/spec/integration/external-data/access_panels_spec.rb
@@ -33,7 +33,7 @@ describe "Access Panels", feature: true, :"data-integration" => true do
 
       within(".panel-online") do
         within(".panel-heading") do
-          expect(page).to have_content('Also available at')
+          expect(page).to have_content("Available online")
         end
         within(".panel-body") do
           expect(page).to have_css("a", text: "purl.stanford.edu")

--- a/spec/views/catalog/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_online.html.erb_spec.rb
@@ -27,6 +27,12 @@ describe "catalog/access_panels/_online.html.erb" do
       expect(rendered).to have_css("span.additional-link-text", text: "4 at one time")
       expect(rendered).to have_css("a[title='Available to Stanford-affiliated users only']", text: "Link text", count: 3)
     end
+    it 'renders a different heading for SDR items' do
+      assign(:document, SolrDocument.new(marcxml: simple_856, druid: 'ng161qh7958'))
+      render
+      expect(rendered).to have_css '.panel-online'
+      expect(rendered).to have_css '.panel-heading', text: 'Also available at'
+    end
 
     context 'when the record has an SFX link' do
       it 'renders markup w/ attributes to fetch SFX data (and does not render the link)' do

--- a/spec/views/catalog/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_online.html.erb_spec.rb
@@ -16,7 +16,7 @@ describe "catalog/access_panels/_online.html.erb" do
       assign(:document, SolrDocument.new(marcxml: simple_856))
       render
       expect(rendered).to have_css(".panel-online")
-      expect(rendered).to have_css('.panel-heading', text: 'Also available at')
+      expect(rendered).to have_css(".panel-heading", text: "Available online")
       expect(rendered).to have_css("ul.links li a", text: "Link text")
     end
     it "should add the stanford-only class to Stanford only resources" do


### PR DESCRIPTION
Part of #2024 

This PR allows the "Online" panel to have different sub-headings for SDR objects.
Example:
## 1071767 (Managed PURL)
![screen shot 2018-11-19 at 4 10 06 pm](https://user-images.githubusercontent.com/5402927/48742892-a5818f80-ec15-11e8-8e4d-fa14ad82d166.png)

## 12798015 (eBook)
![screen shot 2018-11-19 at 4 11 30 pm](https://user-images.githubusercontent.com/5402927/48742942-e24d8680-ec15-11e8-8b23-015defbb75e2.png)

More test items:
http://searchworks.stanford.edu/view/12317454
http://searchworks.stanford.edu/view/12796410