### PR TITLE
Refactor HathiTrust Publicly Accessible Links to Online Panel

### DIFF
--- a/app/models/concerns/hathi_links.rb
+++ b/app/models/concerns/hathi_links.rb
@@ -1,0 +1,27 @@
+module HathiLinks
+  def hathi_links
+    @hathi_links ||= HathiLinks::Processor.new(self)
+  end
+
+  class Processor < SearchWorks::Links
+    def all
+      return [] unless ht_links.present?
+
+      Array.wrap(
+        SearchWorks::Links::Link.new(
+          html: "<a href=\"#{ht_links.url}\">Full text via HathiTrust</a>",
+          text: 'Full text via HathiTrust',
+          href: ht_links.url,
+          fulltext: true,
+          stanford_only: !ht_links.publicly_available?,
+        )
+      )
+    end
+
+    private
+
+    def ht_links
+      @ht_links ||= HathiTrustLinks.new(@document)
+    end
+  end
+end

--- a/app/models/hathi_trust_links.rb
+++ b/app/models/hathi_trust_links.rb
@@ -42,10 +42,15 @@ class HathiTrustLinks
   end
 
   def work_url
-    "https://catalog.hathitrust.org/Record/#{hathitrust_work_id}?signon=swle:#{stanford_shib_id}"
+    work_base_url = "https://catalog.hathitrust.org/Record/#{hathitrust_work_id}"
+    return work_base_url if publicly_available?
+
+    "#{work_base_url}?signon=swle:#{stanford_shib_id}"
   end
 
   def item_url
+    return item_target(hathitrust_item_id) if publicly_available?
+
     "https://babel.hathitrust.org/Shibboleth.sso/Login?entityID=#{stanford_shib_id}&target=#{URI.encode(item_target(hathitrust_item_id))}"
   end
 

--- a/app/models/hathi_trust_links.rb
+++ b/app/models/hathi_trust_links.rb
@@ -1,0 +1,67 @@
+class HathiTrustLinks
+  attr_reader :document
+  def initialize(document)
+    @document = document
+  end
+
+  def present?
+    (hathitrust_work_id.present? || hathitrust_item_id.present?) && !fulltext_available?
+  end
+
+  # According to https://www.hathitrust.org/hathifiles_description access will be "allow"
+  # even in the case that the item is copyrighted in the US, or only Public Domain in the US
+  # (and therefore not available to users outside the US).
+  def publicly_available?
+    return false unless access_rights.present?
+
+    access_rights.none? do |value|
+      value == 'deny' || %w[allow:icus allow:pdus].include?(value)
+    end
+  end
+
+  def url
+    if hathitrust_item_id.nil? || many_holdings?
+      work_url
+    else
+      item_url
+    end
+  end
+
+  private
+
+  def access_rights
+    Array(document['ht_access_sim'])
+  end
+
+  def hathitrust_item_id
+    document.first('ht_htid_ssim')
+  end
+
+  def hathitrust_work_id
+    document.first('ht_bib_key_ssim')
+  end
+
+  def work_url
+    "https://catalog.hathitrust.org/Record/#{hathitrust_work_id}?signon=swle:#{stanford_shib_id}"
+  end
+
+  def item_url
+    "https://babel.hathitrust.org/Shibboleth.sso/Login?entityID=#{stanford_shib_id}&target=#{URI.encode(item_target(hathitrust_item_id))}"
+  end
+
+  def stanford_shib_id
+    'urn:mace:incommon:stanford.edu'
+  end
+
+  def many_holdings?
+    document.holdings.callnumbers.many?(&:present?)
+  end
+
+  def fulltext_available?
+    document&.index_links&.fulltext&.any? || document&.index_links&.sfx&.any?
+  end
+
+  def item_target(id)
+    "https://babel.hathitrust.org/cgi/pt?id=#{URI.encode(id)}&view=1up&seq=9"
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -7,6 +7,7 @@ class SolrDocument
   include MarcLinks
   include IndexLinks
   include EdsLinks
+  include HathiLinks
   include DisplayType
   include CourseReserves
   include AccessPanelsConcern

--- a/app/views/catalog/_index_online_section.html.erb
+++ b/app/views/catalog/_index_online_section.html.erb
@@ -11,7 +11,7 @@
       <% if document.access_panels.temporary_access? %>
         <% temp_access = document.access_panels.temporary_access %>
         <li class="stanford-only">
-          <%= link_to('Full text via HathiTrust', temp_access.url) %>
+          <%= temp_access.link.html.html_safe %>
         </li>
       <% end %>
 

--- a/app/views/catalog/access_panels/_temporary_access.html.erb
+++ b/app/views/catalog/access_panels/_temporary_access.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="panel-body">
       <span class="stanford-only">
