### PR TITLE
De-dup mods abstracts coming from summary_display.

### DIFF
--- a/app/models/concerns/mods_data.rb
+++ b/app/models/concerns/mods_data.rb
@@ -37,6 +37,6 @@ module ModsData
   end
 
   def mods_abstract
-    fetch(:summary_display, [])
+    fetch(:summary_display, [])&.uniq
   end
 end

--- a/spec/models/concerns/mods_data_spec.rb
+++ b/spec/models/concerns/mods_data_spec.rb
@@ -29,4 +29,20 @@ describe ModsData do
       expect(document.prettified_mods).to match />A record with everything</
     end
   end
+
+  describe '#mods_abstract' do
+    let(:document) { SolrDocument.new(summary_display: ['The Abstract']) }
+
+    it 'is fetched from the index' do
+      expect(document.mods_abstract).to eq ['The Abstract']
+    end
+
+    context 'when the index data has duplicate content' do
+      let(:document) { SolrDocument.new(summary_display: ['The Abstract', 'The Abstract']) }
+
+      it 'de-duplicates it' do
+        expect(document.mods_abstract).to eq ['The Abstract']
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #2435

Ultimately this should be addressed at the index level but will require both a fix and a re-index of all MODS content before we'll see a change in production (but we can get a quick fix for this in the app in the meantime).

`summary_display` a copyField whose source is `summary_search`.  `summary_search` does not have this duplicate content so not sure why it is ending up in the copy field destination.  If anybody can point me towards a quick fix for that I would be happy to submit it, otherwise I'll open a ticket in the indexer to look into this root cause more.

## Result For zs026hw5182 Before
<img width="778" alt="zs026hw5182-result-before" src="https://user-images.githubusercontent.com/96776/79892660-b6f53b00-83b7-11ea-8fac-b581a510acd7.png">

## Result For zs026hw5182 After
<img width="780" alt="zs026hw5182-result-after" src="https://user-images.githubusercontent.com/96776/79892666-b8266800-83b7-11ea-85e4-24fdb7bc468a.png">

