### PR TITLE
Add a list item for GBS Links to the online access panel for records …

### DIFF
--- a/app/views/catalog/access_panels/_online.html.erb
+++ b/app/views/catalog/access_panels/_online.html.erb
@@ -51,6 +51,17 @@
           </div>
         </li>
       </ul>
+    <% elsif book_ids.values.any?(&:present?) %>
+      <ul class="links" data-long-list data-list-type="online">
+        <li>
+          <div class="row google-books <%= css_class %>">
+            <div class="col-lg-12 col-md-12 google-preview">
+              <%= image_tag "gbs_preview_button.gif", alt:"" %>
+              <a href="" class="full-view">(Full view)</a>
+            </div>
+          </div>
+        </li>
+      </ul>
     <% end %>
   </div>
   <% if document.access_panels.online? and document.is_a_database? %>

--- a/spec/views/catalog/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/catalog/access_panels/_online.html.erb_spec.rb
@@ -46,6 +46,16 @@ describe "catalog/access_panels/_online.html.erb" do
       end
     end
 
+    describe 'when the record is not online, has an SFX link, but may return a GBS link (due to a standard number)' do
+      it 'renders content to be filled by GBS if something is returned' do
+        assign(:document, SolrDocument.new(oclc: ['abc123']))
+        render
+
+        expect(rendered).to have_css('.panel-online', visible: false)
+        expect(rendered).to have_css('.panel-online .google-books.OCLCabc123')
+      end
+    end
+
     describe "database" do
       before do
         assign(:document, SolrDocument.new(marc_links_struct: [{ html: '<a href="...">Link text</a>', fulltext: true }], format_main_ssim: ["Database"]))


### PR DESCRIPTION
…that don't otherwise have links (but do have standard numbers that may return a google book link).

Addresses JIRA issue SW-3796

## Before (1998042)
<img width="675" alt="1998042-before" src="https://user-images.githubusercontent.com/96776/53547333-9ac37a00-3ae3-11e9-97ab-99efc6b497e3.png">

## After (1998042)
<img width="696" alt="1998042-after" src="https://user-images.githubusercontent.com/96776/53547335-9ac37a00-3ae3-11e9-8024-fa20856e663d.png">