-        <%= link_to('Full text via HathiTrust', temp_access.url) %>
+        <%= temp_access.link.html.html_safe %>
       </span>
       <div class="etas-results-block">
         <p class="etas-notice">Available by special arrangement in response to the COVID-19 outbreak. Simultaneous access is limited. </p>

--- a/lib/access_panels/online.rb
+++ b/lib/access_panels/online.rb
@@ -3,7 +3,7 @@ class AccessPanels
     delegate :present?, to: :links
 
     def links
-      sfx_links || marc_fulltext_links || eds_links
+      sfx_links || marc_fulltext_links || hathi_links || eds_links
     end
 
     private
@@ -18,6 +18,14 @@ class AccessPanels
 
     def eds_links
       @document.eds_links.fulltext if @document.eds_links.present?
+    end
+
+    def hathi_links
+      non_stanford_links = @document.hathi_links.all.reject(&:stanford_only?)
+
+      return unless non_stanford_links.any?
+
+      non_stanford_links
     end
   end
 end

--- a/lib/access_panels/temporary_access.rb
+++ b/lib/access_panels/temporary_access.rb
@@ -3,64 +3,17 @@ class AccessPanels
     def present?
       return false unless Settings.HATHI_ETAS_ACCESS
 
-      (hathitrust_work_id.present? || hathitrust_item_id.present?) && !fulltext_available?
+      stanford_only_hathi_links.present?
     end
 
-    # According to https://www.hathitrust.org/hathifiles_description access will be "allow"
-    # even in the case that the item is copyrighted in the US, or only Public Domain in the US
-    # (and therefore not available to users outside the US).
-    def publicly_available?
-      return false unless access_rights.present?
-
-      access_rights.none? do |value|
-        value == 'deny' || %w[allow:icus allow:pdus].include?(value)
-      end
-    end
-
-    def url
-      if hathitrust_item_id.nil? || many_holdings?
-        work_url
-      else
-        item_url
-      end
+    def link
+      stanford_only_hathi_links.first
     end
 
     private
 
-    def access_rights
-      Array(@document['ht_access_sim'])
-    end
-
-    def hathitrust_item_id
-      @document.first('ht_htid_ssim')
-    end
-
-    def hathitrust_work_id
-      @document.first('ht_bib_key_ssim')
-    end
-
-    def work_url
-      "https://catalog.hathitrust.org/Record/#{hathitrust_work_id}?signon=swle:#{stanford_shib_id}"
-    end
-
-    def item_url
-      "https://babel.hathitrust.org/Shibboleth.sso/Login?entityID=#{stanford_shib_id}&target=#{URI.encode(item_target(hathitrust_item_id))}"
-    end
-
-    def stanford_shib_id
-      'urn:mace:incommon:stanford.edu'
-    end
-
-    def many_holdings?
-      @document.holdings.callnumbers.many?(&:present?)
-    end
-
-    def fulltext_available?
-      @document&.index_links&.fulltext&.any? || @document&.index_links&.sfx&.any?
-    end
-
-    def item_target(id)
-      "https://babel.hathitrust.org/cgi/pt?id=#{URI.encode(id)}&view=1up&seq=9"
+    def stanford_only_hathi_links
+      @document.hathi_links.all.select(&:stanford_only?)
     end
   end
 end

--- a/spec/lib/access_panels/online_spec.rb
+++ b/spec/lib/access_panels/online_spec.rb
@@ -46,6 +46,18 @@ describe AccessPanels::Online do
     )
   end
 
+  let(:hathi_public) do
+    described_class.new(
+      SolrDocument.new(ht_bib_key_ssim: ['abc123'], ht_htid_ssim: ['1234567'], ht_access_sim: ['allow'])
+    )
+  end
+
+  let(:hathi_non_public) do
+    described_class.new(
+      SolrDocument.new(ht_bib_key_ssim: ['abc123'], ht_htid_ssim: ['1234567'])
+    )
+  end
+
   describe '#present?' do
     it 'is true when there are fulltext links present' do
       expect(fulltext).to be_present
@@ -86,6 +98,17 @@ describe AccessPanels::Online do
 
     it 'should not return any non-fulltext links' do
       expect(supplemental.links).to be_blank
+    end
+
+    it 'should not return HathiTrust non-public access links' do
+      expect(hathi_non_public.links).to be_blank
+    end
+
+    it 'should return HathiTrust public access links' do
+      links = hathi_public.links
+      expect(links.length).to eq 1
+      expect(links.first.html).to match(%r{^<a.*>Full text via HathiTrust<\/a>$})
+      expect(links.first).not_to be_stanford_only
     end
   end
 end

