### PR TITLE
Replace custom alert implementation with global_alerts gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,3 +111,4 @@ gem 'oauth2', '~> 1.4' # Pinning so we don't get downgraded
 gem 'rinku', require: 'rails_rinku'
 gem 'bootstrap-sass'
 gem 'rack-attack' # For throttle configuration
+gem 'global_alerts'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,8 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
     dotenv (2.7.6)
     dry-configurable (0.11.6)
@@ -237,12 +239,28 @@ GEM
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.13.1)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    global_alerts (0.0.4)
+      http
+      rails (>= 5.0, < 7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (3.6.0)
     honeybadger (4.7.2)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -573,6 +591,7 @@ DEPENDENCIES
   ebsco-eds (= 1.1.0)
   faraday (~> 0.10)
   font-awesome-rails
+  global_alerts
   honeybadger (~> 4.7, != 4.7.1)
   jbuilder (~> 2.5)
   jquery-datatables-rails

--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -90,11 +90,7 @@
 
           <%= render partial: 'shared/ajax_modal' %>
           <section id="main-container" role="main" data-analytics-id="<%= Settings.GOOGLE_ANALYTICS_ID %>">
-            <% if Settings.GLOBAL_ALERT %>
-              <div class="global-alert">
-                <%= t('searchworks.global_alert_html') %>
-              </div>
-            <% end %>
+            <%= render 'global_alerts/alerts' if Settings.GLOBAL_ALERT %>
             <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
             <%= yield %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -26,10 +26,6 @@ en:
       catalog:
         clear:
           action_confirm: Clear your catalog selections?
-    global_alert_html: >
-      <b>AIR QUALITY ALERT</b><br/>
-      All libraries are CLOSED due to poor air quality. Online services are available. <br/>
-      For updates visit <a href="https://library.stanford.edu/alerts">library.stanford.edu/alerts</a>.
     headers:
       articles:
         search_bar: SearchWorks articles+


### PR DESCRIPTION
Custom alerts can now be managed with https://github.com/sul-dlss/global_alerts/blob/main/sul.yaml file