### PR TITLE
Handle unbalanced single quote characters better when replacing …

### DIFF
--- a/app/controllers/concerns/replace_special_quotes.rb
+++ b/app/controllers/concerns/replace_special_quotes.rb
@@ -12,11 +12,34 @@ module ReplaceSpecialQuotes
   def replace_special_quotes
     modifiable_params_keys.each do |param|
       if params.has_key?(param) and params[param].present?
+        replace_single_quotes_from_param(params[param])
+
         special_quote_characters.each do |char|
           params[param].gsub!(/#{char}/, '"')
         end
       end
     end
+  end
+
+  def replace_single_quotes_from_param(param)
+    special_single_quotation_marks.each do |open_quote, close_quote|
+      opens = param.scan(open_quote)
+      closes = param.scan(close_quote)
+
+      if opens.length != closes.length # uneven single quotes
+        if opens.length == 1
+          param.sub!(/#{open_quote}/, "'")
+        end
+
+        if closes.length == 1
+          param.sub!(/#{close_quote}/, "'")
+        end
+      end
+    end
+  end
+
+  def special_single_quotation_marks
+    [["\u2018", "\u2019"], ["\u201A", "\u201B"]]
   end
 
   def special_quote_characters

--- a/app/controllers/concerns/replace_special_quotes.rb
+++ b/app/controllers/concerns/replace_special_quotes.rb
@@ -1,8 +1,13 @@
+# frozen_string_literal: true
+
+##
+# Module to be mixed into a controller to replace
+# special quote characters on the index action
 module ReplaceSpecialQuotes
   extend ActiveSupport::Concern
 
   included do
-    if self.respond_to?(:before_action)
+    if respond_to?(:before_action)
       before_action :replace_special_quotes, only: :index
     end
   end
@@ -11,12 +16,12 @@ module ReplaceSpecialQuotes
 
   def replace_special_quotes
     modifiable_params_keys.each do |param|
-      if params.has_key?(param) and params[param].present?
-        replace_single_quotes_from_param(params[param])
+      next unless params[param]&.present?
 
-        special_quote_characters.each do |char|
-          params[param].gsub!(/#{char}/, '"')
-        end
+      replace_single_quotes_from_param(params[param])
+
+      special_quote_characters.each do |char|
+        params[param].gsub!(/#{char}/, '"')
       end
     end
   end
@@ -26,15 +31,11 @@ module ReplaceSpecialQuotes
       opens = param.scan(open_quote)
       closes = param.scan(close_quote)
 
-      if opens.length != closes.length # uneven single quotes
-        if opens.length == 1
-          param.sub!(/#{open_quote}/, "'")
-        end
+      # only uneven single quotes
+      next unless opens.length != closes.length
 
-        if closes.length == 1
-          param.sub!(/#{close_quote}/, "'")
-        end
-      end
+      param.sub!(/#{open_quote}/, "'") if opens.length == 1
+      param.sub!(/#{close_quote}/, "'") if closes.length == 1
     end
   end
 

--- a/spec/controllers/concerns/replace_special_quotes_spec.rb
+++ b/spec/controllers/concerns/replace_special_quotes_spec.rb
@@ -8,7 +8,7 @@ describe ReplaceSpecialQuotes do
 
   before do
     controller.extend(ReplaceSpecialQuotes)
-    allow(controller).to receive(:modifiable_params_keys).and_return(['a_param'])
+    allow(controller).to receive(:modifiable_params_keys).and_return(%w[a_param b_param c_param d_param])
     allow(controller).to receive(:params).and_return(HashWithIndifferentAccess.new(params))
   end
 
@@ -20,6 +20,48 @@ describe ReplaceSpecialQuotes do
       expect(params[:a_param].scan("\"#{q}\"").length).to eq 14
       ["«", "「", "〟", "』"].each do |character|
         expect(params[:a_param]).not_to include(character)
+      end
+    end
+  end
+
+  describe 'with special single quotes' do
+    context 'when there is only one single quotation mark in the string' do
+      let(:params) do
+        {
+          a_param: "#{q}‘s",
+          b_param: "#{q}’s",
+          c_param: "#{q}‚s",
+          d_param: "#{q}‛s"
+        }
+      end
+
+      it 'should be replaced with an apostrophe' do
+        controller.send(:replace_special_quotes)
+
+        expect(params[:a_param]).to eq "query's"
+        expect(params[:b_param]).to eq "query's"
+        expect(params[:c_param]).to eq "query's"
+        expect(params[:d_param]).to eq "query's"
+      end
+    end
+
+    context 'when there are multiple single quotation marks in the string' do
+      let(:params) do
+        {
+          a_param: "‘#{q}‘",
+          b_param: "’#{q}’",
+          c_param: "‚#{q}‚",
+          d_param: "‛#{q}‛"
+        }
+      end
+
+      it 'should be replaced with the standard double quote character' do
+        controller.send(:replace_special_quotes)
+
+        expect(params[:a_param]).to eq '"query"'
+        expect(params[:b_param]).to eq '"query"'
+        expect(params[:c_param]).to eq '"query"'
+        expect(params[:d_param]).to eq '"query"'
       end
     end
   end


### PR DESCRIPTION
…special quote characters in query strings.

Fixes issue #2461

It seems like this will most likely happen when somebody is copy/pasting from typeset data where U+2019 is used for an apostrophe instead of U+0027. I threw the other single quotes for good measure (although I'm not sure if there would likely be cases where these characters were used as an apostrophe).

I could have taken this to the extreme and updated the code to only transform balanced special quote characters at all, but this felt like it had less possibility to introduce erroneous behavior.

