### PR TITLE
Make TemporaryAccess links always have a Stanford S icon.

### DIFF
--- a/app/views/catalog/_index_online_section.html.erb
+++ b/app/views/catalog/_index_online_section.html.erb
@@ -10,7 +10,7 @@
     <ul class="online-links" data-behavior="truncate-results-online-links">
       <% if document.access_panels.temporary_access? %>
         <% temp_access = document.access_panels.temporary_access %>
-        <li class="<%= 'stanford-only' unless temp_access.publicly_available? %>">
+        <li class="stanford-only">
           <%= link_to('Full text via HathiTrust', temp_access.url) %>
         </li>
       <% end %>

--- a/app/views/catalog/access_panels/_temporary_access.html.erb
+++ b/app/views/catalog/access_panels/_temporary_access.html.erb
@@ -5,7 +5,7 @@
       <h3>Temporary access</h3>
     </div>
     <div class="panel-body">
-      <span class="<%= 'stanford-only' unless temp_access.publicly_available? %>">
+      <span class="stanford-only">
         <%= link_to('Full text via HathiTrust', temp_access.url) %>
       </span>
       <div class="etas-results-block">


### PR DESCRIPTION
Connected to #2455