### PR TITLE
Update Bento Home Page Section

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -87,4 +87,9 @@
     }
   }
 
+  .home-page-search-all {
+    .media-object {
+      font-size: 3.5em;
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -44,6 +44,23 @@
     padding: 0px;
   }
 
+  .bento-sections {
+    display: flex;
+    flex-wrap: wrap;
+
+    .bento-block {
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 48%;
+      min-width: 48%;
+
+      @media screen and (min-width: $screen-md-min) {
+        max-width: 24%;
+        min-width: 24%;
+      }
+    }
+  }
+
   img {
     width: 100%;
     display: block;

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -40,17 +40,22 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-12 home-page-bento bento-search-panel">
+    <div class="col-md-6">
       <div class="panel panel-default">
-        <div class="panel-body text-center">
-          <h3><%= link_to 'All of the above', 'https://library.stanford.edu/all' %></h3>
-          <p class="hidden-xs">Get an overview of what’s available in all these sources for your search topic.</p>
+        <div class="panel-body">
+          <div class="col-md-12 home-page-search-all media">
+            <div class="search-tools-icon media-left">
+              <span aria-hidden="true" class="media-object">🍱</span>
+            </div>
+            <div class="search-tools-body media-body">
+              <h3><%= link_to 'Search all', 'https://library.stanford.edu/all' %></h3>
+              <p class="hidden-xs">See an overview of what's available for your topic in all these sources.</p>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6 home-page-more">
+    <div class="col-md-6">
       <div class="panel panel-default">
         <div class="panel-body">
           <div class="col-md-12 home-page-search-tools media">

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -6,7 +6,7 @@
         <div class="panel-body">
           <%= image_tag 'homepage/catalog.jpg' %>
           <h3><%= link_to_unless controller_name == 'catalog', 'Catalog', root_path %></h3>
-          <p class="hidden-xs">Search the physical collections and digital resources of Stanford’s libraries. Find books, media, and <%= link_to 'topic-specific databases', databases_path %>.</p>
+          <p class="hidden-xs">Physical and digital books, media, journals, archives, and databases.</p>
         </div>
       </div>
     </div>
@@ -15,7 +15,7 @@
         <div class="panel-body">
           <%= image_tag 'homepage/articles.jpg' %>
           <h3><%= link_to_unless article_search?, 'Articles+', articles_path %></h3>
-          <p class="hidden-xs">Search a combined index of 100s of databases and connect directly to the article or resource.</p>
+          <p class="hidden-xs">Journal articles, e-books, and other e-resources.</p>
         </div>
       </div>
     </div>
@@ -25,7 +25,7 @@
         <div class="panel-body">
           <%= image_tag 'homepage/website.jpg' %>
           <h3><%= link_to 'Library website', 'https://library.stanford.edu' %></h3>
-          <p class="hidden-xs">Find topic specialists, blog posts, descriptions of our notable collections, as well as libraries, hours, and policies.</p>
+          <p class="hidden-xs">Libraries and subject specialists; blogs, events, and policies.</p>
         </div>
       </div>
     </div>
@@ -34,7 +34,7 @@
         <div class="panel-body">
           <%= image_tag 'homepage/yewno.jpg' %>
           <h3><%= link_to 'Yewno', 'https://stanford.idm.oclc.org/login?url=https://discover.yewno.com' %></h3>
-          <p class="hidden-xs">Explore concepts and connections, and understand interdisciplinary subjects, in a graph interface.</p>
+          <p class="hidden-xs">Knowledge graphs for interconnecting concepts.</p>
         </div>
       </div>
     </div>
@@ -59,7 +59,7 @@
             </div>
             <div class="search-tools-body media-body">
               <h3><%= link_to 'More search tools', 'https://library.stanford.edu/search-services' %></h3>
-              <p class="hidden-xs">Discover and access library and archival materials, journals, databases, data, and e-resources beyond SearchWorks.</p>
+              <p class="hidden-xs">Tools to help you discover resources at Stanford and beyond.</p>
             </div>
           </div>
         </div>

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -1,7 +1,7 @@
 <div class="home-page-bento">
   <h1>Search Stanford's library resources</h1>
-  <div class="row">
-    <div class="col-sm-3 col-xs-6 home-page-catalog <%= 'home-page-you-are-here' unless article_search? %>">
+  <div class="bento-sections">
+    <div class="bento-block home-page-catalog <%= 'home-page-you-are-here' unless article_search? %>">
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/catalog.jpg' %>
@@ -10,7 +10,8 @@
         </div>
       </div>
     </div>
-    <div class="col-sm-3 col-xs-6 home-page-articles <%= 'home-page-you-are-here' if article_search? %>">
+
+    <div class="bento-block home-page-articles <%= 'home-page-you-are-here' if article_search? %>">
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/articles.jpg' %>
@@ -19,8 +20,8 @@
         </div>
       </div>
     </div>
-    <div class="clearfix visible-xs"></div>
-    <div class="col-sm-3 col-xs-6 home-page-website">
+
+    <div class="bento-block home-page-website">
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/website.jpg' %>
@@ -29,7 +30,8 @@
         </div>
       </div>
     </div>
-    <div class="col-sm-3 col-xs-6 home-page-yewno">
+
+    <div class="bento-block home-page-yewno">
       <div class="panel panel-default">
         <div class="panel-body">
           <%= image_tag 'homepage/yewno.jpg' %>
@@ -39,6 +41,7 @@
       </div>
     </div>
   </div>
+
   <div class="row">
     <div class="col-md-6">
       <div class="panel panel-default">
@@ -55,6 +58,7 @@
         </div>
       </div>
     </div>
+
     <div class="col-md-6">
       <div class="panel panel-default">
         <div class="panel-body">

--- a/spec/views/shared/_home_page_bento.html.erb_spec.rb
+++ b/spec/views/shared/_home_page_bento.html.erb_spec.rb
@@ -17,7 +17,7 @@ describe 'shared/_home_page_bento.html.erb' do
 
     it 'links to Bento section' do
       render
-      expect(rendered).to have_css('h3', text: 'All of the above')
+      expect(rendered).to have_css('h3', text: 'Search all')
     end
   end
 
@@ -37,7 +37,7 @@ describe 'shared/_home_page_bento.html.erb' do
 
     it 'links to Bento section' do
       render
-      expect(rendered).to have_css('h3', text: 'All of the above')
+      expect(rendered).to have_css('h3', text: 'Search all')
     end
   end
 end


### PR DESCRIPTION
Part of #2518 

_Note: This PR does not add the LibGuides & Exhibits blocks, but adds some affordances to make them easier.  They will be added once we're ready in #2521_

## Before
<img width="1218" alt="home-page-before" src="https://user-images.githubusercontent.com/96776/89947246-ffd83600-dbd8-11ea-9ae1-6bcf1a0b9144.png">

## After
<img width="1208" alt="home-page-after" src="https://user-images.githubusercontent.com/96776/89947252-036bbd00-dbd9-11ea-8257-010656022aa0.png">

## Responsive

![sw-home-responsive](https://user-images.githubusercontent.com/96776/89947511-6a897180-dbd9-11ea-84c4-54734fa94e51.gif)

