### PR TITLE
Don't link to Hoover Library/Archive requests when available via ETAS.

### DIFF
--- a/app/models/request_links/hoover_archive_request_link.rb
+++ b/app/models/request_links/hoover_archive_request_link.rb
@@ -7,6 +7,8 @@ module RequestLinks
     end
 
     def url
+      return if available_via_temporary_access?
+
       document&.index_links&.finding_aid&.first&.href
     end
 

--- a/app/models/request_links/hoover_request_link.rb
+++ b/app/models/request_links/hoover_request_link.rb
@@ -3,7 +3,7 @@
 module RequestLinks
   class HooverRequestLink < RequestLink
     def present?
-      true
+      !available_via_temporary_access?
     end
 
     def url

--- a/spec/models/request_links/hoover_archive_request_link_spec.rb
+++ b/spec/models/request_links/hoover_archive_request_link_spec.rb
@@ -20,8 +20,21 @@ RSpec.describe RequestLinks::HooverArchiveRequestLink do
   end
 
   describe '#url' do
-    it 'is the finding aid link' do
-      expect(link.url).to eq 'http://oac.cdlib.org/ark:/abc123'
+    context 'when available via temporary access' do
+      let(:document) do
+        SolrDocument.new(
+          url_suppl: ['http://oac.cdlib.org/ark:/abc123'],
+          ht_htid_ssim: 'abc123'
+        )
+      end
+
+      it { expect(link.url).not_to be_present }
+    end
+
+    context 'when not available via temporary access' do
+      it 'is the finding aid link' do
+        expect(link.url).to eq 'http://oac.cdlib.org/ark:/abc123'
+      end
     end
   end
 

--- a/spec/models/request_links/hoover_request_link_spec.rb
+++ b/spec/models/request_links/hoover_request_link_spec.rb
@@ -13,8 +13,15 @@ RSpec.describe RequestLinks::HooverRequestLink do
   subject(:link) { described_class.new(document: document, library: library, location: location, items: items) }
 
   describe '#present?' do
-    # Always render links for Hoover
-    it { expect(link).to be_present }
+    context 'when available via temporary access' do
+      let(:document) { SolrDocument.new(marcxml: metadata1, ht_htid_ssim: 'abc123') }
+
+      it { expect(link).not_to be_present }
+    end
+
+    context 'when not available via temporary access' do
+      it { expect(link).to be_present }
+    end
   end
 
   describe '#url' do


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
