### PR TITLE
Guard against the 740 field not existing

### DIFF
--- a/app/models/marc_fields/added_entry.rb
+++ b/app/models/marc_fields/added_entry.rb
@@ -5,7 +5,7 @@ class AddedEntry < MarcField
   def label
     f = marc[tags.first]
 
-    if f.indicator2 == '2'
+    if f&.indicator2 == '2'
       'Included Work'
     else
       super


### PR DESCRIPTION
This might happen if the data is coming from an unmatched vernacular field.

Fixes #2670

