### PR TITLE
Update search bar banner styling and layout

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -3,6 +3,15 @@
     font-weight: 400;
     border-bottom: none;
   }
+
+  // This is suboptimal, but we want this particular h2 to be styled
+  // exactly like an h1 (but not the others on this page)
+  .h1 {
+    color: $sul-h1-font-color;
+    font-weight: 300;
+    line-height: 1.2em;
+    padding: 10px 0;
+  }
 }
 
 .article-home-page {

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -61,9 +61,10 @@
     margin: 3px 0;
     padding: 0;
 
-    h1 {
+    &.h1 {
       color: $white;
       display: inline-block;
+      font-weight: 100;
       margin: 30px 0 0;
       padding: 0;
       text-indent: 0;
@@ -119,7 +120,7 @@
       margin-top: 5px;
       vertical-align: baseline;
 
-      h1 {
+      &.h1 {
         margin-top: 0;
       }
     }

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -17,23 +17,36 @@
   }
 
   .search-navbar-headings {
+    align-items: center;
+    display: flex;
+    height: 100%;
+
     .navbar-brand {
       height: 28px;
-      margin: 36px 10px 36px 0;
       padding: 0;
 
       img {
         height: 28px;
+        // Adding negative top margin to handle images + text alignment issues
+        margin-top: -1px;
       }
     }
 
     .search-dropdown {
       display: inline-block;
-      height: inherit;
+      margin-left: 1em;
+
+      .search-target {
+        margin: 0;
+      }
 
       .dropdown-menu {
         left: auto;
         top: 70%;
+
+        li {
+          max-width: inherit;
+        }
 
         li.active {
           background-color: $public-note-yellow;
@@ -58,15 +71,11 @@
   .search-target {
     border-bottom: $white dashed 2px;
     color: $white;
-    margin: 3px 0;
-    padding: 0;
 
     &.h1 {
       color: $white;
       display: inline-block;
       font-weight: 100;
-      margin: 30px 0 0;
-      padding: 0;
       text-indent: 0;
     }
   }
@@ -101,9 +110,16 @@
     }
 
     .search-navbar-headings {
+      height: 40px;
+      margin-left: auto;
+      margin-right: auto;
       margin-top: 5px;
       text-align: center;
-      width: 100%;
+
+      .navbar-brand img {
+        // Adding negative top margin to handle images + text alignment issues
+        margin-top: -2px;
+      }
 
       .search-dropdown {
         .dropdown-menu {

--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -1,7 +1,6 @@
 <% @page_title= t 'blacklight.home.title' %>
 
 <h1>Books, media, &amp; more</h1>
-<h1 class="sr-only">SearchWorks</h1>
 
 <%= render 'schema_dot_org_website_search' %>
 

--- a/app/views/catalog/_search_targets_widget.html.erb
+++ b/app/views/catalog/_search_targets_widget.html.erb
@@ -1,17 +1,14 @@
 <div class="search-dropdown">
-  <a href="#" class="dropdown-toggle navbar-text search-target" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <h1>
-      <span class="sr-only">search</span>
-      <% if article_search?  %>
-        <%= t('searchworks.search_dropdown.articles.label') %>
-      <% else %>
-        <%= t('searchworks.search_dropdown.catalog.label') %>
-      <% end %>
-
-      <span class="caret"></span>
-    </h1>
+  <a href="#" class="dropdown-toggle navbar-text search-target h1" data-toggle="dropdown" role="button" aria-expanded="false">
+    <span class="sr-only">Select search scope, currently:</span>
+    <% if article_search? %>
+      <%= t('searchworks.search_dropdown.articles.label') %>
+    <% else %>
+      <%= t('searchworks.search_dropdown.catalog.label') %>
+    <% end %>
+    <span class="caret"></span>
   </a>
-  <ul class="dropdown-menu" role="menu">
+  <ul class="dropdown-menu">
     <li>
       <%= link_to_bento_search %>
     </li>

--- a/app/views/catalog/_search_targets_widget.html.erb
+++ b/app/views/catalog/_search_targets_widget.html.erb
@@ -1,5 +1,5 @@
 <div class="search-dropdown">
-  <a href="#" class="dropdown-toggle navbar-text search-target h1" data-toggle="dropdown" role="button" aria-expanded="false">
+  <a href="#" class="navbar-text search-target h1" data-toggle="dropdown" role="button" aria-expanded="false">
     <span class="sr-only">Select search scope, currently:</span>
     <% if article_search? %>
       <%= t('searchworks.search_dropdown.articles.label') %>

--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -89,7 +89,6 @@
           <%= render_masthead_partial %>
 
           <%= render partial: 'shared/ajax_modal' %>
-          <%= render 'shared/print_header' %>
           <section id="main-container" role="main" data-analytics-id="<%= Settings.GOOGLE_ANALYTICS_ID %>">
             <% if Settings.GLOBAL_ALERT %>
               <div class="global-alert">

--- a/app/views/shared/_home_page_bento.html.erb
+++ b/app/views/shared/_home_page_bento.html.erb
@@ -1,5 +1,5 @@
 <div class="home-page-bento">
-  <h1>Search Stanford's library resources</h1>
+  <h2 class="h1">Search Stanford's library resources</h2>
   <div class="bento-sections">
     <div class="bento-block home-page-catalog <%= 'home-page-you-are-here' unless article_search? %>">
       <div class="panel panel-default">

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -1,4 +1,8 @@
 <div id="search-navbar-container">
+  <h2 class="sr-only">
+    <%= t("searchworks.headers.#{article_search? ? 'articles' : 'catalog'}.search_bar") %>
+  </h2>
+
   <nav id="search-navbar" class="navbar search-bar navbar-default" role="navigation">
     <div class="search-navbar-headings">
       <%= link_to (image_tag 'searchworks.svg', {:"data-svg-fallback" => "#{image_path('searchworks.png')}", :alt => 'SearchWorks'}), root_path, :class => 'navbar-brand', :id => 'searchworks-logo' %>

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -5,7 +5,7 @@
 
   <nav id="search-navbar" class="navbar search-bar navbar-default" role="navigation">
     <div class="search-navbar-headings">
-      <%= link_to (image_tag 'searchworks.svg', {:"data-svg-fallback" => "#{image_path('searchworks.png')}", :alt => 'SearchWorks'}), root_path, :class => 'navbar-brand', :id => 'searchworks-logo' %>
+      <%= link_to (image_tag 'searchworks.svg', {:"data-svg-fallback" => "#{image_path('searchworks.png')}", :alt => 'Home'}), article_search? ? articles_path : root_path, :class => 'navbar-brand', :id => 'searchworks-logo' %>
       <%= render_search_targets_widget %>
       </div>
     <div class="search-form">

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -7,7 +7,7 @@
     <div class="search-navbar-headings">
       <%= link_to (image_tag 'searchworks.svg', {:"data-svg-fallback" => "#{image_path('searchworks.png')}", :alt => 'Home'}), article_search? ? articles_path : root_path, :class => 'navbar-brand', :id => 'searchworks-logo' %>
       <%= render_search_targets_widget %>
-      </div>
+    </div>
     <div class="search-form">
       <%= render_search_bar %>
     </div>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -29,6 +29,11 @@ en:
     global_alert_html: >
       <b>AIR QUALITY ALERT</b><br/>
       All libraries are CLOSED today, August 19th, due to poor air quality. Online services are available.
+    headers:
+      articles:
+        search_bar: SearchWorks articles+
+      catalog:
+        search_bar: SearchWorks catalog
     home_page_notice:
       heading: 'New My Library Account!'
       body_html:

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -7,7 +7,7 @@ feature 'Article Searching' do
       visit root_path
 
       within '.search-dropdown' do
-        click_link 'search catalog'
+        click_link 'Select search scope, currently: catalog'
 
         expect(page).to have_css('.dropdown-menu', visible: true)
 
@@ -26,7 +26,7 @@ feature 'Article Searching' do
       visit articles_path
 
       within '.search-dropdown' do
-        click_link 'search articles'
+        click_link 'Select search scope, currently: articles+'
         expect(page).to have_css('.dropdown-menu', visible: true)
         expect(page).not_to have_css('li.active a', text: /articles/)
         expect(page).to have_css('li.active', text: /articles/)


### PR DESCRIPTION
Closes #2516 

Paired with @jvine and @camillevilla on this

## Mobile (before)
<img width="746" alt="mobile-before" src="https://user-images.githubusercontent.com/96776/90681846-ed817c00-e218-11ea-8491-3d5b2246ca92.png">

## Desktop (before)
<img width="1002" alt="desktop-before" src="https://user-images.githubusercontent.com/96776/90681848-eeb2a900-e218-11ea-9a57-74043e969647.png">

## Mobile (after)
<img width="745" alt="mobile-after" src="https://user-images.githubusercontent.com/96776/90681854-ef4b3f80-e218-11ea-91d5-7affb2b37c08.png">

## Desktop (after)
<img width="1208" alt="desktop-after" src="https://user-images.githubusercontent.com/96776/90681858-efe3d600-e218-11ea-81b5-9d6e37181ea5.png">

