### PR TITLE
Update COVID page link to 2021 access

### DIFF
--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -17,7 +17,7 @@
         </li>
         <li>
           <a class="nav-link covid-status" href="https://library.stanford.edu/status">
-            COVID-19 Libraries update
+            2021 Access
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## Before
<img width="381" alt="Screen Shot 2021-09-07 at 4 03 16 PM" src="https://user-images.githubusercontent.com/5402927/132421173-fec518b3-0c71-4692-8513-dd6d633f2e25.png">

## After
<img width="447" alt="Screen Shot 2021-09-07 at 4 03 36 PM" src="https://user-images.githubusercontent.com/5402927/132421172-cc89429d-d520-423b-92d9-7409b6436838.png">
