### PR TITLE
Remove unused slideshow view code

### DIFF
--- a/app/assets/stylesheets/modules/gallery-view.scss
+++ b/app/assets/stylesheets/modules/gallery-view.scss
@@ -117,7 +117,3 @@ div.fake-cover-text {
   max-height: 7.3em;
   overflow: hidden;
 }
-
-.view-icon-slideshow {
-  &:before { content: "\e158"; }
-}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -442,9 +442,6 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 5
 
-    # Deletes slideshow view
-    # config.view.delete_field("slideshow")
-
     # View type group config
     config.view.list.icon_class = "fa-th-list"
 


### PR DESCRIPTION
Now that we're not using blacklight-gallery... we don't need code to disable slideshow view.
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
