### PR TITLE
Add some JS errors to the Honeybadger ignore patterns.

### DIFF
--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -28,6 +28,11 @@
         environment: '<%= Honeybadger.config.get(:env) %>',
         debug: false,
         onerror: true,
+        ignorePatterns: [
+          /reCAPTCHA placeholder element must be empty/i,
+          /Undefined variable: MutationObserver/i, // Seems to only come from Opera Mini. Not in our codebase.
+          /Blocked a frame with origin "https:\/\/\w+\.stanford.edu"/i // We don't need to know that this happens
+        ],
         revision: '<%= Settings.REVISION %>'
       });
     </script>


### PR DESCRIPTION
These are errors that are seemingly coming from plugins or by our dependencies in ways that we can't really do anything about (e.g. reCaptcha)

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
