### PR TITLE
Update collection masthead to match record view

### DIFF
--- a/app/views/catalog/mastheads/_collection.html.erb
+++ b/app/views/catalog/mastheads/_collection.html.erb
@@ -14,13 +14,13 @@
         <div class="col-xs-4">
           <dl class="dl-horizontal dl-invert">
             <% if @parent.collection_members.present? %>
-              <dt>Digital content</dt>
-              <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'item'), @parent) %></dd>
+              <dt>Digital collection</dt>
+              <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'digital item'), @parent) %></dd>
             <% end %>
             <% # this stuff is temporary until we have item level merge (mods + marc) %>
-            <% if @parent.extent.present? %>
-              <dt><%= @parent.extent_label %></dt>
-              <dd><%= @parent.extent %></dd>
+            <% if @parent.extent_sans_format.present? %>
+              <dt>Physical collection</dt>
+              <dd><%= @parent.extent_sans_format %></dd>
             <% end %>
             <% if @parent.index_links.finding_aid.present? %>
               <dt>Finding aid</dt>

--- a/spec/features/access_points/collection_spec.rb
+++ b/spec/features/access_points/collection_spec.rb
@@ -9,8 +9,8 @@ feature "Collection Access Point" do
     within("#masthead") do
       expect(page).to have_css("h1", text: "Image Collection1")
       expect(page).to have_css("div", text: "A collection of fixture images from the SearchWorks development index.")
-      expect(page).to have_css("dt", text: "Digital content")
-      expect(page).to have_css("dd", text: "1 item")
+      expect(page).to have_css('dt', text: 'Digital collection')
+      expect(page).to have_css('dd', text: '1 digital item')
       expect(page).to have_css("dt", text: "Finding aid")
       expect(page).to have_css("dd a", text: "Online Archive of California")
     end


### PR DESCRIPTION
Part of #2126 / #2024 / fixes https://github.com/sul-dlss/SearchWorks/pull/2126#discussion_r234844438 

This PR updates the Collection masthead so that it matches the new SDR item record view. 
(See similar changes in #2178)

## Before
![collection_masthead_before](https://user-images.githubusercontent.com/5402927/48805996-d45b3c80-eccd-11e8-8c9c-f962b7c0dfa5.png)

## After
![collection_masthead_after](https://user-images.githubusercontent.com/5402927/48805997-d45b3c80-eccd-11e8-9005-9b7a3859ae55.png)