### PR TITLE
Refactor SearchWorks::Links to accept the pre-parsed links data so we…

### DIFF
--- a/app/models/concerns/hathi_links.rb
+++ b/app/models/concerns/hathi_links.rb
@@ -1,27 +1,23 @@
 module HathiLinks
   def hathi_links
-    @hathi_links ||= HathiLinks::Processor.new(self)
+    @hathi_links ||= SearchWorks::Links.new([ht_link].compact)
   end
 
-  class Processor < SearchWorks::Links
-    def all
-      return [] unless ht_links.present?
+  private
 
-      Array.wrap(
-        SearchWorks::Links::Link.new(
-          html: "<a href=\"#{ht_links.url}\">Full text via HathiTrust</a>",
-          text: 'Full text via HathiTrust',
-          href: ht_links.url,
-          fulltext: true,
-          stanford_only: !ht_links.publicly_available?,
-        )
-      )
-    end
+  def ht_link
+    return unless ht_links.present?
 
-    private
+    SearchWorks::Links::Link.new(
+      html: "<a href=\"#{ht_links.url}\">Full text via HathiTrust</a>",
+      text: 'Full text via HathiTrust',
+      href: ht_links.url,
+      fulltext: true,
+      stanford_only: !ht_links.publicly_available?,
+    )
+  end
 
-    def ht_links
-      @ht_links ||= HathiTrustLinks.new(@document)
-    end
+  def ht_links
+    @ht_links ||= HathiTrustLinks.new(self)
   end
 end

--- a/app/models/concerns/index_links.rb
+++ b/app/models/concerns/index_links.rb
@@ -3,83 +3,87 @@
 # Link objects for every link field in the SolrDocument.
 module IndexLinks
   def index_links
-    @index_links ||= IndexLinks::Processor.new(self)
+    @index_links ||= SearchWorks::Links.new(link_fields.map { |link_field| IndexLinkProcessor.new(self, link_field).to_searchworks_link })
   end
 
   private
 
-  class Processor < SearchWorks::Links
-    def all
-      link_fields.map do |link_field|
-        SearchWorks::Links::Link.new(
-          html: link_html(link_field),
-          text: link_text(link_field),
-          href: link_field,
-          fulltext: link_is_fulltext?(link_field),
-          stanford_only: link_is_stanford_only?(link_field),
-          finding_aid: link_is_finding_aid?(link_field),
-          sfx: link_is_sfx?(link_field),
-          managed_purl: link_is_managed_purl?(link_field)
-        )
-      end
+  def link_fields
+    [
+      self[:url_fulltext],
+      self[:url_suppl],
+      self[:url_sfx],
+      self[:managed_purl_urls]
+    ].flatten.compact.uniq
+  end
+
+  class IndexLinkProcessor
+    attr_reader :document, :link_field
+
+    def initialize(document, link_field)
+      @document = document
+      @link_field = link_field
+    end
+
+    def to_searchworks_link
+      SearchWorks::Links::Link.new(
+        html: link_html,
+        text: link_text,
+        href: link_field,
+        fulltext: link_is_fulltext?,
+        stanford_only: link_is_stanford_only?,
+        finding_aid: link_is_finding_aid?,
+        sfx: link_is_sfx?,
+        managed_purl: link_is_managed_purl?
+      )
     end
 
     private
 
-    def link_html(link_field)
-      "<a href='#{link_field}'#{" class='sfx'".html_safe if link_is_sfx?(link_field)}>#{link_text(link_field)}</a>"
+    def link_html
+      "<a href='#{link_field}'#{" class='sfx'".html_safe if link_is_sfx?}>#{link_text}</a>"
     end
 
-    def link_text(link_field)
-      if link_is_finding_aid?(link_field)
+    def link_text
+      if link_is_finding_aid?
         'Online Archive of California'
-      elsif link_is_sfx?(link_field)
+      elsif link_is_sfx?
         'Find full text'
       else
-        link_host(link_field)
+        link_host
       end
     end
 
-    def link_is_finding_aid?(link_field)
-      link_field =~ %r{oac\.cdlib\.org(\/findaid)?\/ark:}
+    def link_is_finding_aid?
+      link_field =~ %r{oac\.cdlib\.org(/findaid)?/ark:}
     end
 
-    def link_fields
-      [
-        @document[:url_fulltext],
-        @document[:url_suppl],
-        @document[:url_sfx],
-        @document[:managed_purl_urls]
-      ].flatten.compact.uniq
-    end
-
-    def link_is_fulltext?(link)
+    def link_is_fulltext?
       @document[:url_fulltext] &&
-        @document[:url_fulltext].include?(link)
+        @document[:url_fulltext].include?(link_field)
     end
 
-    def link_is_stanford_only?(link)
+    def link_is_stanford_only?
       @document[:url_restricted] &&
