### PR TITLE
Use form_with to generated scoped form element ids for feedback forms

### DIFF
--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -34,7 +34,7 @@ class FeedbackFormsController < ApplicationController
   protected
 
   def set_form_type
-    @form_type = params.permit(:type)[:type]
+    @form_type = params.permit(:type)[:type] || 'feedback'
   end
 
   def validate

--- a/app/helpers/feedback_form_helper.rb
+++ b/app/helpers/feedback_form_helper.rb
@@ -1,8 +1,8 @@
 module FeedbackFormHelper
   def render_feedback_form(form_type)
-    render 'shared/feedback_forms/form', locals: {
+    render 'shared/feedback_forms/form',
+      type: form_type,
       target: form_type == 'connection' ? '#connection-form' : '#feedback-form'
-    }
   end
 
   def show_feedback_form?

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="col-sm-10 col-sm-offset-1">
     <%= render "shared/feedback_forms/reporting_from" %>
 
-    <% if locals[:target] == '#feedback-form' %>
+    <% if target == '#feedback-form' %>
       <div>
         <div class="col-sm-12 col-sm-offset-3">
           <%= render "shared/feedback_forms/chat_with_librarian" if on_campus_or_su_affiliated_user? %>
@@ -11,6 +11,6 @@
       </div>
     <% end %>
 
-    <%= render "shared/feedback_forms/form_fields", locals: locals %>
+    <%= render "shared/feedback_forms/form_fields", target: target, type: type %>
   </div>
 </div>

--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -1,49 +1,49 @@
-<%= form_tag feedback_form_path, method: :post, class: "form-horizontal feedback-form", role: "form" do %>
-  <%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
+<%= form_with url: feedback_form_path, method: :post, class: "form-horizontal feedback-form", role: "form", namespace: type do |f| %>
+  <%= f.hidden_field :url, value: request.referer, class:"reporting-from-field" %>
   <span style="display:none;visibility:hidden;">
-    <%= text_field_tag :user_agent %>
-    <%= text_field_tag :viewport %>
-    <%= text_field_tag :last_search %>
+    <%= f.text_field :user_agent %>
+    <%= f.text_field :viewport %>
+    <%= f.text_field :last_search %>
   </span>
   <div class="col-sm-8 col-sm-offset-1">
-    <% if locals[:target] == '#connection-form' %>
-      <%= hidden_field_tag :type, 'connection' %>
+    <% if type == 'connection' %>
+      <%= f.hidden_field :type, value: type %>
       <div class="form-group">
-        <%= label_tag(:connection_resource_name, 'Name of resource', class:"col-sm-3 control-label") %>
+        <%= f.label(:resource_name, 'Name of resource', class:"col-sm-3 control-label") %>
         <div class="col-sm-9">
-          <%= text_field_tag :resource_name, "", id: 'connection_resource_name', class:"form-control", required: true %>
+          <%= f.text_field :resource_name, value: "", class:"form-control", required: true %>
         </div>
       </div>
       <div class="form-group">
-        <%= label_tag(:connection_problem_url, 'Problem URL', class:"col-sm-3 control-label") %>
+        <%= f.label(:problem_url, 'Problem URL', class:"col-sm-3 control-label") %>
         <div class="col-sm-9">
-          <%= text_field_tag :problem_url, "", id: 'connection_problem_url', class:"form-control", required: true %>
+          <%= f.text_field :problem_url, value: "", class:"form-control", required: true %>
         </div>
       </div>
       <div class="form-group">
-        <%= label_tag(:connection_message, 'Describe the connection issue', class:"col-sm-3 control-label") %>
+        <%= f.label(:message, 'Describe the connection issue', class:"col-sm-3 control-label") %>
         <div class="col-sm-9">
-          <%= text_area_tag :message, "", id: 'connection_message', rows:"5", class:"form-control", required: true %>
+          <%= f.text_area :message, value: "", rows:"5", class:"form-control", required: true %>
         </div>
       </div>
     <% else %>
       <div class="form-group">
