### PR TITLE
Escape user's search terms before sending to the LibGuides API.

### DIFF
--- a/app/models/lib_guides_api.rb
+++ b/app/models/lib_guides_api.rb
@@ -53,7 +53,7 @@ class LibGuidesApi
         status: 1,
         sort_by: 'relevance'
       }.to_query,
-      "&search_terms=#{query}"
+      "&search_terms=#{CGI.escape(query)}"
     ].join
   end
 end

--- a/spec/models/lib_guides_api_spec.rb
+++ b/spec/models/lib_guides_api_spec.rb
@@ -3,7 +3,20 @@
 require 'spec_helper'
 
 RSpec.describe LibGuidesApi do
-  subject(:api) { described_class.new('Search Term') }
+  let(:term) { 'Search Term' }
+
+  subject(:api) { described_class.new(term) }
+
+  describe 'user search term encoding' do
+    let(:term) { 'Kōzanji' }
+
+    it 'encodes the users query' do
+      url = api.send(:url)
+
+      expect(url).not_to include(term)
+      expect(url).to include('Ko%CC%84zanji')
+    end
+  end
 
   context 'when the API responds successfully' do
     it 'returns data from the API response as json' do


### PR DESCRIPTION
Closes #2537
