### PR TITLE
Add `ENDPROCESS` to the list of special collection of SPEC-COLL exceptions

### DIFF
--- a/app/models/request_link.rb
+++ b/app/models/request_link.rb
@@ -118,7 +118,7 @@ class RequestLink
 
   def disabled_current_locations_map
     {
-      'SPEC-COLL' => %w[INPROCESS MISSING ON-ORDER SPEC-INPRO],
+      'SPEC-COLL' => %w[INPROCESS MISSING ON-ORDER SPEC-INPRO ENDPROCESS],
       'default' => %w[]
     }
   end


### PR DESCRIPTION
> @seestone: [See] https://searchworks-uat.stanford.edu/view/13323342
> It’s SPEC-COLL but getting a request link.
> It’s because the current loc isn’t INPROCESS, but ENDPROCESS.  Two locations used for slightly different “end processes”…but both meaning you can’t get it yet
> so we need to add ENDPROCESS to the list of SPEC-COLL that shouldn’t get a link