### PR TITLE
Don't put the request-modal popup data attributes on SSRC request links.

### DIFF
--- a/app/helpers/request_link_helper.rb
+++ b/app/helpers/request_link_helper.rb
@@ -45,9 +45,15 @@ module RequestLinkHelper
   end
 
   def link_data_attributes(callnumber)
-    return { behavior: 'requests-modal' } unless callnumber && Constants::HOOVER_LIBS.include?(callnumber.library)
+    return unless callnumber
 
-    { toggle: 'tooltip', html: 'true', title: t('searchworks.request_link.aeon_note') }
+    if Constants::HOOVER_LIBS.include?(callnumber.library)
+      { toggle: 'tooltip', html: 'true', title: t('searchworks.request_link.aeon_note') }
+    elsif callnumber.home_location == 'SSRC-DATA'
+      {}
+    else
+      { behavior: 'requests-modal' }
+    end
   end
 
   def hoover_request_url(document, callnumber)

--- a/spec/helpers/request_link_helper_spec.rb
+++ b/spec/helpers/request_link_helper_spec.rb
@@ -25,6 +25,13 @@ describe RequestLinkHelper do
     )
   end
 
+  let(:ssrc_document) do
+    SolrDocument.new(
+      id: '1234',
+      item_display: ['barcode -|- library -|- SSRC-DATA -|- current_location -|- type -|- truncated_callnumber -|- shelfkey -|- reverse_shelfkey -|- callnumber']
+    )
+  end
+
   describe 'link_to_request_link' do
     it 'returns link html for the given parameters' do
       link = link_to_request_link(
@@ -90,6 +97,26 @@ describe RequestLinkHelper do
         expect(link).to have_css('a[data-title^="Requires Aeon signup"]')
       end
     end
+
+    describe 'SSRC-DATA links' do
+      let(:presenter) do
+        OpenStruct.new(heading: 'Document Title')
+      end
+
+      let(:link) do
+        Capybara.string(
+          helper.link_to_request_link(document: ssrc_document, callnumber: ssrc_document.holdings.callnumbers.first)
+        )
+      end
+
+      before do
+        expect(helper).to receive(:show_presenter).with(ssrc_document).and_return(presenter)
+      end
+
+      it 'should not include data attributes that will cause the link to be rendered in a modal' do
+        expect(link).not_to have_css('[data-behavior="requests-modal"]')
+      end
+    end
   end
 
   describe '#request_link' do
@@ -142,12 +169,6 @@ describe RequestLinkHelper do
     end
 
     describe 'SSRC-DATA' do
-      let(:ssrc_document) do
-        SolrDocument.new(
-          id: '1234',
-          item_display: ['barcode -|- library -|- SSRC-DATA -|- current_location -|- type -|- truncated_callnumber -|- shelfkey -|- reverse_shelfkey -|- callnumber']
-        )
-      end
       let(:presenter) do
         OpenStruct.new(heading: 'Document Title')
       end


### PR DESCRIPTION
The SSRC form is managed separately from our requests form and therefor should not be
rendered in our modal (since it cannot appropriately report success amongst other things)