### PR TITLE
Pass MARC TOC elements through the render_struct_field_data helper.

### DIFF
--- a/app/views/catalog/record/_marc_contents_summary.html.erb
+++ b/app/views/catalog/record/_marc_contents_summary.html.erb
@@ -19,9 +19,9 @@
     <%- unless toc[:fields].nil? -%>
       <%- toc[:fields].each do |toc_field| -%>
         <ul class="toc">
-          <%- toc_field.each do |field| -%>
-            <li><%= field %></li>
-          <%- end -%>
+          <% Array.wrap(toc_field).each do |field| %>
+            <li><%= render_struct_field_data(document, field) %></li>
+          <% end %>
         </ul>
       <%- end -%>
     <%- end -%>


### PR DESCRIPTION
This is consistent with the data in the results view.

Closes #2433 

## Before (13243356)
<img width="720" alt="13243356-before" src="https://user-images.githubusercontent.com/96776/79915338-a5be2580-83db-11ea-951a-a248b7459118.png">

## After (13243356)
<img width="717" alt="13243356-after" src="https://user-images.githubusercontent.com/96776/79915343-a6ef5280-83db-11ea-9e50-9bd2f44e06bc.png">
