### PR TITLE
Add the results_document helper to the list of mailer helpers…

### DIFF
--- a/app/mailers/search_works_record_mailer.rb
+++ b/app/mailers/search_works_record_mailer.rb
@@ -5,7 +5,7 @@ class SearchWorksRecordMailer < ActionMailer::Base
   default 'Content-Transfer-Encoding' => '7bit'
   include Roadie::Rails::Automatic
   include Blacklight::Configurable
-  helper :application, :catalog, :marc, :record
+  helper :application, :catalog, :marc, :record, :results_document
 
   def email_record(documents, details, url_gen_params)
     setup_email_defaults(documents, details, url_gen_params)


### PR DESCRIPTION
…(since we now use some helpers from that file to build the full record email)
