### PR TITLE
Augment JSON API documents to include link data (similar to Articles+)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -526,6 +526,21 @@ class CatalogController < ApplicationController
     flash[:success] = I18n.t('blacklight.email.success')
   end
 
+  def augment_solr_document_json_response(documents)
+    documents.map do |document|
+      next document.as_json unless document&.access_panels&.online?
+
+      links = document&.access_panels&.online&.links&.map do |link|
+        html = link.stanford_only? ? "<span class=\"stanford-only\">#{link.html}</span>" : link.html
+
+        "<span class=\"online-label\">Online</span> #{html}"
+      end
+
+      document.as_json.merge('fulltext_link_html' => links)
+    end
+  end
+  helper_method :augment_solr_document_json_response
+
   def modifiable_params_keys
     %w[q search search_author search_title subject_terms series_search pub_search isbn_search]
   end

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -1,0 +1,6 @@
+# Overridden from Blacklight to inject content into documents
+json.response do
+  json.docs augment_solr_document_json_response(@presenter.documents)
+  json.facets @presenter.search_facets_as_json
+  json.pages @presenter.pagination_info
+end


### PR DESCRIPTION
This is to facilitate the Online link described in sul-dlss/sul-bento-app#293