### PR TITLE
logger 1.2.8 was yanked.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    logger (1.2.8)
+    logger (1.2.7)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
This might make searchworks deployable; logger 1.2.7 might also turn out to be total garbage.

https://github.com/ebsco/edsapi-ruby/pull/89 is probably a better fix.