### PR TITLE
Bring feedback form closer to compliance w/ current expected look & feel

### DIFF
--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -15,6 +15,24 @@ $panel-footer-bg: $sul-panel-bg;
 $panel-default-heading-bg: $sul-panel-heading-default;
 $panel-default-border: $sul-panel-border-bottom;
 
+// NOTE: Remove this when upgrading to BS5, as it will then be unnecessary.
+// State -- we lifted these colors from BS5 for better a11y in alerts and elsewhere
+$state-info-bg: #cff4fc;
+$state-info-border: #b6effb;
+$state-info-text: #055160;
+
+$state-success-bg: #d1e7dd;
+$state-success-border: #badbcc;
+$state-success-text: #0f5132;
+
+$state-warning-bg: #fff3cd;
+$state-warning-border: #ffecb5;
+$state-warning-text: #664d03;
+
+$state-danger-bg: #f8d7da;
+$state-danger-border: #f5c2c7;
+$state-danger-text: #842029;
+
 // Buttons
 $btn-default-color: $gray;
 $btn-default-bg: $light-sandstone;

--- a/app/assets/stylesheets/modules/feedback-form.scss
+++ b/app/assets/stylesheets/modules/feedback-form.scss
@@ -1,9 +1,10 @@
-.librarian-chat{
+.librarian-chat {
   padding-bottom: 25px;
-}
 
-.check-status {
-  padding-bottom: 25px;
+  .btn {
+    margin-top: -3px;
+    padding-left: 0;
+  }
 }
 
 .quick-report{

--- a/app/assets/stylesheets/modules/feedback-form.scss
+++ b/app/assets/stylesheets/modules/feedback-form.scss
@@ -1,5 +1,5 @@
 .librarian-chat {
-  padding-bottom: 25px;
+  padding-bottom: 12px;
 
   .btn {
     margin-top: -3px;

--- a/app/helpers/feedback_form_helper.rb
+++ b/app/helpers/feedback_form_helper.rb
@@ -1,11 +1,8 @@
 module FeedbackFormHelper
   def render_feedback_form(form_type)
-    case form_type
-    when 'connection'
-      render 'shared/feedback_forms/connection_form'
-    else
-      render 'shared/feedback_forms/form'
-    end
+    render 'shared/feedback_forms/form', locals: {
+      target: form_type == 'connection' ? '#connection-form' : '#feedback-form'
+    }
   end
 
   def show_feedback_form?

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -45,6 +45,6 @@
   </div>
 </div>
 <div id="connection-form" class="feedback-form-container collapse">
-  <%= render "shared/feedback_forms/connection_form" if show_feedback_form? %>
+  <%= render_feedback_form('connection') if show_feedback_form? %>
   <hr>
 </div>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -18,5 +18,5 @@
   </header>
 </div>
 <div id="feedback-form" class="feedback-form-container collapse">
-  <%= render "shared/feedback_forms/form" if show_feedback_form? %>
+  <%= render_feedback_form('feedback') if show_feedback_form? %>
 </div>

--- a/app/views/shared/feedback_forms/_chat_with_librarian.html.erb
+++ b/app/views/shared/feedback_forms/_chat_with_librarian.html.erb
@@ -1,5 +1,5 @@
-<div class="librarian-chat">
-  <div data-library-h3lp data-jid="ic@chat.libraryh3lp.com">
+<div class="librarian-chat col-sm-3">
+  <div data-library-h3lp data-jid="ic@chat.libraryh3lp.com" class="btn btn-link"">
     <%= link_to "Chat with a librarian", "https://library.stanford.edu/ask" %>
     <span class="image-icon image-icon-message-away"></span>
   </div>

--- a/app/views/shared/feedback_forms/_connection_form.html.erb
+++ b/app/views/shared/feedback_forms/_connection_form.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="col-sm-6 col-sm-offset-2">
-    <%= render "shared/feedback_forms/form_fields", locals: { target: '#connection-form'} %>
+  <div class="col-sm-10 col-sm-offset-1">
+    <%= render "shared/feedback_forms/form_fields", locals: { target: '#connection-form' } %>
   </div>
 </div>

--- a/app/views/shared/feedback_forms/_connection_form.html.erb
+++ b/app/views/shared/feedback_forms/_connection_form.html.erb
@@ -1,5 +1,0 @@
-<div class="container">
-  <div class="col-sm-10 col-sm-offset-1">
-    <%= render "shared/feedback_forms/form_fields", locals: { target: '#connection-form' } %>
-  </div>
-</div>

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -1,12 +1,5 @@
 <div class="container">
-  <div class="col-sm-6 col-sm-offset-2">
+  <div class="col-sm-10 col-sm-offset-1">
     <%= render "shared/feedback_forms/form_fields", locals: { target: '#feedback-form'} %>
-  </div>
-  <div class="col-sm-4">
-    <%= render "shared/feedback_forms/chat_with_librarian" if on_campus_or_su_affiliated_user? %>
-    <div class="check-status">
-      <%= link_to 'Check system status', 'http://library-status.stanford.edu' %>
-    </div>
-    <%= render "shared/quick_reports/form", layout: nil %>
   </div>
 </div>

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -1,5 +1,16 @@
 <div class="container">
   <div class="col-sm-10 col-sm-offset-1">
-    <%= render "shared/feedback_forms/form_fields", locals: { target: '#feedback-form'} %>
+    <%= render "shared/feedback_forms/reporting_from" %>
+
+    <% if locals[:target] == '#feedback-form' %>
+      <div>
+        <div class="col-sm-12 col-sm-offset-3">
+          <%= render "shared/feedback_forms/chat_with_librarian" if on_campus_or_su_affiliated_user? %>
+          <%= render "shared/quick_reports/form", layout: nil %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= render "shared/feedback_forms/form_fields", locals: locals %>
   </div>
 </div>

--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -1,15 +1,19 @@
-<%= form_tag feedback_form_path, method: :post, class:"form-horizontal feedback-form", role:"form" do %>
+<%= render "shared/feedback_forms/reporting_from" %>
+<% if locals[:target] == '#feedback-form' %>
   <div>
-    <div class="col-sm-offset-3">
-      <%= render "shared/feedback_forms/reporting_from" %>
+    <div class="col-sm-12 col-sm-offset-3">
+      <%= render "shared/feedback_forms/chat_with_librarian" if on_campus_or_su_affiliated_user? %>
+      <%= render "shared/quick_reports/form", layout: nil %>
     </div>
   </div>
+<% end %>
+<%= form_tag feedback_form_path, method: :post, class: "form-horizontal feedback-form", role: "form" do %>
   <span style="display:none;visibility:hidden;">
     <%= text_field_tag :user_agent %>
     <%= text_field_tag :viewport %>
     <%= text_field_tag :last_search %>
   </span>
-  <div>
+  <div class="col-sm-8 col-sm-offset-1">
     <% if locals[:target] == '#connection-form' %>
       <%= hidden_field_tag :type, 'connection' %>
       <div class="form-group">
@@ -64,7 +68,7 @@
     <div class="form-group">
       <div class="col-sm-offset-3 col-sm-9">
         <button type="submit" class="btn btn-primary">Send</button>
-        <%= link_to "Cancel", :back, class:"cancel-link", data: {toggle:"collapse", target: locals[:target] } %>
+        <%= link_to "Cancel", :back, class:"cancel-link", data: { toggle: 'collapse', target: locals[:target] } %>
       </div>
     </div>
   </div>

--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -1,13 +1,5 @@
-<%= render "shared/feedback_forms/reporting_from" %>
-<% if locals[:target] == '#feedback-form' %>
-  <div>
-    <div class="col-sm-12 col-sm-offset-3">
-      <%= render "shared/feedback_forms/chat_with_librarian" if on_campus_or_su_affiliated_user? %>
-      <%= render "shared/quick_reports/form", layout: nil %>
-    </div>
-  </div>
-<% end %>
 <%= form_tag feedback_form_path, method: :post, class: "form-horizontal feedback-form", role: "form" do %>
+  <%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
   <span style="display:none;visibility:hidden;">
     <%= text_field_tag :user_agent %>
     <%= text_field_tag :viewport %>

--- a/app/views/shared/feedback_forms/_reporting_from.html.erb
+++ b/app/views/shared/feedback_forms/_reporting_from.html.erb
@@ -1,2 +1,11 @@
-Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
-<%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
+<div class="alert alert-info" role="alert">
+  <div class="row">
+    <div class="col-sm-10">
+      Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
+      <%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
+    </div>
+    <div class="col-sm-2">
+      <%= link_to 'Check system status', 'http://library-status.stanford.edu' %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/feedback_forms/_reporting_from.html.erb
+++ b/app/views/shared/feedback_forms/_reporting_from.html.erb
@@ -2,7 +2,6 @@
   <div class="row">
     <div class="col-sm-10">
       Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
-      <%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
     </div>
     <div class="col-sm-2">
       <%= link_to 'Check system status', 'http://library-status.stanford.edu' %>

--- a/app/views/shared/quick_reports/_form.html.erb
+++ b/app/views/shared/quick_reports/_form.html.erb
@@ -1,6 +1,8 @@
 <% if show_quick_report? %>
-  <%= form_tag quick_reports_path, method: :post, class:'form-horizontal feedback-form', role:'form' do %>
-    <%= hidden_field_tag(:url, request.referer, class: 'reporting-from-field') %>
-    <button type='submit' class='btn btn-default btn-quick-report'>Report wrong cover image</button>
-  <% end %>
+  <div class="col-sm-3">
+    <%= form_tag quick_reports_path, method: :post, class: 'form-horizontal feedback-form', role: 'form' do %>
+      <%= hidden_field_tag(:url, request.referer, class: 'reporting-from-field') %>
+      <button type='submit' class='btn btn-default btn-quick-report'>Report wrong cover image</button>
+    <% end %>
+  </div>
 <% end %>

--- a/spec/features/quick_report_spec.rb
+++ b/spec/features/quick_report_spec.rb
@@ -13,7 +13,7 @@ feature 'Quick report form (js)', js: true do
     click_link 'Feedback'
     expect(page).to have_css('button.btn-quick-report')
     click_button 'Report wrong cover image'
-    expect(page).to have_css('div.alert-success', text: 'Thank you! Your feedback has been sent.')
+    expect(page).to have_css('div.alert-info', text: 'Thank you! Your feedback has been sent.')
   end
 end
 

--- a/spec/features/quick_report_spec.rb
+++ b/spec/features/quick_report_spec.rb
@@ -6,14 +6,13 @@ feature 'Quick report form (js)', js: true do
   end
 
   scenario 'Quick report should only be available on show page' do
-    skip('Passes locally, not on Travis.') if ENV['CI']
     click_link 'Feedback'
     expect(page).not_to have_css('button.btn-quick-report')
     visit solr_document_path('1')
     click_link 'Feedback'
     expect(page).to have_css('button.btn-quick-report')
     click_button 'Report wrong cover image'
-    expect(page).to have_css('div.alert-info', text: 'Thank you! Your feedback has been sent.')
+    expect(page).to have_css('div.alert-success', text: 'Thank you! Your feedback has been sent.')
   end
 end
 


### PR DESCRIPTION
Fixes #2497

This PR makes visual changes to the feedback form and the connection form in
SearchWorks. Also includes:

* Fix test
* Increase contrast of info/success/warning/danger states (including alerts)
  * This brings Bootstrap 5 colors, which provide better accessibility, into Bootstrap 3
* Remove an unused CSS class

# Screenshot

![Screenshot from 2021-05-11 11-48-58](https://user-images.githubusercontent.com/131982/117870147-94e38a80-b250-11eb-9820-53a8feb46cd0.png)

What do you think, @ggeisler ? Anything I missed, or any feedback to offer?