--- a/spec/lib/access_panels/temporary_access_spec.rb
+++ b/spec/lib/access_panels/temporary_access_spec.rb
@@ -17,72 +17,17 @@ describe AccessPanels::TemporaryAccess do
 
       it { expect(temp_access).not_to be_present }
     end
-
-    context 'when the document has fulltext' do
-      before { document_data[:url_fulltext] = ['http://example.com'] }
-
-      it { expect(temp_access).not_to be_present }
-    end
   end
 
-  describe '#publicly_available?' do
-    context 'when there is no access data' do
-      it { expect(temp_access).not_to be_publicly_available }
+  describe '#link' do
+    context 'when there is a non-publicly available HathiTrust link' do
+      it { expect(temp_access.link.html).to match(%r{<a.*>Full text via HathiTrust</a>}) }
     end
 
-    context 'when the access statements include deny' do
-      before { document_data[:ht_access_sim] = ['deny', 'allow'] }
+    context 'when the HathiTrust link is publicly available' do
+      before {  document_data[:ht_access_sim] = ['allow'] }
 
-      it { expect(temp_access).not_to be_publicly_available }
-    end
-
-    context 'when the access statements include allow (but have copyright status that does not guarantee access)' do
-      before { document_data[:ht_access_sim] = ['allow', 'allow:icus'] }
-
-      it { expect(temp_access).not_to be_publicly_available }
-    end
-
-    context 'when the access statments indicate users can access' do
-      before { document_data[:ht_access_sim] = ['allow', 'allow:pd'] }
-
-      it { expect(temp_access).to be_publicly_available }
-    end
-  end
-
-  describe '#url' do
-    context 'when there is no item ID' do
-      before do
-        document_data[:ht_htid_ssim] = nil
-      end
-
-      it 'is the url to the work' do
-        expect(temp_access.url).to include('hathitrust.org/Record/abc123')
-      end
-    end
-
-    context 'when the document has many holdings' do
-      before do
-        document_data[:item_display] = [
-          '123 -|- GREEN -|- STACKS -|-  -|-  -|-  -|-  -|-  -|- AB 123 -|- ',
-          '321 -|- GREEN -|- STACKS -|-  -|-  -|-  -|-  -|-  -|- AB 321 -|- '
-        ]
-      end
-
-      it 'is the url to the work' do
-        expect(temp_access.url).to include('hathitrust.org/Record/abc123')
-      end
-    end
-
-    context 'when the document only has one holding' do
-      before do
-        document_data[:item_display] = [
-          '123 -|- GREEN -|- STACKS -|-  -|-  -|-  -|-  -|-  -|- AB 123 -|- '
-        ]
-      end
-
-      it 'is the url to the item' do
-        expect(temp_access.url).to include('hathitrust.org/cgi/pt?id=1234567&view=1up')
-      end
+      it { expect(temp_access.link).not_to be_present }
     end
   end
 end

--- a/spec/models/concerns/hathi_links_spec.rb
+++ b/spec/models/concerns/hathi_links_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'HathiLinks SolrDocument Concern' do
+  let(:document_data) { {} }
+  subject(:links) { SolrDocument.new(document_data).hathi_links }
+
+  context 'when there is no Hathi data' do
+    it { expect(links).not_to be_present }
+  end
+
+  context 'when there is Hathi data' do
+    let(:document_data) do
+      { ht_bib_key_ssim: ['abc123'], ht_htid_ssim: ['1234567'] }
+    end
+
+    it 'is an array of the one HathiTrust link' do
+      expect(links).to be_a(SearchWorks::Links)
+      expect(links.all.length).to eq 1
+      expect(links.first.text).to eq 'Full text via HathiTrust'
+      expect(links.first).to be_stanford_only
+    end
+  end
+
+  context 'when the link is publicly available' do
+    let(:document_data) do
+      { ht_bib_key_ssim: ['abc123'], ht_htid_ssim: ['1234567'], ht_access_sim: ['allow'] }
+    end
+
+    it 'is not stanford only' do
+      expect(links.all.length).to eq 1
+      expect(links.first.text).to eq 'Full text via HathiTrust'
+      expect(links.first).not_to be_stanford_only
+    end
+  end
+end