-        @document[:url_restricted].include?(link)
+        @document[:url_restricted].include?(link_field)
     end
 
-    def link_is_sfx?(link)
+    def link_is_sfx?
       @document[:url_sfx] &&
-        @document[:url_sfx].include?(link)
+        @document[:url_sfx].include?(link_field)
     end
 
-    def link_is_managed_purl?(link)
+    def link_is_managed_purl?
       @document[:managed_purl_urls] &&
-        @document[:managed_purl_urls].include?(link)
+        @document[:managed_purl_urls].include?(link_field)
     end
 
-    def link_host(link_field)
+    def link_host
       uri = URI.parse(Addressable::URI.encode(link_field.strip))
       host = uri.host
-      if host =~ SearchWorks::Links::PROXY_REGEX
-        if uri.query && (query = CGI.parse(uri.query))['url'].present?
-          host = URI.parse(query['url'].first).host
-        end
+      if host =~ SearchWorks::Links::PROXY_REGEX && uri.query
+        query = CGI.parse(uri.query)
+        host = URI.parse(query['url'].first).host if query['url'].present?
       end
       host || link_field
     rescue URI::InvalidURIError

--- a/app/models/concerns/marc_links.rb
+++ b/app/models/concerns/marc_links.rb
@@ -1,17 +1,7 @@
 module MarcLinks
   def marc_links
-    @marc_links ||= LinksWrapper.new(fetch(:marc_links_struct, []).map do |data|
+    @marc_links ||= SearchWorks::Links.new(fetch(:marc_links_struct, []).map do |data|
       SearchWorks::Links::Link.new(data)
     end)
-  end
-
-  class LinksWrapper < SearchWorks::Links
-    def initialize(data)
-      @data = data
-    end
-
-    def all
-      @data
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module SearchWorks
     require 'access_panels/online'
     require 'access_panels/sfx'
     require 'access_panels/temporary_access'
-    require 'links'
+    require 'search_works/links'
     require 'hours_request'
     require 'holdings'
     require 'live_lookup'

--- a/lib/search_works/links.rb
+++ b/lib/search_works/links.rb
@@ -3,12 +3,12 @@ module SearchWorks
     PROXY_REGEX = /stanford\.idm\.oclc\.org/
 
     delegate :present?, :first, :last, :each, :map, :select, :find, to: :all
-    def initialize(document)
-      @document = document
+    def initialize(links = [])
+      @links = links
     end
 
     def all
-      []
+      @links || []
     end
 
     def fulltext
@@ -38,6 +38,7 @@ module SearchWorks
 
     class Link
       attr_accessor :html, :text, :href, :file_id, :druid, :type, :sort
+
       def initialize(options = {})
         @html = options[:html]
         @text = options[:text]

--- a/spec/lib/links_spec.rb
+++ b/spec/lib/links_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe SearchWorks::Links do
-  let(:links) { SearchWorks::Links.new({}) }
+  let(:links) { SearchWorks::Links.new(all_links) }
 
-  before do
-    allow(links).to receive(:all).and_return([
+  let(:all_links) do
+    [
       OpenStruct.new(html: 'non-fulltext link', fulltext?: false),
       OpenStruct.new(html: 'fulltext link',     fulltext?: true),
       OpenStruct.new(html: '1st finding aid link', fulltext?: true,  finding_aid?: true),
       OpenStruct.new(html: '2nd finding aid link', fulltext?: false, finding_aid?: true),
       OpenStruct.new(html: 'Managed purl link', fulltext?: true, managed_purl?: true)
-    ])
+    ]
   end
 
   it 'should identify fulltext links' do
@@ -35,13 +35,13 @@ describe SearchWorks::Links do
   end
 
   context 'with multiple managed purls' do
-    before do
-      allow(links).to receive(:all).and_return([
+    let(:all_links) do
+      [
         OpenStruct.new(text: '1', managed_purl?: true),
         OpenStruct.new(managed_purl?: true),
         OpenStruct.new(text: '2', managed_purl?: true, sort: 'xyz'),
         OpenStruct.new(text: '3', managed_purl?: true, sort: 'abc')
-      ])
+      ]
     end
 
     it 'sorts by the sort key and then by the title, with empty values last' do

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe EdsLinks do
       end
     end
 
-    it 'does not consider links full-text when label is missing' do
+    it 'is present when it has a label' do
       expect(document.eds_links.fulltext).to be_present
+    end
 
+    it 'does not consider links full-text when label is missing' do
       document['eds_fulltext_links'].first.delete('label')
       expect(document.eds_links.fulltext).not_to be_present
     end
 
     it 'does not consider links full-text when type is not correct' do
-      expect(document.eds_links.fulltext).to be_present
-
       document['eds_fulltext_links'].first['type'] = 'unknown'
       expect(document.eds_links.fulltext).not_to be_present
     end


### PR DESCRIPTION
… can use the same class for all the different link types

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
