### PR TITLE
Add a link/backend lookup on zero results page of articles to SmartText mode

### DIFF
--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -36,11 +36,3 @@ $btn-preview-border: darken($sul-btn-preview-bg, 9.8%);
 a.btn-sul-toolbar {
   border-bottom: none;
 }
-
-.btn-zero-results {
-  @include button-variant($sul-link-color, transparent, $cardinal-red);
-  border-radius: $sul-constraint-btn-radius;
-  &:hover,:focus {
-    text-decoration: underline;
-  };
-}

--- a/app/assets/stylesheets/modules/zero-results.scss
+++ b/app/assets/stylesheets/modules/zero-results.scss
@@ -13,3 +13,22 @@
     margin-bottom: 15px;
   }
 }
+
+.zero-results-link {
+  &:hover, &:focus { border-bottom: none;}
+
+  .btn-zero-results {
+    @include button-variant($sul-link-color, transparent, $cardinal-red);
+    border-radius: $sul-constraint-btn-radius;
+    white-space: normal;
+
+    &:hover,:focus {
+      text-decoration: underline;
+    };
+  }
+  strong {
+    &:hover,:focus {
+      text-decoration: underline;
+    };
+  }
+}

--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -34,8 +34,13 @@ module Eds
         results = eds_session.solr_retrieve_list(list: bl_params['q']['id'])
       else
         # Regular search
+        if (bl_params || {})['smarttext']
+          eds_session = eds_session.update_session_options(smarttext_failover: true)
+        end
+
         results = eds_results_with_date_range(eds_session.search(bl_params).to_solr)
       end
+
       blacklight_config.response_model.new(results,
                                            bl_params,
                                            document_model: blacklight_config.document_model,

--- a/app/models/eds/session.rb
+++ b/app/models/eds/session.rb
@@ -13,6 +13,12 @@ module Eds
       @object ||= EBSCO::EDS::Session.new(session_options)
     end
 
+    def update_session_options(update_options)
+      @object = EBSCO::EDS::Session.new(session_options.merge(update_options))
+
+      self
+    end
+
     private
 
     attr_reader :eds_params
@@ -36,8 +42,7 @@ module Eds
         recover_from_bad_source_type: true,
         citation_link_find:           Settings.EDS_CITATION_LINK_PATTERN,
         citation_link_replace:        Settings.EDS_CITATION_LINK_REPLACE,
-        citation_db_find:             Settings.EDS_CITATION_DB_PATTERN,
-        smarttext_failover:           Settings.EDS_SMARTTEXT_FAILOVER
+        citation_db_find:             Settings.EDS_CITATION_DB_PATTERN
       }
     end
   end

--- a/app/views/articles/_index.html.erb
+++ b/app/views/articles/_index.html.erb
@@ -2,6 +2,16 @@
 <div class="breadcrumb row">
   <div class="col-md-12">
     <%= render 'constraints' %>
+
+    <% if params['smarttext'] %>
+      <div class="row">
+        <div class="col-md-offset-4 col-md-8 col-sm-offset-5 col-sm-7">
+          <div class="alert alert-info">
+            <strong>Note:</strong> you are using SmartText searching mode. [<%= link_to('remove', url_for(params.merge(smarttext: nil))) %>]
+          </div>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>
 <div class='row'>

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -28,6 +28,15 @@
             <% end %>
           </li>
         <% end %>
+
+        <% if article_search? && !params['smarttext'] %>
+          <li>
+            <%= t 'blacklight.search.zero_results.smarttext' %>
+            <%= link_to searchworks_search_action_path(params.merge(smarttext: true)), data: {behavior: "backend-lookup", track: 'zero-results-search-all-fields', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(params.merge(smarttext: true)))}"} do %>
+              <%= content_tag :span, "#{params[:q]}", class: 'btn btn-zero-results', role: 'button' %>
+            <% end %>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -15,7 +15,7 @@
         <% if @search_modifier.has_filters? && @search_modifier.has_query? %>
           <li>
             <%= t 'blacklight.search.zero_results.limit_fields' %>
