### PR TITLE
Add an Access Panel to display when an item or...

### DIFF
--- a/app/assets/javascripts/exhibitPanel.js
+++ b/app/assets/javascripts/exhibitPanel.js
@@ -1,0 +1,123 @@
+(function( global) {
+  'use strict';
+  var ExhibitsPanel;
+
+  ExhibitsPanel = {
+    panel: null,
+    druid: null,
+    exhibitsHost: null,
+    isCollection: null,
+    exhibitToggleThreshold: 5,
+
+    init: function(panel) {
+      this.panel = panel;
+      this.druid = this.panel.data('druid');
+      this.exhibitsHost = this.panel.data('exhibitsHost');
+      this.isCollection = this.panel.data('isCollection');
+      this.fetchExhibits();
+    },
+
+    fetchExhibits: function() {
+      var _this = this;
+
+      $.ajax({
+        url: _this.exhibitsHost + "/exhibit_finder/" + _this.druid,
+        dataType: 'json'
+      }).done(function(data) {
+        if (data.length === 0) {
+          return;
+        }
+
+        _this.showAppropriatePanelHeading(data.length);
+
+        var panelBody = _this.panel.find('.panel-body');
+        $.each(data, function(i, exhibit) {
+          panelBody.append(_this.exhibitMediaObject(exhibit));
+        });
+
+        _this.addToggleLinkBehavior(panelBody, data.length);
+
+        $('[data-behavior="metadata-panel-context-heading"]').show(); // Ensure heading is displayed
+        _this.panel.show();
+      });
+    },
+
+    exhibitsUrl: function(slug) {
+      var baseExhibitUrl = this.exhibitsHost + '/' + slug;
+      if (this.isCollection) {
+        return baseExhibitUrl;
+      } else {
+        return baseExhibitUrl + '/catalog/' + this.druid;
+      }
+    },
+
+    showAppropriatePanelHeading: function(exhibitCount) {
+      if (exhibitCount > 1) {
+        this.panel.find('[data-behavior="multiple-exhibit-heading"]').show();
+      } else {
+        this.panel.find('[data-behavior="single-exhibit-heading"]').show();
+      }
+    },
+
+    addToggleLinkBehavior: function(container, exhibitCount) {
+      var _this = this;
+      if (exhibitCount >= _this.exhibitToggleThreshold) {
+        var toggleLink = $('<a href="#">See all ' + exhibitCount + ' exhibits</a>');
+        var exhibitMediaObjects = container.find('.media');
+        exhibitMediaObjects.each(function(i) {
+          if (i >= _this.exhibitToggleThreshold) {
+            $(this).hide();
+          }
+        });
+        toggleLink.on('click', function(e) {
+          e.preventDefault();
+
+          // We don't have good text for a toggle off link.
+          // When we do we can remove this and update the text appropriately
+          toggleLink.remove();
+          exhibitMediaObjects.each(function(i) {
+            if (i >= _this.exhibitToggleThreshold) {
+              if($(this).is(':visible')) {
+                $(this).hide(); // Will be used when we have a toggle closed link
+              } else {
+                $(this).show();
+              }
+            }
+          });
+        });
+        container.append(toggleLink);
+      }
+    },
+
+    exhibitMediaObject: function(exhibit) {
+      var exhibitUrl = this.exhibitsUrl(exhibit.slug);
+      var wrapper = $('<div class="media"></div>');
+      var image = $(
+        '<div class="media-left"><a href="' + exhibitUrl + '"><img src="" /></a></div>'
+      );
+      var body = $('<div class="media-body"></div>');
+      var heading = $('<div class="media-heading"></div>');
+      if (exhibit.thumbnail_url) {
+        wrapper.append(image);
+        image.find('img').prop('src', exhibit.thumbnail_url);
+      }
+      wrapper.append(body);
+      body.append(heading);
+      heading.append(
+        '<h4><a href="' + exhibitUrl + '">' + exhibit.title + '</a></h4> '
+      );
+      if (exhibit.subtitle && exhibit.subtitle !== '') {
+        heading.append(exhibit.subtitle)
+      }
+      return wrapper;
+    }
+  }
+
+  global.ExhibitsPanel = ExhibitsPanel;
+})(this);
+
+Blacklight.onLoad(function() {
+  $('[data-behavior="exhibits-panel"]').each(function(i, element) {
+    ExhibitsPanel.init($(element));
+  })
+});

