### PR TITLE
Add a barcodes json endpoint to return the document ID associated w/ …

### DIFF
--- a/app/controllers/barcode_controller.rb
+++ b/app/controllers/barcode_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BarcodeController < ApplicationController
+  def show
+    render json: BarcodeSearch.new(params[:id])
+  end
+end

--- a/app/models/barcode_search.rb
+++ b/app/models/barcode_search.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class BarcodeSearch
+  attr_reader :barcode
+
+  def initialize(barcode)
+    @barcode = barcode
+  end
+
+  def document_id
+    return if documents.blank?
+
+    documents.first['id']
+  end
+
+  def as_json(*)
+    { barcode: barcode, id: document_id }
+  end
+
+  private
+
+  def documents
+    response.dig('response', 'docs') || []
+  end
+
+  def response
+    @response ||= blacklight_solr.get('barcode', params: { n: barcode })
+  end
+
+  def blacklight_solr
+    Blacklight.default_index.connection
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   concern :exportable, Blacklight::Routes::Exportable.new
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
 
+  resources :barcode, only: :show
+
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
     concerns :range_searchable

--- a/spec/controllers/barcode_controller_spec.rb
+++ b/spec/controllers/barcode_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BarcodeController do
+  describe 'routes' do
+    it 'is available at /barcode' do
+      request = { get: '/barcode/3610512345' }
+      expect(request).to route_to(controller: 'barcode', action: 'show', id: '3610512345')
+    end
+  end
+
+  describe 'GET show' do
+    it 'renders the json returned by the BarcodeSearch class' do
+      json = { id: 'abc123', barcode: '3610512345' }
+      expect(BarcodeSearch).to receive(:new).with('3610512345').and_return(json)
+
+      get :show, params: { id: '3610512345' }
+
+      expect(response).to be_success
+      response_json = JSON.parse(response.body)
+      expect(response_json['id']).to eq(json[:id])
+      expect(response_json['barcode']).to eq(json[:barcode])
+    end
+  end
+end

--- a/spec/models/barcode_search_spec.rb
+++ b/spec/models/barcode_search_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BarcodeSearch do
+  subject { described_class.new(barcode) }
+
+  let(:barcode) { '3610512345' }
+  let(:stub_response) do
+    { response: { docs: [{ id: 'abc123' }] } }.with_indifferent_access
+  end
+  let(:stub_no_docs_response) do
+    { response: { docs: [] } }.with_indifferent_access
+  end
+
+  describe 'when the barcode search returns a document' do
+    before do
+      expect(subject).to receive_messages(response: stub_response)
+    end
+
+    it 'gets the document id from the first document in the response' do
+      expect(subject.document_id).to eq('abc123')
+    end
+
+    it 'has a json response that returns the barcode and id' do
+      expect(subject.as_json[:barcode]).to eq '3610512345'
+      expect(subject.as_json[:id]).to eq 'abc123'
+    end
+  end
+
+  describe 'when the barcode search does not return a document' do
+    before do
+      expect(subject).to receive_messages(response: stub_no_docs_response)
+    end
+
+    it 'returns nil for the document_id' do
+      expect(subject.document_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
…a barcode.

This is intended to serve this feature in dor-services w/o dor-services having to hit solr directly: https://github.com/sul-dlss/dor-services-app/blob/75ca4fa2ffb68a15616b6cce1dae12a6dcfe9807/app/models/marcxml_resource.rb#L9-L13

