### PR TITLE
Re-add the restriction for emails to not include links  …

### DIFF
--- a/app/controllers/concerns/email_validation.rb
+++ b/app/controllers/concerns/email_validation.rb
@@ -5,6 +5,8 @@ module EmailValidation
     case
     when !%w(full brief).include?(params[:type])
       flash[:error] = I18n.t('blacklight.email.errors.type')
+    when anonymous_user_sent_link?
+      flash[:error] = I18n.t('blacklight.email.errors.message.spam')
     when params[:to].blank?
       flash[:error] = I18n.t('blacklight.email.errors.to.blank')
     when too_many_email_addresses?
@@ -14,6 +16,12 @@ module EmailValidation
     end
 
     flash[:error].blank?
+  end
+
+  def anonymous_user_sent_link?
+    return false if current_user.present?
+
+    params[:message] =~ %r{href|url=|https?://}i
   end
 
   def valid_email_addresses?

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -40,12 +40,26 @@ class FeedbackFormsController < ApplicationController
   def validate
     errors = []
 
-    errors << 'You must pass the reCAPTCHA challenge' if current_user.blank? && !verify_recaptcha
+    if current_user.blank?
+      errors << 'You must pass the reCAPTCHA challenge' unless verify_recaptcha
+
+      if params[:message] =~ url_regex
+        errors << "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
+      end
+
+      if params[:user_agent] =~ url_regex || params[:viewport] =~ url_regex
+         errors << "Your message appears to be spam, and has not been sent."
+      end
+    end
 
     if params[:message].nil? or params[:message] == ""
       errors << "A message is required"
     end
     flash[:error] = errors.join("<br/>") unless errors.empty?
     flash[:error].nil?
+  end
+
+  def url_regex
+    /.*href=.*|.*url=.*|.*http:\/\/.*|.*https:\/\/.*/i
   end
 end

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -108,6 +108,8 @@ en:
           placeholder: '(optional)'
       errors:
         type: 'Invalid email type provided'
+        message:
+          spam: 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
         to:
           invalid: 'You must enter only valid email addresses.'
           too_many: 'You have entered more than the maximum (%{max}) email addresses allowed.'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -58,8 +58,10 @@ describe CatalogController do
     end
 
     context 'when the user is logged in' do
+      let(:user) { User.new(email: 'user@stanford.edu') }
+
       before do
-        allow(controller).to receive(:current_user).and_return(User.new(email: 'user@stanford.edu'))
+        allow(controller).to receive(:current_user).and_return(user)
       end
 
       it 'should set the provided subject' do
@@ -87,6 +89,27 @@ describe CatalogController do
         end.to change { ActionMailer::Base.deliveries.count }.by(3)
       end
       describe 'validations' do
+        context 'with a logged in user' do
+          it 'should allow messages that have links in them' do
+            expect do
+              post :email, params: { to: 'email@example.com', message: 'https://library.stanford.edu', type: 'full', id: '1' }
+            end.to change { ActionMailer::Base.deliveries.count }.by(1)
+            expect(flash[:error]).to be_nil
+          end
+        end
+
+        context 'with an anonymous user' do
+          let(:user) { nil }
+
+          it 'should not allow messages that have links in them' do
+            expect do
+              post :email, params: { to: 'email@example.com', message: 'https://library.stanford.edu', type: 'full', id: '1' }
+            end.not_to change { ActionMailer::Base.deliveries.count }
+            expect(flash[:error]).to include('Your message appears to be spam, and has not been sent.')
+            expect(flash[:error]).to include('Please try sending your message again without any links in the comments.')
+          end
+        end
+
         it 'should prevent incorrect email types from being sent' do
           expect do
             post :email, params: { to: 'email@example.com', type: 'not-a-type' }

--- a/spec/controllers/feedback_forms_controller_spec.rb
+++ b/spec/controllers/feedback_forms_controller_spec.rb
@@ -27,6 +27,27 @@ describe FeedbackFormsController do
         end.not_to change(ActionMailer::Base.deliveries, :count)
       end
     end
+
+    it "should block potential spam with a href in the message" do
+      post :create, params: { message: "I like to spam by sending you a <a href='http://www.somespam.com'>Link</a>.  lolzzzz", url: "http://test.host/", email_address: "" }
+      expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
+    end
+    it "should block potential spam with a url= in the message" do
+      post :create, params: { message: "I like to spam by sending you a <a url='http://www.somespam.com'>Link</a>.  lolzzzz", url: "http://test.host/", email_address: "" }
+      expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
+    end
+    it "should block potential spam with a http:// in the message" do
+      post :create, params: { message: "I like to spam by sending you a http://www.somespam.com.  lolzzzz", url: "http://test.host/", email_address: "" }
+      expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments."
+    end
+    it 'should block potential spam with a http:// in the user_agent field' do
+      post :create, params: { user_agent: "http://www.google.com", message: "Legit message", url: "http://test.host" }
+      expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent."
+    end
+    it 'should block potential spam with a http:// in the viewport field' do
+      post :create, params: { viewport: "http://www.google.com", message: "Legit message", url: "http://test.host" }
+      expect(flash[:error]).to eq "Your message appears to be spam, and has not been sent."
+    end
   end
 
   context 'when a current user is present' do
@@ -47,6 +68,11 @@ describe FeedbackFormsController do
       it "should return an error if no message is sent" do
         post :create, params: { url: "http://test.host/", message: "", email_address: "" }
         expect(flash[:error]).to eq "A message is required"
+      end
+
+      it 'allows URLs to be sent through the message' do
+        post :create, params: { message: 'This is totally not spam because you know me https://spam.com', url: "http://test.host/", email_address: "" }
+        expect(flash[:error]).to be_nil
       end
     end
   end


### PR DESCRIPTION
…(but only for non-logged in users)

If we do go this route, we will likely want to update some relevant help text/flash messages.

##  Feedback Form/Help Text
<img width="691" alt="feedback form" src="https://user-images.githubusercontent.com/96776/108297083-93259180-714f-11eb-845e-6a8c43bfbcc3.png">

## Feedback Flash Message
<img width="866" alt="feedback flash message" src="https://user-images.githubusercontent.com/96776/108297081-90c33780-714f-11eb-9721-d400d2417f9d.png">

## Record Email Form/Help Text
<img width="594" alt="record email form" src="https://user-images.githubusercontent.com/96776/108299346-1dbbc000-7153-11eb-94fc-3e8eb8dd7b60.png">

## Record Email Flash Message
<img width="591" alt="record email feedback" src="https://user-images.githubusercontent.com/96776/108299367-27ddbe80-7153-11eb-9f6d-1ae18aad00d5.png">

---

# Possible Alternative 
The main reason why we are re-implementing this is reCaptcha has been [solved](https://prowebscraper.com/blog/top-10-captcha-solving-services-compared/) and we're seeing an increasing amount of spam coming through. I looked at updating to V3 (although that also appears to have been solved), but it would present some additional design changes.  This captcha is no-friction (e.g. no action required by the user) and instead monitors behavior to "score" how likely the user is human vs. a bot.  This could allow us to block the emails outright, present a traditional captcha, etc. however; might not actually do us any good if the bots are solving the captcha in other ways.

If we did look into captcha V3, the design changes we'll need to account for is there is a requirement to have the reCaptcha brand, privacy policy link, and ToS link as part of the user flow ([source](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed)).  They add a little icon on all pages, but we could avoid that by adding something like what is described in the above link on the feedback / email forms themselves.

## On all pages
<img width="88" alt="default captcha badge example" src="https://user-images.githubusercontent.com/96776/108299899-2a8ce380-7154-11eb-9e5a-cf0b20e8edf4.png">

**vs**

## Only in the forms/user flow
![text captcha badge example](https://user-images.githubusercontent.com/96776/108299872-1ea12180-7154-11eb-9570-b4e396e470a7.png)
