### PR TITLE
Replace struct being rendered w/ render_field_from_marc to use...

### DIFF
--- a/app/views/catalog/record/_marc_contents_summary.html.erb
+++ b/app/views/catalog/record/_marc_contents_summary.html.erb
@@ -46,12 +46,10 @@
   </dd>
 <% end %>
 
-<% summary_data = render partial: 'catalog/summary_data', locals: { document: document } %>
-<% if summary_data.present? %>
-  <dt>Summary</dt>
-  <dd>
-    <%= sanitize summary_data %>
-  </dd>
+
+<% summary = document.fetch(:summary_struct, []).first %>
+<% unless summary.nil? %>
+  <%= render_field_from_marc(summary) %>
 <% end %>
 
 <% if document.marc_links.supplemental.present? %>

--- a/app/views/catalog/record/_marc_contents_summary.html.erb
+++ b/app/views/catalog/record/_marc_contents_summary.html.erb
@@ -46,10 +46,23 @@
   </dd>
 <% end %>
 
-
 <% summary = document.fetch(:summary_struct, []).first %>
-<% unless summary.nil? %>
-  <%= render_field_from_marc(summary) %>
+<% if summary.present? %>
+  <% if summary[:fields].present? %>
+    <dt>Summary</dt>
+    <% summary[:fields].each do |field| %>
+      <dd>
+        <%= render_struct_field_data document, field[:field] %>
+        <%= "<br/>#{field[:vernacular]}".html_safe unless field[:vernacular].nil? %>
+        <%= "<br/>".html_safe if field != summary[:fields].last %>
+      </dd>
+    <% end %>
+  <% end %>
+  <% if summary[:unmatched_vernacular].present? %>
+    <dd>
+      <%= summary[:unmatched_vernacular].join("<br/>").html_safe %>
+    </dd>
+  <% end %>
 <% end %>
 
 <% if document.marc_links.supplemental.present? %>


### PR DESCRIPTION
...render_struct_field_data w/ custom markup instead.

The partial from the results doesn't know how to label Contents vs. Summary so we can't use that here w/o some additional refactoring.  This change addresses an issue where we're getting duplicated TOCs in the page.
