### PR TITLE
Switch the h2 to inline to fix some weird safari (-only?) alignment i…

### DIFF
--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -118,6 +118,7 @@
 
 .search_num_of_results {
   text-align: left;
+  margin-top: $font-size-h2 / 2;
 
   .results-heading a {
     border-bottom: 0;
@@ -125,8 +126,9 @@
 
   h2 {
     border-bottom: 0;
-    display: inline-block;
+    display: inline;
     margin-bottom: 0;
+    width: auto;
   }
 
   .rss-icon {


### PR DESCRIPTION
After:
![Screen Shot 2021-03-02 at 15 42 10](https://user-images.githubusercontent.com/111218/109730155-e21af000-7b6d-11eb-8cc6-c7f1112f12ea.png)

Before:
![Screen Shot 2021-03-02 at 15 42 31](https://user-images.githubusercontent.com/111218/109730166-e941fe00-7b6d-11eb-84bb-13f587131d18.png)

…ssue so the results count does not wrap

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
