### PR TITLE
Destroys datatable for crez on page nav

### DIFF
--- a/app/assets/javascripts/course_reserves.js
+++ b/app/assets/javascripts/course_reserves.js
@@ -20,6 +20,13 @@ Blacklight.onLoad(function(){
   browseCourseReservesTable.on('draw', function(){
     modifyPaginationElements();
   });
+  
+  $(document).on('turbolinks:before-cache', function() {
+    if (browseCourseReservesTable !== null) {
+     browseCourseReservesTable.destroy();
+     browseCourseReservesTable = null;
+    }
+  });
 
   function modifyPaginationElements(){
     // Change the active anchor element to a span


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/course_reserves/issues/219

Note: per https://m.phillydevshop.com/turbolinks-5-and-datatables-a882c29d6eff the table state will be lost on navigation. This seems preferred over the duplication.

![Kapture 2020-07-16 at 8 04 45](https://user-images.githubusercontent.com/1656824/87680863-2c647380-c73b-11ea-824b-d560d6e560a8.gif)
