### PR TITLE
Clear Rack::Attack cache on cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,3 +11,7 @@ end
 every '0 0 1,15 * *', roles: %i[app] do # biweekly
   rake 'searchworks:clear_eds_cache'
 end
+
+every '0 3 * * *', roles: %i[app] do # daily at 3 am
+  rake 'searchworks:clear_rack_attack_cache'
+end

--- a/lib/tasks/searchworks.rake
+++ b/lib/tasks/searchworks.rake
@@ -74,6 +74,19 @@ namespace :searchworks do
     end
   end
 
+  desc "Clear Rack::Attack cache"
+  task clear_rack_attack_cache: [:environment] do
+    if Settings.THROTTLE_TRAFFIC
+      # This functionality will be available as Rack::Attack.reset! but as of 6.2.2 this is not released
+      store = Rack::Attack.cache.store
+      if store.respond_to?(:delete_matched)
+        store.delete_matched("#{Rack::Attack.cache.prefix}*")
+      else
+        puts "Error Clearing Rack::Attack cache. Store #{store.class.name} does not respond to #delete_matched"
+      end
+    end
+  end
+
   def eds_cache
     cache_dir = File.join(Settings.EDS_CACHE_DIR, 'faraday_eds_cache')
     return ActiveSupport::Cache::FileStore.new(cache_dir) if File.directory?(cache_dir)


### PR DESCRIPTION
This should hopefully help with the disk filling up issue that's happening on the bot nodes.

This could just be a temporary fix until we have a more robust Rack::Attack caching solution (e.g. Redis) or we could see if this will work "Well Enough" for our user facing nodes as well w/o having to setup the additional infrastructure.  Given that we're only using this for throttling (and not fail2Ban etc) this short lived 1 day cache should work okay for us for now.