### PR TITLE
Remove some extra bottom margin from featured resources panels

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -44,6 +44,10 @@
       height: 100px;
       margin-right: 12px;
     }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Before:
![Screen Shot 2021-08-11 at 12 04 39](https://user-images.githubusercontent.com/111218/129088027-a283949f-27f2-4d99-ac86-152f2c574200.png)

After:
![Screen Shot 2021-08-11 at 12 04 47](https://user-images.githubusercontent.com/111218/129088045-ae5b2d46-103f-4639-b5ea-e8f1ce3eb459.png)

🤷 