### PR TITLE
Allow users to report URLs in their feedback and record emails.

### DIFF
--- a/app/controllers/concerns/email_validation.rb
+++ b/app/controllers/concerns/email_validation.rb
@@ -5,8 +5,6 @@ module EmailValidation
     case
     when !%w(full brief).include?(params[:type])
       flash[:error] = I18n.t('blacklight.email.errors.type')
-    when params[:message] =~ %r{href|url=|https?://}i
-      flash[:error] = I18n.t('blacklight.email.errors.message.spam')
     when params[:to].blank?
       flash[:error] = I18n.t('blacklight.email.errors.to.blank')
     when too_many_email_addresses?

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -37,10 +37,6 @@ class FeedbackFormsController < ApplicationController
     @form_type = params.permit(:type)[:type]
   end
 
-  def url_regex
-    /.*href=.*|.*url=.*|.*http:\/\/.*|.*https:\/\/.*/i
-  end
-
   def validate
     errors = []
 
@@ -48,13 +44,6 @@ class FeedbackFormsController < ApplicationController
 
     if params[:message].nil? or params[:message] == ""
       errors << "A message is required"
-    end
-    if params[:message] =~ url_regex
-      errors << "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
-    end
-    if params[:user_agent] =~ url_regex ||
-       params[:viewport]   =~ url_regex
-       errors << "Your message appears to be spam, and has not been sent."
     end
     flash[:error] = errors.join("<br/>") unless errors.empty?
     flash[:error].nil?

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -108,8 +108,6 @@ en:
           placeholder: '(optional)'
       errors:
         type: 'Invalid email type provided'
-        message:
-          spam: 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
         to:
           invalid: 'You must enter only valid email addresses.'
           too_many: 'You have entered more than the maximum (%{max}) email addresses allowed.'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -87,14 +87,6 @@ describe CatalogController do
         end.to change { ActionMailer::Base.deliveries.count }.by(3)
       end
       describe 'validations' do
-        it 'should not allow messages that have links in them' do
-          expect do
-            post :email, params: { to: 'email@example.com', message: 'https://library.stanford.edu', type: 'full' }
-          end.not_to change { ActionMailer::Base.deliveries.count }
-          expect(flash[:error]).to include('Your message appears to be spam, and has not been sent.')
-          expect(flash[:error]).to include('Please try sending your message again without any links in the comments.')
-        end
-
         it 'should prevent incorrect email types from being sent' do
           expect do
             post :email, params: { to: 'email@example.com', type: 'not-a-type' }

--- a/spec/controllers/feedback_forms_controller_spec.rb
+++ b/spec/controllers/feedback_forms_controller_spec.rb
@@ -48,26 +48,6 @@ describe FeedbackFormsController do
         post :create, params: { url: "http://test.host/", message: "", email_address: "" }
         expect(flash[:error]).to eq "A message is required"
       end
-      it "should block potential spam with a href in the message" do
-        post :create, params: { message: "I like to spam by sending you a <a href='http://www.somespam.com'>Link</a>.  lolzzzz", url: "http://test.host/", email_address: "" }
-        expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
-      end
-      it "should block potential spam with a url= in the message" do
-        post :create, params: { message: "I like to spam by sending you a <a url='http://www.somespam.com'>Link</a>.  lolzzzz", url: "http://test.host/", email_address: "" }
-        expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
-      end
-      it "should block potential spam with a http:// in the message" do
-        post :create, params: { message: "I like to spam by sending you a http://www.somespam.com.  lolzzzz", url: "http://test.host/", email_address: "" }
-        expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
-      end
-      it 'should block potential spam with a http:// in the user_agent field' do
-        post :create, params: { user_agent: "http://www.google.com", message: "Legit message", url: "http://test.host" }
-        expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent."
-      end
-      it 'should block potential spam with a http:// in the viewport field' do
-        post :create, params: { viewport: "http://www.google.com", message: "Legit message", url: "http://test.host" }
-        expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent."
-      end
     end
   end
 end


### PR DESCRIPTION
Now that we're only allowing Captcha authenticated anonymous users to submit feedback/record emails so it seems like we can ease the rule about blocking content with URLs as spam.

I'm interested in the take of others (in particular those who manage the feedback @trapido / @jlkalchik) on allowing users to send links via feedback now.  It would be tough to say what legitimate spam is being blocked by that filter (my assumption would be zero as it would get stopped by the Captcha).  I'm guessing we're only seeing actual users being frustrated by this filter now, and we can/should remove it.

I'm also not sure if we can/should provide more guidance to the user that we report the URL of the page they submit the feedback/etc from (because it seems like more often than not that's the URL they're trying to report to us anyway).