### PR TITLE
Escape query parameters when passing them through the regular …

### DIFF
--- a/app/models/concerns/cjk_query.rb
+++ b/app/models/concerns/cjk_query.rb
@@ -33,7 +33,7 @@ module CJKQuery
             else
               stripped_param = modify_field_key_for_cjk(param)
               if cjk_local_params.present?
-                solr_params[:q].gsub!(/\{!edismax(.*(q|p)f\d?=\$(q|p)f?\d?_(#{stripped_param})\s?)}#{blacklight_params[param]}/, '{!edismax \1 mm=' + cjk_local_params['mm'].to_s + ' qs=' + cjk_local_params['qs'].to_s + ' }' + blacklight_params[param])
+                solr_params[:q].gsub!(/\{!edismax(.*(q|p)f\d?=\$(q|p)f?\d?_(#{stripped_param})\s?)}#{Regexp.escape(blacklight_params[param])}/, '{!edismax \1 mm=' + cjk_local_params['mm'].to_s + ' qs=' + cjk_local_params['qs'].to_s + ' }' + blacklight_params[param])
               end
               solr_params[:q].gsub!(/((q|p)f\d?=\$(q|p)f?\d?_(#{stripped_param}))/, '\1_cjk')
             end

--- a/spec/models/concerns/cjk_query_spec.rb
+++ b/spec/models/concerns/cjk_query_spec.rb
@@ -54,6 +54,14 @@ describe CJKQuery do
       it "should not do anything w/ the number qf/pf" do
         expect(solr_params[:q]).to include "{!edismax qf=$qf_number pf=$pf_number pf3=$pf3_number pf2=$pf2_number}#{q_str}"
       end
+
+      context 'when there are unbalanced parenthesis in the query' do
+        let(:q_str) { '((舊小說)' }
+
+        it 'is handled without error' do
+          expect(solr_params[:q]).to include "{!edismax qf=$qf_cjk pf=$pf_cjk pf3=$pf3_cjk pf2=$pf2_cjk #{local_params} }#{q_str}"
+        end
+      end
     end
 
     describe "pre-processed" do


### PR DESCRIPTION
…expression in the CJK Query processor (so they do not throw regex errors)

https://app.honeybadger.io/projects/50022/faults/43235990