### PR TITLE
Don't use recaptcha 5.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ gem 'whenever' # manages cron jobs
 gem 'bitly', '>= 2.0.0.beta' # For bit.ly
 gem 'bootsnap', require: false
 gem 'leaflet-rails'
-gem 'recaptcha'
+gem 'recaptcha', '!= 5.4.0'
 gem 'oauth2', '~> 1.4' # Pinning so we don't get downgraded
 gem 'rinku', require: 'rails_rinku'
 gem 'bootstrap-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    recaptcha (5.4.0)
+    recaptcha (5.3.0)
       json
     regexp_parser (1.7.0)
     require_all (2.0.0)
@@ -589,7 +589,7 @@ DEPENDENCIES
   rack-utf8_sanitizer
   rails (~> 5.2)
   rails-controller-testing
-  recaptcha
+  recaptcha (!= 5.4.0)
   retina_tag
   rinku
   roadie-rails (~> 2)
@@ -614,4 +614,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
ambethia/recaptcha#356 aims to address this issue, and will hopefully be released as 5.5.0

This is causing reCaptcha restricted emails to not be sent (even w/ a valid recaptcha challenge)
