### PR TITLE
Update library services menu and add COVID status link

### DIFF
--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -35,6 +35,13 @@
     padding-left: 20px;
   }
   .navbar-nav > li {
+    a.covid-status {
+      background-color: $poppy;
+      color: $black;
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+
     a {
       background-color: $sul-subnavbar-bg-color;
       border: 0;
@@ -58,7 +65,7 @@
   }
 
   // the last menu item should be right-aligned
-  .navbar-nav > li:last-child > a {
+  .navbar-nav.navbar-right > li:last-child > a {
     margin-right: 0;
     padding-right: 0;
   }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -115,4 +115,20 @@
       white-space: normal;
     }
   }
+
+  // Responsive fixes for COVID-19 status
+  @media screen and (max-width: $screen-md-min) {
+    .navbar-nav > li {
+      a {
+        font-size: 1.4em;
+      }
+    }
+
+    .dropdown-menu {
+      li a,
+      li span {
+        font-size: 1.4em;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -69,7 +69,12 @@
     border-radius: 0;
     left: inherit;
 
-    li a {
+    // Menu subheadings
+    li span.menugroup {
+      font-variant: all-small-caps;
+    }
+
+    li a, li span {
       font-size: 1.6rem;
       font-weight: 100;
       line-height: 35px;

--- a/app/views/shared/_search_navbar_services_menu.html.erb
+++ b/app/views/shared/_search_navbar_services_menu.html.erb
@@ -3,10 +3,16 @@
     <span class="menugroup">Need help?</span>
     <ul>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connecting to e-resources</a>
+        <a role="menuitem" href="https://library.stanford.edu/chat" class="stanford-only" title="limited to Stanford community">Chat with us  <span class="sr-only"> (limited to Stanford community)</span></a>
       </li>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">Interlibrary services</a>
+        <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Email a reference question</a>
+      </li>
+      <li>
+        <a role="menuitem" href="https://library.stanford.edu/people">Find a subject specialist</a>
+      </li>
+      <li>
+        <a role="menuitem" href="https://guides.library.stanford.edu/searchworks">Using SearchWorks</a>
       </li>
     </ul>
   </li>
@@ -14,43 +20,21 @@
     <span class="menugroup">Connection</span>
     <ul>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Ask a reference question</a>
+        <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connect to e-resources</a>
       </li>
       <li>
         <a role="menuitem" href="https://library.stanford.edu/ask/email/connection-problems">Report a connection problem</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/suggest_purchase">Suggest a purchase (requires login)</a>
-      </li>
-    </ul>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/about">About the Stanford Libraries</a>
-    <ul>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/people">Find a specialist</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library-hours.stanford.edu/">Library hours</a>
       </li>
     </ul>
   </li>
   <li>
     <span class="menugroup">If we don't have it</span>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/collections">Collections</a>
-  </li>
-  <li>
     <ul>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/guides/topic">Topic guides</a>
+        <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">Interlibrary borrowing</a>
       </li>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/guides/course">Course guides</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/search-tools">More search tools</a>
+        <a role="menuitem" href="https://library.stanford.edu/suggest_purchase" class="stanford-only" title="limited to Stanford community">Suggest a purchase <span class="sr-only"> (limited to Stanford community)</span></a>
       </li>
     </ul>
   </li>

--- a/app/views/shared/_search_navbar_services_menu.html.erb
+++ b/app/views/shared/_search_navbar_services_menu.html.erb
@@ -1,6 +1,6 @@
 <ul class="dropdown-menu sul-services-menu" role="menu" aria-labelledby="searchNavbarTopMenu">
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/using">Using the libraries</a>
+    <span class="menugroup">Need help?</span>
     <ul>
       <li>
         <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connecting to e-resources</a>
@@ -11,7 +11,7 @@
     </ul>
   </li>
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/ask">Ask us</a>
+    <span class="menugroup">Connection</span>
     <ul>
       <li>
         <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Ask a reference question</a>
@@ -36,13 +36,12 @@
     </ul>
   </li>
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/libraries">Libraries</a>
+    <span class="menugroup">If we don't have it</span>
   </li>
   <li>
     <a role="menuitem" href="https://library.stanford.edu/collections">Collections</a>
   </li>
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/research">Research support</a>
     <ul>
       <li>
         <a role="menuitem" href="https://library.stanford.edu/guides/topic">Topic guides</a>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -15,6 +15,11 @@
           </a>
           <%= render :partial => 'shared/search_navbar_services_menu' %>
         </li>
+        <li>
+          <a class="nav-link covid-status" href="https://library.stanford.edu/status">
+            COVID-19 Libraries update
+          </a>
+        </li>
       </ul>
       <% unless article_search? %>
         <ul class="nav navbar-nav navbar-right">

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -11,7 +11,7 @@
       <ul class="nav navbar-nav navbar-left">
         <li class="dropdown search-subnavbar-about">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-            Library services<span class="caret"/>
+            Help<span class="caret"/>
           </a>
           <%= render :partial => 'shared/search_navbar_services_menu' %>
         </li>

--- a/spec/features/article_searching_spec.rb
+++ b/spec/features/article_searching_spec.rb
@@ -39,7 +39,7 @@ feature 'Article Searching' do
       stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
       visit articles_path
 
-      expect(page).to have_css('a', text: /Library services/)
+      expect(page).to have_css('a', text: /Help/)
       expect(page).not_to have_css('a', text: /Advanced search/)
       expect(page).not_to have_css('a', text: /Course reserves/)
       expect(page).to have_css('a', text: /Selections \(\d+\)/)

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -9,7 +9,7 @@ describe "Search toolbar", js: true, feature: true do
         expect(page).to have_css("button.btn.btn-default.search-btn", text: "")
       end
       within "#search-subnavbar-container" do
-        expect(page).to have_css("li a", text: "Library services", visible: true)
+        expect(page).to have_css("li a", text: "Help", visible: true)
         expect(page).to have_css("li a", text: "Advanced search", visible: true)
         expect(page).to have_css("li a", text: "Course reserves", visible: true)
         expect(page).to have_css("li a", text: /SELECTIONS/i, visible: true)

--- a/spec/features/responsive/search_subnavbar_responsive_spec.rb
+++ b/spec/features/responsive/search_subnavbar_responsive_spec.rb
@@ -6,7 +6,7 @@ describe 'Responsive subnavbar (gray banner)', js: true, feature: true, responsi
   scenario 'collapses menu options in mobile view' do
     visit root_path
 
-    expect(page).to have_css('a', text: /Library services/, visible: false)
+    expect(page).to have_css('a', text: /Help/, visible: false)
     expect(page).to have_css('a', text: /Advanced search/, visible: false)
     expect(page).to have_css('a', text: /Course reserves/, visible: false)
     expect(page).to have_css('a', text: /Selections/, visible: false)


### PR DESCRIPTION
Closes #2552

## Before 
<img width="320" alt="old services menu" src="https://user-images.githubusercontent.com/5402927/94325502-924b5380-ff53-11ea-9a1e-4fc711a29c9b.png">

## After
<img width="367" alt="trimmed down services menu" src="https://user-images.githubusercontent.com/5402927/94325505-96777100-ff53-11ea-9b65-3a1affbfa745.png">