-            <%= link_to searchworks_search_action_path(@search_modifier.params_without_filters), data: {behavior: "backend-lookup", track: 'zero-results-remove-limit', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_filters))}"} do %>
+            <%= link_to searchworks_search_action_path(@search_modifier.params_without_filters), class: 'zero-results-link', data: {behavior: "backend-lookup", track: 'zero-results-remove-limit', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_filters))}"} do %>
               <%= content_tag :span, "#{search_field_label(params)} > #{params[:q]}", class: 'btn btn-zero-results', role: 'button' %>
             <% end %>
           </li>
@@ -23,7 +23,7 @@
         <% if @search_modifier.fielded_search? %>
           <li>
             <%= t 'blacklight.search.zero_results.search_fields' %>
-            <%= link_to searchworks_search_action_path(@search_modifier.params_without_fielded_search_and_filters), data: {behavior: "backend-lookup", track: 'zero-results-search-all-fields', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_fielded_search_and_filters))}"} do %>
+            <%= link_to searchworks_search_action_path(@search_modifier.params_without_fielded_search_and_filters), class: 'zero-results-link', data: {behavior: "backend-lookup", track: 'zero-results-search-all-fields', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(@search_modifier.params_without_fielded_search_and_filters))}"} do %>
               <%= content_tag :span, "#{params[:q]}", class: 'btn btn-zero-results', role: 'button' %>
             <% end %>
           </li>
@@ -32,7 +32,7 @@
         <% if article_search? && !params['smarttext'] %>
           <li>
             <%= t 'blacklight.search.zero_results.smarttext' %>
-            <%= link_to searchworks_search_action_path(params.merge(smarttext: true)), data: {behavior: "backend-lookup", track: 'zero-results-search-all-fields', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(params.merge(smarttext: true)))}"} do %>
+            <%= link_to searchworks_search_action_path(params.merge(smarttext: true)), class: 'zero-results-link', data: {behavior: "backend-lookup", track: 'zero-results-search-all-fields', lookup: "#{url_for({controller: controller_name, action: 'backend_lookup'}.merge(params.merge(smarttext: true)))}"} do %>
               <%= content_tag :span, "#{params[:q]}", class: 'btn btn-zero-results', role: 'button' %>
             <% end %>
           </li>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -126,6 +126,7 @@ en:
         return_to_advanced_search: "Return to Advanced search page"
         search_context: "Try your search in…"
         check_spelling: 'Check spelling, or use fewer words to start.'
+        smarttext: 'Try SmartText searching mode:'
 
     bookmarks:
       page_heading: "Selections list"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,7 +57,6 @@ EDS_HOSTS:
 EDS_CITATION_LINK_PATTERN: '[.,]\s+(&lt;i&gt;EBSCOhost|viewed|Available|Retrieved from|(?:https?:\/\/)?stanford\.idm\.oclc\.org|Disponível em).+$'
 EDS_CITATION_LINK_REPLACE: '.'
 EDS_CITATION_DB_PATTERN: '\s+<i>EBSCOhost<\/i>\.?'
-EDS_SMARTTEXT_FAILOVER: false
 SU_AFFILIATIONS: []
 STANFORD_NETWORK:
   singletons: []


### PR DESCRIPTION
Connected to #2561

## TODO
- [ ] Come up with better texty-text (as to meet the "Do not call it SmartText" mandate)
- [ ] Move logic into SearchQueryModifier for consistency

## Zero Results Page
<img width="805" alt="Screen Shot 2020-11-03 at 1 56 01 PM" src="https://user-images.githubusercontent.com/96776/98045122-d34d4800-1ddc-11eb-8f76-15e05d122d42.png">

## Search Results in SmartText Mode
<img width="1215" alt="Screen Shot 2020-11-03 at 1 56 23 PM" src="https://user-images.githubusercontent.com/96776/98045126-d5afa200-1ddc-11eb-872c-a5120c2a91c2.png">