--- a/app/assets/stylesheets/modules/access-panel-exhibit.scss
+++ b/app/assets/stylesheets/modules/access-panel-exhibit.scss
@@ -1,0 +1,12 @@
+.access-panel {
+  &.panel-exhibit {
+    .media-left img {
+      height: 75px;
+      width: 75px;
+    }
+
+    .media-heading h4 {
+      margin-top: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -5,6 +5,7 @@
 
 @import 'modules/access-panel';
 @import 'modules/access-panel-course-reserve';
+@import 'modules/access-panel-exhibit';
 @import 'modules/access-panel-library-locations';
 @import 'modules/access-panel-online';
 @import 'modules/access-panel-related';

--- a/app/views/catalog/access_panels/_exhibits.html.erb
+++ b/app/views/catalog/access_panels/_exhibits.html.erb
@@ -1,0 +1,28 @@
+<% document ||= @document %>
+
+<% if (access_panel = document.access_panels.exhibit).present? && Settings.EXHIBITS_ACCESS_PANEL.enabled %>
+  <div
+    class="panel panel-default access-panel panel-exhibit"
+    data-behavior="exhibits-panel"
+    data-exhibits-host="<%= Settings.EXHIBITS_ACCESS_PANEL.exhibits_host %>"
+    data-is-collection="<%= document.is_a_collection?.to_s %>"
+    data-druid="<%= access_panel.druid %>"
+    style="display:none;"
+  >
+    <div class="access-panel-heading panel-heading">
+      <h3>
+        <% if document.is_a_collection? %>
+          Exhibits
+        <% else %>
+          <span style="display:none" data-behavior="single-exhibit-heading">Item is featured in an exhibit</span>
+          <span style="display:none" data-behavior="multiple-exhibit-heading">Item is featured in exhibits</span>
+        <% end %>
+      </h3>
+    </div>
+    <div class="panel-body">
+      <% if document.is_a_collection? %>
+        <p>Items from this collection are featured in:</p>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/record/_metadata_panels.html.erb
+++ b/app/views/catalog/record/_metadata_panels.html.erb
@@ -1,16 +1,23 @@
 <%
   appears_in = render "catalog/access_panels/appears_in"
   in_collection = render "catalog/access_panels/in_collection"
+  exhibits = render 'catalog/access_panels/exhibits'
 %>
 
 <div class="metadata-panels">
   <%= render "catalog/access_panels/online" %>
   <%= render "catalog/access_panels/course_reserve" %>
   <%= render "catalog/access_panels/location" %>
-  <% if appears_in.present? || in_collection.present? %>
-    <h2>Context</h2>
+  <% if appears_in.present? || in_collection.present? || exhibits.present? %>
+    <h2
+      data-behavior="metadata-panel-context-heading"
+      style="<%= 'display:none' unless appears_in.present? || in_collection.present? %>"
+    >
+      Context
+    </h2>
   <% end %>
   <%= appears_in %>
   <%= in_collection %>
+  <%= exhibits %>
   <%= render "catalog/access_panels/related" %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module SearchWorks
     require 'access_panel'
     require 'access_panels'
     require 'access_panels/course_reserve'
+    require 'access_panels/exhibit'
     require 'access_panels/library_location'
     require 'access_panels/online'
     require 'access_panels/sfx'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+Dir[Rails.root.join("spec/support/rack_apps/*.rb")].each { |f| require f }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   mount Blacklight::Engine => '/'
   mount BlacklightAdvancedSearch::Engine => '/'
+  mount MockExhibitsFinderEndpoint.new, at: '/exhibit_finder' if Rails.env.test?
 
   concern :searchable, Blacklight::Routes::Searchable.new
   concern :exportable, Blacklight::Routes::Exportable.new

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,9 @@ NUMBER_OF_DAYS_TO_PRUNE: '7'
 PURL_EMBED_PROVIDER: 'https://embed.stanford.edu/embed'
 PURL_EMBED_URL_SCHEME: 'https://purl.stanford.edu/*'
 PURL_EMBED_RESOURCE: 'https://purl.stanford.edu/'
+EXHIBITS_ACCESS_PANEL:
+  enabled: false
+  exhibits_host: http://example.com
 GLOBAL_ALERT: <%= false %>
 HOME_PAGE_NOTICE: <%= false %>
 GOOGLE_SITE_VERIFICATION: "FZOfWKmcoL5TIDC-0G8vEHMnqcPXi-PhI5OwDvJL0Zo"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,3 +3,5 @@ HOSTNAME: "TEST-HOST"
 PURL_EMBED_PROVIDER: 'http://embed.stanford.edu/embed'
 SU_AFFILIATIONS:
   - test-stanford:test
+EXHIBITS_ACCESS_PANEL:
+  enabled: true

--- a/lib/access_panels/exhibit.rb
+++ b/lib/access_panels/exhibit.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AccessPanels
+  class Exhibit < ::AccessPanel
+    delegate :druid, to: :@document
+    delegate :present?, to: :druid
+  end
+end

--- a/spec/features/access_panels/exhibit_spec.rb
+++ b/spec/features/access_panels/exhibit_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Exhibit Access Panel', type: :feaature, js: true do
+  let(:content) { [] }
+  before do
+    expect(Settings.EXHIBITS_ACCESS_PANEL).to receive(:exhibits_host).and_return(
+      "http://127.0.0.1:#{Capybara.current_session.server.port}"
+    )
+
+    MockExhibitsFinderEndpoint.configure do |endpoint|
+      endpoint.content = content.to_json
+    end
+  end
+
+  context 'when there are no exhibits' do
+    it 'does not display the Context heading' do
+      visit '/view/mf774fs2413'
+      expect(page).not_to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      expect(page).to have_css('h2', text: 'Context', visible: false)
+    end
+  end
+
+  context 'when there is one exhibit' do
+    let(:content) do
+      [{ slug: 'exhibit1', title: 'Exhibit Title' }]
+    end
+
+    it 'displays the Context heading' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      expect(page).to have_css('h2', text: 'Context', visible: true)
+    end
+
+    it 'has a specific panel title' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('h3', text: 'Item is featured in an exhibit')
+      end
+    end
+
+    it 'renders the panel with a media object for each exhibit' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('.media', count: 1)
+      end
+    end
+
+    it 'links the title' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"] .media-heading' do
+        expect(page).to have_link('Exhibit Title')
+      end
+    end
+  end
+
+  context 'when the exhibit has a thumbnail' do
+    let(:content) do
+      [{ slug: 'exhibit1', title: 'Exhibit Titlte', thumbnail_url: 'http://example.com/thumb.jpg' }]
+    end
+
+    it 'is displayed and linked' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('.media-left img[src="http://example.com/thumb.jpg"]')
+      end
+    end
+  end
+
+  context 'when the exhibit has a subtitle' do
+    let(:content) do
+      [{ slug: 'exhibit1', title: 'Exhibit Titlte', subtitle: 'The subtitle' }]
+    end
+
+    it 'is displayed' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('.media-heading', text: /The subtitle$/)
+      end
+    end
+  end
+
+  context 'when there are more than 5 exhibits' do
+    let(:content) do
+      7.times.map do |index|
+        { slug: "exhibit-#{index}", title: "Exhibit #{index} Title" }
+      end
+    end
+
+    it 'has a specific panel title' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('h3', text: 'Item is featured in exhibits')
+      end
+    end
+
+    it 'donly displays the first 5 exhibits and has a link to toggle any additional' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('.media', count: 5, visible: true)
+        expect(page).to have_link('See all 7 exhibits')
+        click_link('See all 7 exhibits')
+        expect(page).to have_css('.media', count: 7, visible: true)
+        expect(page).not_to have_link('See all 7 exhibits')
+      end
+    end
+  end
+
+  context 'when the document is an item' do
+    let(:content) do
+      [{ slug: 'exhibit1', title: 'Exhibit Title' }]
+    end
+
+    it 'links to the document within the exhibit' do
+      visit '/view/mf774fs2413'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_link('Exhibit Title', href: %r{/exhibit1/catalog/mf774fs2413$})
+      end
+    end
+  end
+
+  context 'when the document is a collection' do
+    let(:content) do
+      [{ slug: 'exhibit1', title: 'Exhibit Title' }]
+    end
+
+    it 'has a specific panel title' do
+      visit '/view/34'
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_css('h3', text: 'Exhibit')
+      end
+    end
+
+    it 'links to the exhibit landing page' do
+      visit '/view/34'
+
+      expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
+
+      within '[data-behavior="exhibits-panel"]' do
+        expect(page).to have_link('Exhibit Title', href: %r{/exhibit1$})
+      end
+    end
+  end
+end

--- a/spec/support/rack_apps/mock_exhibits_finder_endpoint.rb
+++ b/spec/support/rack_apps/mock_exhibits_finder_endpoint.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class MockExhibitsFinderEndpoint
+  cattr_accessor :content, :content_type, :status
+
+  class << self
+    def status
+      @@status || 200
+    end
+
+    def content_type
+      @@content_type || 'application/json'
+    end
+
+    def content
+      @@content || [].to_json
+    end
+
+    def configure
+      yield(self) if block_given?
+      self
+    end
+  end
+
+  def call(_env)
+    [
+      self.class.status,
+      { 'content_type' => self.class.content_type },
+      [self.class.content]
+    ]
+  end
+end


### PR DESCRIPTION
... item(s) in a collection is in an exhibit.

Builds on the API in sul-dlss/exhibits#1494

Closes sul-dlss/exhibits#1465
Closes sul-dlss/exhibits#1468

![document-privacy-toggle](https://user-images.githubusercontent.com/96776/72559204-1b54ab80-3859-11ea-9e11-09cfad3a6ec1.gif)


## Single Exhibit
<img width="480" alt="Screen Shot 2020-01-15 at 10 12 46 PM" src="https://user-images.githubusercontent.com/96776/72498433-2faa9100-37e4-11ea-8d7c-92c7daa2dfc9.png">

## Multiple Exhibits
<img width="470" alt="Screen Shot 2020-01-15 at 10 12 05 PM" src="https://user-images.githubusercontent.com/96776/72498435-30432780-37e4-11ea-94d6-e62cbf4d53b6.png">

## Collection with Exhibits
<img width="470" alt="Screen Shot 2020-01-15 at 10 12 27 PM" src="https://user-images.githubusercontent.com/96776/72498434-2faa9100-37e4-11ea-9560-d1e45da2d49e.png">

