### PR TITLE
Disable smarttext search mode

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,7 +57,7 @@ EDS_HOSTS:
 EDS_CITATION_LINK_PATTERN: '[.,]\s+(&lt;i&gt;EBSCOhost|viewed|Available|Retrieved from|(?:https?:\/\/)?stanford\.idm\.oclc\.org|Disponível em).+$'
 EDS_CITATION_LINK_REPLACE: '.'
 EDS_CITATION_DB_PATTERN: '\s+<i>EBSCOhost<\/i>\.?'
-EDS_SMARTTEXT_FAILOVER: true
+EDS_SMARTTEXT_FAILOVER: false
 SU_AFFILIATIONS: []
 STANFORD_NETWORK:
   singletons: []


### PR DESCRIPTION
Disabling for now until we can add some text to indicate to users
that they are now in this mode because of not receiving results

Related to #2561