### PR TITLE
Relabel 'images' to 'parts' in collection film strip

### DIFF
--- a/app/views/collection_members/_image_collection_filmstrip.html.erb
+++ b/app/views/collection_members/_image_collection_filmstrip.html.erb
@@ -20,7 +20,7 @@
             <img src="" class="thumb-<%= document[:id] %>" data-url="<%= document.image_urls(:thumbnail).first %>" data-alt="<%= get_main_title(document) %>">
             </a>
             <% if document.image_urls.length > 1 %>
-            <div class="img-label"><%= pluralize(document.image_urls.length,"image") %></div>
+            <div class="img-label"><%= pluralize(document.image_urls.length,"part") %></div>
             <% end %>
             </li>
             <% end %>


### PR DESCRIPTION
Part of #2581
Fixes #2624 

![Screen Shot 2021-04-20 at 5 59 41 PM](https://user-images.githubusercontent.com/5402927/115481801-3b181380-a202-11eb-9190-6ff96198ee0a.png)

