### PR TITLE
Teach MarcFieldWrapper to not identify fields that have a …

### DIFF
--- a/app/models/marc_fields/marc_field_wrapper.rb
+++ b/app/models/marc_fields/marc_field_wrapper.rb
@@ -34,7 +34,11 @@ class MarcFieldWrapper
   end
 
   def vernacular_matcher?
-    vernacular_matching_field.include?('-')
+    vernacular_matching_field.include?('-') && if marc_field.tag.start_with?('8')
+                                                !vernacular_matching_field.start_with?('8')
+                                               else
+                                                 vernacular_matching_field.start_with?('8')
+                                               end
   end
 
   def subfields

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -297,6 +297,10 @@ module MarcMetadataFixtures
           <subfield code="6">880-03</subfield>
           <subfield code="a">This is not Vernacular</subfield>
         </datafield>
+        <datafield tag="610" ind1="1" ind2="0">
+          <subfield code="6">610-00</subfield>
+          <subfield code="a">Bad Venacular Matcher</subfield>
+        </datafield>
         <datafield tag="700" ind1=" " ind2=" ">
           <subfield code="6">880-04</subfield>
           <subfield code="a">This is not Vernacular</subfield>
@@ -324,6 +328,10 @@ module MarcMetadataFixtures
         <datafield tag="880" ind1=" " ind2=" ">
           <subfield code="a">710-05</subfield>
           <subfield code="6">This is Vernacular</subfield>
+        </datafield>
+        <datafield tag="880" ind1=" " ind2=" ">
+          <subfield code="6">880-00</subfield>
+          <subfield code="6">This is A vernacular matching field that does not point to a valid field</subfield>
         </datafield>
       </record>
     xml

--- a/spec/models/marc_fields/marc_field_wrapper_spec.rb
+++ b/spec/models/marc_fields/marc_field_wrapper_spec.rb
@@ -58,6 +58,20 @@ describe MarcFieldWrapper do
         expect(subject).not_to be_vernacular_matcher
       end
     end
+
+    describe 'when the $6 points to a non-880' do
+      let(:field) { marc_fields(bad_vernacular_fixture, '610').first }
+
+      it { expect(subject).not_to be_vernacular_matcher }
+    end
+
+    describe 'when the $6 in an 880 does not point to a regular marc field' do
+      let(:field) do
+        marc_fields(bad_vernacular_fixture, '880').find { |f| f['6'] == '880-00'  }
+      end
+
+      it { expect(subject).not_to be_vernacular_matcher }
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
…non-compliant vernacular matching field as a vernacular field.

Part of #2365 

