### PR TITLE
Several CSS tweaks to wrap up some of the recent changes

### DIFF
--- a/app/assets/stylesheets/modules/article.scss
+++ b/app/assets/stylesheets/modules/article.scss
@@ -29,3 +29,9 @@
 searchLink {
   font-style: italic;
 }
+
+.eds-full-text-section {
+  h2 {
+    border-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/modules/facets.scss
+++ b/app/assets/stylesheets/modules/facets.scss
@@ -55,7 +55,6 @@
   &,
   ul {
     padding-left: 0;
-    vertical-align: top;
   }
 
   li.h-node {
@@ -71,6 +70,7 @@
         width: 15px;
         content: '\f196';
         color: $cool-grey;
+        vertical-align: top;
       }
     }
 

--- a/app/assets/stylesheets/modules/gallery-view.scss
+++ b/app/assets/stylesheets/modules/gallery-view.scss
@@ -18,8 +18,9 @@
     font-weight: 400;
     font-size: .937em;
     text-align: center;
-    padding: 3px 0;
+    padding: 3px;
     overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
     width: $gallery-document-width - 2;
   }
@@ -32,7 +33,7 @@
   .gallery-document {
     @include document-borders;
     position: relative;
-    margin: 0 0 15px 15px;
+    margin: 0 0 25px 15px;
     float: left;
     display: inline;
     background-color: $white;

--- a/app/assets/stylesheets/modules/item-preview.scss
+++ b/app/assets/stylesheets/modules/item-preview.scss
@@ -37,7 +37,7 @@
 
 .preview {
   background-color: #fff;
-  border: 1px solid $sul-btn-preview-bg;
+  border: 1px solid $sul-preview-border;
   border-radius: 3px;
   display: none;
   min-height: 200px;
@@ -60,7 +60,11 @@
   }
 
   .preview-content {
-    overflow: auto;
+    &:after {
+      display: block;
+      content: "";
+      clear: both;
+    }
 
     dt {
       width: auto;

--- a/app/assets/stylesheets/modules/mastheads.scss
+++ b/app/assets/stylesheets/modules/mastheads.scss
@@ -8,10 +8,6 @@
     margin: 0;
   }
 
-  dl {
-    margin-top: 10px;
-  }
-
   .inline-links {
     margin-top: 0.5em;
     a {
@@ -61,6 +57,19 @@
   .database-prefix {
     h2 {
       margin-bottom: 0;
+    }
+  }
+
+  .collection-content {
+    display: flex;
+
+    .collection-summary {
+      flex-shrink: 2;
+      margin-right: 30px;
+    }
+
+    .collection-metadata {
+      flex-shrink: 1;
     }
   }
 }

--- a/app/assets/stylesheets/modules/mastheads.scss
+++ b/app/assets/stylesheets/modules/mastheads.scss
@@ -7,6 +7,11 @@
   h1 {
     margin: 0;
   }
+
+  dl {
+    margin-top: 10px;
+  }
+
   .inline-links {
     margin-top: 0.5em;
     a {
@@ -27,7 +32,6 @@
       margin-left: 10px;
       padding: 10px;
       a {
-        display: block;
         font-size: 1.138em;
       }
     }

--- a/app/assets/stylesheets/modules/record-view.scss
+++ b/app/assets/stylesheets/modules/record-view.scss
@@ -24,4 +24,9 @@ $show-title-left-margin: 40px;
   .metadata-panels {
     margin-top: 10px;
   }
+
+  .results-metadata-section {
+    clear: left;
+    padding: 10px 0;
+  }
 }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -44,10 +44,6 @@
       line-height: 35px;
       margin-right: 20px;
       padding: 0;
-
-      &.connection-problem {
-        font-size: 1.1em;
-      }
     }
     // Add the border on hover, or when the #connection-form is open
     a:hover, a[data-target="#connection-form"][aria-expanded="true"] {

--- a/app/assets/stylesheets/modules/thumbnail.scss
+++ b/app/assets/stylesheets/modules/thumbnail.scss
@@ -2,7 +2,7 @@
   margin-bottom: 0;
 }
 
-#documents .preview .document-thumbnail {
+.preview .document-thumbnail {
   float: right;
   padding-left: $line-height-computed;
   margin-bottom: $line-height-computed;

--- a/app/views/articles/record/_html_fulltext.erb
+++ b/app/views/articles/record/_html_fulltext.erb
@@ -3,7 +3,7 @@
   <button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-toggle="collapse" href="#toggleFulltext" aria-expanded="true" aria-controls="toggleFulltext">
     <h2>Hide full text <i class='fa fa-chevron-down'></i></h2>
   </button>
-  <div class='section-body collapse in' id="toggleFulltext">
+  <div class='eds-full-text-section section-body collapse in' id="toggleFulltext">
     <% fields.each do |field_name| -%>
       <% field_name = field_name.to_s -%>
       <% value = doc_presenter.field_value field_name -%>

--- a/app/views/catalog/_accordion_section_course_reserves.html.erb
+++ b/app/views/catalog/_accordion_section_course_reserves.html.erb
@@ -17,7 +17,7 @@
       <%= snippet %>
     </span>
     <div class="details <%= id %>-course-reserves" aria-expanded="false">
-      <dl>
+      <dl class="dl-horizontal">
         <% document.access_panels.course_reserve.courses.each do |course| %>
           <dt>Course</dt>
           <dd>

--- a/app/views/catalog/mastheads/_collection.html.erb
+++ b/app/views/catalog/mastheads/_collection.html.erb
@@ -3,26 +3,30 @@
   <div id="masthead-container">
     <div id="masthead" class="collection-masthead">
       <h1><%= @parent[:title_display] %></h1>
-      <% if @parent[:summary_display] %>
-        <p data-behavior='truncate'>
-          <%= @parent[:summary_display].join(', ') %>
-        </p>
-      <% end %>
-      <dl class="dl-horizontal dl-invert">
-        <% if @parent.collection_members.present? %>
-          <dt>Digital content</dt>
-          <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
+      <div class="collection-content">
+        <% if @parent[:summary_display] %>
+          <div class="collection-summary">
+            <div data-behavior='truncate'>
+              <%= @parent[:summary_display].join(', ') %>
+            </div>
+          </div>
         <% end %>
-        <% # this stuff is temporary until we have item level merge (mods + marc) %>
-        <% if @parent.extent.present? %>
-          <dt><%= @parent.extent_label %></dt>
-          <dd><%= @parent.extent %></dd>
-        <% end %>
-        <% if @parent.index_links.finding_aid.present? %>
-          <dt>Finding aid</dt>
-          <dd><%= @parent.index_links.finding_aid.first.html.html_safe %></dd>
-        <% end %>
-      </dl>
+        <dl class="dl-horizontal dl-invert collection-metadata">
+          <% if @parent.collection_members.present? %>
+            <dt>Digital content</dt>
+            <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
+          <% end %>
+          <% # this stuff is temporary until we have item level merge (mods + marc) %>
+          <% if @parent.extent.present? %>
+            <dt><%= @parent.extent_label %></dt>
+            <dd><%= @parent.extent %></dd>
+          <% end %>
+          <% if @parent.index_links.finding_aid.present? %>
+            <dt>Finding aid</dt>
+            <dd><%= @parent.index_links.finding_aid.first.html.html_safe %></dd>
+          <% end %>
+        </dl>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/catalog/mastheads/_collection.html.erb
+++ b/app/views/catalog/mastheads/_collection.html.erb
@@ -3,32 +3,26 @@
   <div id="masthead-container">
     <div id="masthead" class="collection-masthead">
       <h1><%= @parent[:title_display] %></h1>
-      <div class="row">
-        <div class="col-xs-8">
-          <% if @parent[:summary_display] %>
-            <div data-behavior='truncate'>
-              <%= @parent[:summary_display].join(', ') %>
-            </div>
-          <% end %>
-        </div>
-        <div class="col-xs-4">
-          <dl class="dl-horizontal dl-invert">
-            <% if @parent.collection_members.present? %>
-              <dt>Digital content</dt>
-              <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
-            <% end %>
-            <% # this stuff is temporary until we have item level merge (mods + marc) %>
-            <% if @parent.extent.present? %>
-              <dt><%= @parent.extent_label %></dt>
-              <dd><%= @parent.extent %></dd>
-            <% end %>
-            <% if @parent.index_links.finding_aid.present? %>
-              <dt>Finding aid</dt>
-              <dd><%= @parent.index_links.finding_aid.first.html.html_safe %></dd>
-            <% end %>
-          </dl>
-        </div>
-      </div>
+      <% if @parent[:summary_display] %>
+        <p data-behavior='truncate'>
+          <%= @parent[:summary_display].join(', ') %>
+        </p>
+      <% end %>
+      <dl class="dl-horizontal dl-invert">
+        <% if @parent.collection_members.present? %>
+          <dt>Digital content</dt>
+          <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
+        <% end %>
+        <% # this stuff is temporary until we have item level merge (mods + marc) %>
+        <% if @parent.extent.present? %>
+          <dt><%= @parent.extent_label %></dt>
+          <dd><%= @parent.extent %></dd>
+        <% end %>
+        <% if @parent.index_links.finding_aid.present? %>
+          <dt>Finding aid</dt>
+          <dd><%= @parent.index_links.finding_aid.first.html.html_safe %></dd>
+        <% end %>
+      </dl>
     </div>
   </div>
 <% end %>

--- a/app/views/catalog/mastheads/_databases.html.erb
+++ b/app/views/catalog/mastheads/_databases.html.erb
@@ -5,14 +5,16 @@
     <p>Licensed resources are for the non-profit educational use of Stanford University. Use of these resources is governed by copyright law and individual license agreements. Systematic downloading, distributing, or retaining substantial portions of information is prohibited.</p>
     <div class="flexgrid">
       <div class="col">
-        <%= link_to 'Articles+', articles_path %> <span>Search a combined index of 100s of databases.</span>
+        <%= link_to 'Articles+', articles_path %>
+        <p>Search a combined index of 100s of databases.</p>
       </div>
       <div class="col">
-        <%= link_to 'Selected article databases', selected_databases_path %> <span>Not sure where to start? Try one of these.</span>
+        <%= link_to 'Selected article databases', selected_databases_path %>
+        <p>Not sure where to start? Try one of these.</p>
       </div>
       <div class="col">
-        <%= link_to 'Connecting to e-resources', 'https://library.stanford.edu/using/connecting-e-resources' %>
-        <%= link_to 'Report a connection problem', 'https://library.stanford.edu/ask/email/connection-problems' %>
+        <p><%= link_to 'Connecting to e-resources', 'https://library.stanford.edu/using/connecting-e-resources' %></p>
+        <p><%= link_to 'Report a connection problem', 'https://library.stanford.edu/ask/email/connection-problems' %></p>
       </div>
     </div>
     <%= render "catalog/database_prefix" %>

--- a/app/views/catalog/mastheads/_digital_collections.html.erb
+++ b/app/views/catalog/mastheads/_digital_collections.html.erb
@@ -5,13 +5,16 @@
 
     <div class="flexgrid">
       <div class="col">
-          <%= link_to 'All digital items', digital_collections_params_for %> <span>Find all items and collections in the SDR. Filter by images, maps, data, and more.</span>
+        <%= link_to 'All digital items', digital_collections_params_for %>
+        <p>Find all items and collections in the SDR. Filter by images, maps, data, and more.</p>
       </div>
       <div class="col">
-        <%= link_to 'IIIF resources', search_catalog_path(f: {iiif_resources: ['available'] })  %> <span>Find IIIF-compatible items in the SDR.</span>
+        <%= link_to 'IIIF resources', search_catalog_path(f: {iiif_resources: ['available'] })  %>
+        <p>Find IIIF-compatible items in the SDR.</p>
       </div>
       <div class="col">
-        <%= link_to("More about the SDR", "https://library.stanford.edu/research/stanford-digital-repository")%> <span>Stanford Libraries' managed repository for scholarly content of enduring value.</span>
+        <%= link_to("More about the SDR", "https://library.stanford.edu/research/stanford-digital-repository")%>
+        <p>Stanford Libraries' managed repository for scholarly content of enduring value.</p>
       </div>
     </div>
   </div>

--- a/app/views/catalog/mastheads/_sdr.html.erb
+++ b/app/views/catalog/mastheads/_sdr.html.erb
@@ -5,13 +5,16 @@
 
     <div class="flexgrid">
       <div class="col">
-          <%= link_to('Digital collections', search_catalog_path(collections_search_params)) %> <span>Find collections of digital content — archives, donations, and grouped materials — in the SDR.</span>
+        <%= link_to('Digital collections', search_catalog_path(collections_search_params)) %>
+        <p>Find collections of digital content — archives, donations, and grouped materials — in the SDR.</p>
       </div>
       <div class="col">
-        <%= link_to 'IIIF resources', search_catalog_path(f: {iiif_resources: ['available'] })  %> <span>Find IIIF-compatible items in the SDR.</span>
+        <%= link_to 'IIIF resources', search_catalog_path(f: {iiif_resources: ['available'] })  %>
+        <p>Find IIIF-compatible items in the SDR.</p>
       </div>
       <div class="col">
-        <%= link_to("More about the SDR", "https://library.stanford.edu/research/stanford-digital-repository")%> <span>Stanford Libraries' managed repository for scholarly content of enduring value.</span>
+        <%= link_to("More about the SDR", "https://library.stanford.edu/research/stanford-digital-repository")%>
+        <p>Stanford Libraries' managed repository for scholarly content of enduring value.</p>
       </div>
     </div>
   </div>

--- a/app/views/catalog/mastheads/_selected_databases.html.erb
+++ b/app/views/catalog/mastheads/_selected_databases.html.erb
@@ -4,14 +4,16 @@
     <p>Start your research with one of our selected databases below. <%= link_to 'Learn more about finding articles.', 'https://library.stanford.edu/guides/find-articles' %></p>
     <div class="flexgrid">
       <div class="col">
-        <%= link_to 'Articles+', articles_path %> <span>Search a combined index of 100s of databases.</span>
+        <%= link_to 'Articles+', articles_path %>
+        <p>Search a combined index of 100s of databases.</p>
       </div>
       <div class="col">
-        <%= link_to 'Databases', databases_path %> <span>Find a topic-specific database for in-depth research.</span>
+        <%= link_to 'Databases', databases_path %>
+        <p>Find a topic-specific database for in-depth research.</p>
       </div>
       <div class="col">
-        <%= link_to 'Connecting to e-resources', 'https://library.stanford.edu/using/connecting-e-resources' %>
-        <%= link_to 'Report a connection problem', 'https://library.stanford.edu/ask/email/connection-problems' %>
+        <p><%= link_to 'Connecting to e-resources', 'https://library.stanford.edu/using/connecting-e-resources' %></p>
+        <p><%= link_to 'Report a connection problem', 'https://library.stanford.edu/ask/email/connection-problems' %></p>
       </div>
     </div>
   </div>

--- a/app/views/preview/_show_header_default.html.erb
+++ b/app/views/preview/_show_header_default.html.erb
@@ -1,6 +1,6 @@
 <h3 class="preview-title">
   <%= render_resource_icon document[document.format_key] %>
+  <%= document.online_label %>
   <%= link_to_document document, get_main_title(document) %>
   <span class="main-title-date"><%= get_main_title_date(document) %></span>
-  <%= document.online_label %>
 </h3>


### PR DESCRIPTION
Paired w/ @jvine on this.  Lot's of small little things, several things that didn't get covered in previous changes.

Only "new" work is moving the collection masthead to be us `flex` to help in the case where this is no summary.

## Before (with summary)
<img width="1187" alt="before with" src="https://user-images.githubusercontent.com/96776/48755415-0a56dd00-ec4a-11e8-8c50-a8221d63d1b3.png">

## Before (without summary)
<img width="1189" alt="before without" src="https://user-images.githubusercontent.com/96776/48755366-ded3f280-ec49-11e8-8ec9-a449a42e0166.png">

## After (with summary)
<img width="1205" alt="after with" src="https://user-images.githubusercontent.com/96776/48755482-412cf300-ec4a-11e8-85e6-c264ad90b873.png">


## After (without summary)
<img width="1181" alt="after without" src="https://user-images.githubusercontent.com/96776/48755273-9ddbde00-ec49-11e8-9959-6fc6c5290ea9.png">