--- a/spec/models/hathi_trust_links_spec.rb
+++ b/spec/models/hathi_trust_links_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe HathiTrustLinks do
+  let(:document_data) { { ht_bib_key_ssim: ['abc123'], ht_htid_ssim: ['1234567'] } }
+  let(:document) { SolrDocument.new(document_data) }
+  subject(:ht_links) { described_class.new(document) }
+
+  describe '#present?' do
+    context 'when there is hathi data' do
+      it { expect(ht_links).to be_present }
+    end
+
+    context 'when there is no hathi data' do
+      let(:document_data) { {} }
+
+      it { expect(ht_links).not_to be_present }
+    end
+
+    context 'when the document has fulltext' do
+      before { document_data[:url_fulltext] = ['http://example.com'] }
+
+      it { expect(ht_links).not_to be_present }
+    end
+  end
+
+  describe '#publicly_available?' do
+    context 'when there is no access data' do
+      it { expect(ht_links).not_to be_publicly_available }
+    end
+
+    context 'when the access statements include deny' do
+      before { document_data[:ht_access_sim] = ['deny', 'allow'] }
+
+      it { expect(ht_links).not_to be_publicly_available }
+    end
+
+    context 'when the access statements include allow (but have copyright status that does not guarantee access)' do
+      before { document_data[:ht_access_sim] = ['allow', 'allow:icus'] }
+
+      it { expect(ht_links).not_to be_publicly_available }
+    end
+
+    context 'when the access statments indicate users can access' do
+      before { document_data[:ht_access_sim] = ['allow', 'allow:pd'] }
+
+      it { expect(ht_links).to be_publicly_available }
+    end
+  end
+
+  describe '#url' do
+    context 'when there is no item ID' do
+      before do
+        document_data[:ht_htid_ssim] = nil
+      end
+
+      it 'is the url to the work' do
+        expect(ht_links.url).to include('hathitrust.org/Record/abc123')
+      end
+    end
+
+    context 'when the document has many holdings' do
+      before do
+        document_data[:item_display] = [
+          '123 -|- GREEN -|- STACKS -|-  -|-  -|-  -|-  -|-  -|- AB 123 -|- ',
+          '321 -|- GREEN -|- STACKS -|-  -|-  -|-  -|-  -|-  -|- AB 321 -|- '
+        ]
+      end
+
+      it 'is the url to the work' do
+        expect(ht_links.url).to include('hathitrust.org/Record/abc123')
+      end
+    end
+
+    context 'when the document only has one holding' do
+      before do
+        document_data[:item_display] = [
+          '123 -|- GREEN -|- STACKS -|-  -|-  -|-  -|-  -|-  -|- AB 123 -|- '
+        ]
+      end
+
+      it 'is the url to the item' do
+        expect(ht_links.url).to include('hathitrust.org/cgi/pt?id=1234567&view=1up')
+      end
+    end
+  end
+
+end

--- a/spec/models/hathi_trust_links_spec.rb
+++ b/spec/models/hathi_trust_links_spec.rb
@@ -57,6 +57,21 @@ describe HathiTrustLinks do
 
       it 'is the url to the work' do
         expect(ht_links.url).to include('hathitrust.org/Record/abc123')
+        expect(ht_links.url).to include('?signon=swle:urn:mace')
+      end
+
+      context 'when publicly_available' do
+        it 'includes the signon param' do
+          expect(ht_links.url).to include('?signon=swle:urn:mace')
+        end
+      end
+
+      context 'when not publicly_available' do
+        before { document_data[:ht_access_sim] = ['access'] }
+
+        it 'does not include the signon param (and sends the user directly to the work)' do
+          expect(ht_links.url).not_to include('?signon=swle:urn:mace')
+        end
       end
     end
 
@@ -83,7 +98,21 @@ describe HathiTrustLinks do
       it 'is the url to the item' do
         expect(ht_links.url).to include('hathitrust.org/cgi/pt?id=1234567&view=1up')
       end
+
+      context 'when publicly_available' do
+        it 'passes the item URL through the target param' do
+          expect(ht_links.url).to include('target=https://babel.hathitrust.org/cgi/pt?id=1234567&view=1up')
+        end
+      end
+
+      context 'when not publicly_available' do
+        before { document_data[:ht_access_sim] = ['access'] }
+
+        it 'is the item URL directly (not passed as a the targer param)' do
+          expect(ht_links.url).not_to include('target=')
+          expect(ht_links.url).to start_with('https://babel.hathitrust.org/cgi/pt?id=1234567&view=1up')
+        end
+      end
     end
   end
-
 end


### PR DESCRIPTION
Part of #2455 

The goal for this is to have no change to existing links that are truly Stanford only, and that the public domain links can be pulled into the regular Online section w/o forcing the user through Stanford auth.

## 8935702 Before
<img width="666" alt="8935702-before" src="https://user-images.githubusercontent.com/96776/81757857-130e2500-9475-11ea-9169-f8d187813a67.png">

## 8935702 After
<img width="616" alt="8935702-after" src="https://user-images.githubusercontent.com/96776/81757856-12758e80-9475-11ea-9d38-e730ebe264ec.png">