### PR TITLE
Render the eds_publisher field in the Details section …

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -133,6 +133,7 @@ class ArticlesController < ApplicationController
         eds_page_count:           { label: 'Page Count' },
         eds_isbns:                { label: 'ISBN' },
         eds_issns:                { label: 'ISSN' },
+        eds_publisher:            { label: 'Publisher' },
         eds_publication_info:     { label: 'Published' },
         eds_publication_status:   { label: 'Publication Status' },
         eds_document_oclc:        { label: 'OCLC' },


### PR DESCRIPTION
…(along w/ other pub data)

In discussion w/ the EBSCO folks about publishers, we're not rendering this field currently.  We are also not seeing data in this field consistently (which may be why we're not displaying it 🤷‍♂️) but as that is addressed upstream the data will begin to render.

https://github.com/ebsco/edsapi-ruby/blob/1432056a4407b6fdfb6fda8709752d6e38975553/lib/ebsco/eds/record.rb#L218