### PR TITLE
Remove eReserves from 'At the Library' panels

### DIFF
--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -28,11 +28,15 @@ class Holdings
     end
 
     def holding_library?
-      !zombie?
+      !zombie? && !eresv?
     end
 
     def zombie?
       @code == 'ZOMBIE'
+    end
+
+    def eresv?
+      @code == 'E-RESV'
     end
 
     def hoover_archive?

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -109,6 +109,17 @@ describe Holdings::Library do
     end
   end
 
+  describe "eresv?" do
+    let(:eresv) { Holdings::Library.new("E-RESV") }
+
+    it "should be #eresv?" do
+      expect(eresv).to be_eresv
+    end
+    it "should not be a holding library" do
+      expect(eresv).not_to be_holding_library
+    end
+  end
+
   describe '#hoover_archive?' do
     let(:hv_archive) { Holdings::Library.new('HV-ARCHIVE') }
 


### PR DESCRIPTION
Fixes #2436

@saseestone : I assume/hope we also want to remove similar panels with this data (like under Check Availability on search results, in the call number bar for the gallery view, etc)?