### PR TITLE
Add attributes to make the (duplicate) link around the exhibit's…

### DIFF
--- a/app/assets/javascripts/exhibitPanel.js
+++ b/app/assets/javascripts/exhibitPanel.js
@@ -110,7 +110,11 @@
       var exhibitUrl = this.exhibitsUrl(exhibit.slug);
       var wrapper = $('<div class="media"></div>');
       var image = $(
-        '<div class="media-left"><a href="' + exhibitUrl + '"><img src="" /></a></div>'
+        ['<div class="media-left">',
+           '<a href="' + exhibitUrl + '" tabindex="-1" aria-hidden="true">',
+             '<img alt="" src="" />',
+           '</a>',
+         '</div>'].join('')
       );
       var body = $('<div class="media-body"></div>');
       var heading = $('<div class="media-heading"></div>');

--- a/spec/features/access_panels/exhibit_spec.rb
+++ b/spec/features/access_panels/exhibit_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Exhibit Access Panel', type: :feaature, js: true do
 
   context 'when the exhibit has a thumbnail' do
     let(:content) do
-      [{ slug: 'exhibit1', title: 'Exhibit Titlte', thumbnail_url: 'http://example.com/thumb.jpg' }]
+      [{ slug: 'exhibit1', title: 'Exhibit Title', thumbnail_url: 'http://example.com/thumb.jpg' }]
     end
 
     it 'is displayed and linked' do
@@ -73,7 +73,7 @@ RSpec.describe 'Exhibit Access Panel', type: :feaature, js: true do
       expect(page).to have_css('[data-behavior="exhibits-panel"]', visible: true)
 
       within '[data-behavior="exhibits-panel"]' do
-        expect(page).to have_css('.media-left img[src="http://example.com/thumb.jpg"]')
+        expect(page).to have_css('.media-left img[src="http://example.com/thumb.jpg"]', visible: false)
       end
     end
   end


### PR DESCRIPTION
…thumbnail (and the thumbnail itself) imperceptible by screen readers.


