### PR TITLE
Extend SolrDocument to support loading in json-serialized marc data

### DIFF
--- a/app/models/concerns/marc_json_extension.rb
+++ b/app/models/concerns/marc_json_extension.rb
@@ -1,0 +1,11 @@
+module MarcJsonExtension
+  # Override blacklight-marc if we have marcjson available
+  def _marc_source_field
+    :marcjson_ss
+  end
+
+  # Override blacklight-marc if we have marcjson available
+  def _marc_format_type
+    :json
+  end
+end

--- a/app/models/concerns/marc_json_extension.rb
+++ b/app/models/concerns/marc_json_extension.rb
@@ -8,4 +8,16 @@ module MarcJsonExtension
   def _marc_format_type
     :json
   end
+
+  def as_json
+    super.merge(marcxml: solrmarc_style_marcxml)
+  end
+
+  def solrmarc_style_marcxml
+    <<-EOXML
+      <?xml version="1.0" encoding="UTF-8"?><collection xmlns="http://www.loc.gov/MARC21/slim">
+        #{export_as_marcxml}
+      </collection>
+    EOXML
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -47,11 +47,16 @@ class SolrDocument
     (super || '').to_s.gsub('/', '%2F')
   end
 
-      # The following shows how to setup this blacklight document to display marc documents
+  # The following shows how to setup this blacklight document to display marc documents
   extension_parameters[:marc_source_field] = :marcxml
   extension_parameters[:marc_format_type] = :marcxml
+
   use_extension(Blacklight::Solr::Document::Marc) do |document|
-    document.key?(:marcxml)
+    document.key?(:marcxml) || document.key?(:marcjson_ss)
+  end
+
+  use_extension(MarcJsonExtension) do |document|
+    document.key?(:marcjson_ss)
   end
 
   use_extension(EdsExport) do |document|

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -4,10 +4,16 @@ describe SolrDocument do
   include MarcMetadataFixtures
   describe "marc field" do
     let(:marcxml) { SolrDocument.new(marcxml: metadata1) }
+    let(:marcjson) { SolrDocument.new(marcjson_ss: marcxml.to_marc.to_hash.to_json) }
 
-    it "should respond to #to_marc for for marcxml" do
+    it "should respond to #to_marc for marcxml" do
       expect(marcxml).to respond_to(:to_marc)
       expect(marcxml.to_marc).to be_a MARC::Record
+    end
+
+    it "should respond to #to_marc for marcjson" do
+      expect(marcjson).to respond_to(:to_marc)
+      expect(marcjson.to_marc).to be_a MARC::Record
     end
   end
 


### PR DESCRIPTION
I'm considering serializing the MARC record as json to (🤞 ) cut down on size and improve indexing/parsing performance too.