### PR TITLE
Ensure that there are fulltext links present before returning them in…

### DIFF
--- a/lib/access_panels/online.rb
+++ b/lib/access_panels/online.rb
@@ -13,7 +13,7 @@ class AccessPanels
     end
 
     def marc_fulltext_links
-      @document.marc_links.fulltext if @document.marc_links.present?
+      @document.marc_links.fulltext if @document&.marc_links&.fulltext&.present?
     end
 
     def eds_links


### PR DESCRIPTION
… the Online class

This is short-circuiting under certain contexts and returning no links where we might have a hathi link

## Before (3508831)
<img width="370" alt="3508831-before" src="https://user-images.githubusercontent.com/96776/104511240-46bfc280-55a1-11eb-9bca-c8713d7279e8.png">

## After (3508831)
<img width="382" alt="3508831-after" src="https://user-images.githubusercontent.com/96776/104511247-47f0ef80-55a1-11eb-98cd-d36da6182979.png">
