### PR TITLE
Use the summary_data partial on the record view…

### DIFF
--- a/app/views/catalog/record/_marc_contents_summary.html.erb
+++ b/app/views/catalog/record/_marc_contents_summary.html.erb
@@ -46,10 +46,12 @@
   </dd>
 <% end %>
 
-
-<% summary = document.fetch(:summary_struct, []).first %>
-<% unless summary.nil? %>
-  <%= render_field_from_marc(summary) %>
+<% summary_data = render partial: 'catalog/summary_data', locals: { document: document } %>
+<% if summary_data.present? %>
+  <dt>Summary</dt>
+  <dd>
+    <%= sanitize summary_data %>
+  </dd>
 <% end %>
 
 <% if document.marc_links.supplemental.present? %>


### PR DESCRIPTION
…(already used in results).

Fixes #2307 

## Before
<img width="694" alt="3786532-before" src="https://user-images.githubusercontent.com/96776/58514844-df4cc900-8157-11e9-8459-b43d85dacc03.png">

## After
<img width="677" alt="3786532-after" src="https://user-images.githubusercontent.com/96776/58514842-df4cc900-8157-11e9-8664-c5e61078fd78.png">

(Note: @jvine approved the label change as it now matches what is in the results)