-        <%= label_tag(:feedback_message, 'Message', class:"col-sm-3 control-label") %>
+        <%= f.label(:message, 'Message', class:"col-sm-3 control-label") %>
         <div class="col-sm-9">
-          <%= text_area_tag :message, "", id: 'feedback_message', rows:"5", class:"form-control", required: true %>
+          <%= f.text_area :message, value: "", rows:"5", class:"form-control", required: true %>
         </div>
       </div>
     <% end %>
     <div class="form-group">
-      <%= label_tag(:feedback_name, 'Your name', class:"col-sm-3 control-label") %>
+      <%= f.label(:name, 'Your name', class:"col-sm-3 control-label") %>
       <div class="col-sm-9">
-        <%= text_field_tag :name, "", id: 'feedback_name', class:"form-control", required: true %>
+        <%= f.text_field :name, value: "", class:"form-control", required: true %>
       </div>
     </div>
     <div class="form-group">
-      <%= label_tag(:feedback_to, 'Your email', class:"col-sm-3 control-label") %>
+      <%= f.label(:to, 'Your email', class:"col-sm-3 control-label") %>
       <div class="col-sm-9">
-        <%= email_field_tag :to, "", id: 'feedback_to', class:"form-control", required: true %>
+        <%= f.email_field :to, value: "", class:"form-control", required: true %>
       </div>
     </div>
 
@@ -60,7 +60,7 @@
     <div class="form-group">
       <div class="col-sm-offset-3 col-sm-9">
         <button type="submit" class="btn btn-primary">Send</button>
-        <%= link_to "Cancel", :back, class:"cancel-link", data: { toggle: 'collapse', target: locals[:target] } %>
+        <%= link_to "Cancel", :back, class:"cancel-link", data: { toggle: 'collapse', target: target } %>
       </div>
     </div>
   </div>

--- a/app/views/shared/quick_reports/_form.html.erb
+++ b/app/views/shared/quick_reports/_form.html.erb
@@ -1,7 +1,7 @@
 <% if show_quick_report? %>
   <div class="col-sm-3">
-    <%= form_tag quick_reports_path, method: :post, class: 'form-horizontal feedback-form', role: 'form' do %>
-      <%= hidden_field_tag(:url, request.referer, class: 'reporting-from-field') %>
+    <%= form_with url: quick_reports_path, method: :post, class: 'form-horizontal feedback-form', role: 'form', name: 'quick_report' do |f| %>
+      <%= f.hidden_field(:url, value: request.referer, class: 'reporting-from-field') %>
       <button type='submit' class='btn btn-default btn-quick-report'>Report wrong cover image</button>
     <% end %>
   </div>

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -33,3 +33,5 @@ Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = tr
 
 # Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
 # Rails.application.config.active_support.use_sha1_digests = true
+
+Rails.application.config.action_view.form_with_generates_ids = true

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -12,6 +12,7 @@ feature "Feedback form (js)", js: true do
     skip("Passes locally, not on Travis.") if ENV['CI']
     click_link "Feedback"
     expect(page).to have_css("#feedback-form", visible: true)
+    expect(page).to have_css("#feedback_message", count: 1)
     expect(page).to have_css("button", text: "Cancel")
     within "form.feedback-form" do
       fill_in("message", with: "This is only a test")
@@ -31,6 +32,7 @@ feature "Feedback form (no js)" do
   scenario "feedback form should be shown filled out and submitted" do
     click_link "Feedback"
     expect(page).to have_css("#feedback-form", visible: true)
+    expect(page).to have_css("#feedback_message", count: 1)
     expect(page).to have_css("a", text: "Cancel")
     within "form.feedback-form" do
       fill_in("message", with: "This is only a test")


### PR DESCRIPTION
We may render the feedback form (at least) twice -- once for general
feedback, and once for connection problems.

The explicit `name` is unfortunate, but Rails 6.x adds a 'prefix'
attribute to form_with that will replace the scope attriubte and
all those explicit form control `name`  attributes.