### PR TITLE
Use auto_link when generically rendering MARC metadata fields

### DIFF
--- a/app/views/catalog/_field_from_marc.html.erb
+++ b/app/views/catalog/_field_from_marc.html.erb
@@ -1,6 +1,6 @@
 <dt title="<%= fields[:label] %>"><%= fields[:label] %></dt>
 <% fields[:fields].each do |field| %>
-  <dd><%= field[:field] %></dd>
+  <dd><%= auto_link(field[:field]) %></dd>
   <% if field[:vernacular].present? %>
     <dd><%= field[:vernacular] %></dd>
   <% end %>

--- a/app/views/marc_fields/_marc_field.html.erb
+++ b/app/views/marc_fields/_marc_field.html.erb
@@ -1,6 +1,6 @@
 <% if marc_field.values.present? %>
   <dt><%= marc_field.label %></dt>
   <% marc_field.values.each do |value| %>
-    <dd><%= value %></dd>
+    <dd><%= auto_link(value) %></dd>
   <% end  %>
 <% end %>


### PR DESCRIPTION
I wasn't sure if we had a compelling reason not to do so.  Was noticing some records w/ some unlinked URLs in note fields and remembered that we have talked about doing this in the past.  🤷 