### PR TITLE
Change behavior governing what spec-coll items are requestable

### DIFF
--- a/app/models/request_link.rb
+++ b/app/models/request_link.rb
@@ -159,7 +159,7 @@ class RequestLink
 
   def disabled_current_locations_map
     {
-      'SPEC-COLL' => %w[SPEC-INPRO],
+      'SPEC-COLL' => %w[INPROCESS MISSING ON-ORDER SPEC-INPRO],
       'default' => %w[]
     }
   end
@@ -413,7 +413,6 @@ class RequestLink
         GOLDSTAR
         GUNST
         GUNST-30
-        INPROCESS
         LOCKED-MAP
         LOCKED-STK
         MANNING
@@ -426,7 +425,6 @@ class RequestLink
         MSS-30
         MSSX-30
         NEWTON
-        ON-ORDER
         RARE-BOOKS
         RARE-STOR
         RBC-30

--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -18,7 +18,7 @@
     <field name="vern_all_search" type="text" indexed="true" stored="true" />
 
     <!-- Format Field: facet and display
-      (deprecated in favor of format_main_ssim, left for continuity in UI URLs for old formats) -->
+         (deprecated in favor of format_main_ssim, left for continuity in UI URLs for old formats) -->
     <field name="format" type="string" indexed="true" stored="true" multiValued="true" />
 
     <!-- Language Field: facet and display -->
@@ -250,12 +250,12 @@
     <field name="set_with_title" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!-- *************** dynamic field types  ****************** -->
-<!--
-    <dynamicField name="*_unstem_search" type="textNoStem" stored="true" indexed="true" multiValued="true" />
-    <dynamicField name="*_search" type="text" stored="true" indexed="true" multiValued="true" />
-    <dynamicField name="*_facet" type="string" stored="true" indexed="true" multiValued="true" />
-    <dynamicField name="*_display" type="string" stored="true" indexed="false" multiValued="true"/>
--->
+    <!--
+         <dynamicField name="*_unstem_search" type="textNoStem" stored="true" indexed="true" multiValued="true" />
+         <dynamicField name="*_search" type="text" stored="true" indexed="true" multiValued="true" />
+         <dynamicField name="*_facet" type="string" stored="true" indexed="true" multiValued="true" />
+         <dynamicField name="*_display" type="string" stored="true" indexed="false" multiValued="true"/>
+    -->
     <dynamicField name="*_si" type="string" stored="true" indexed="true" omitNorms="true" />
     <dynamicField name="*_sim" type="string" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ss" type="string" stored="true" indexed="false" omitNorms="true" />
@@ -270,6 +270,7 @@
     <dynamicField name="ja_*" type="text_ja" indexed="true" stored="true" multiValued="true" />
     <dynamicField name="*_hsim" type="string_hierarch" stored="true" indexed="true" multiValued="true" />
     <dynamicField name="*_struct" type="string" stored="true" indexed="false" multiValued="true" omitNorms="true" />
+    <dynamicField name="*_dtsi" type="date" stored="true" indexed="false" omitNorms="true" />
   </fields>
 
   <!-- copy fields -->


### PR DESCRIPTION
Fixes #2643

This commit re-adds INPROCESS and ON-ORDER as current locations for spec-coll items that are not requestable. It also adds MISSING as a current location for spec-coll items that are not requestable. This has the effect of disabling the Request button for these items.
