### PR TITLE
Don't assume a given barcode exists for an item

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -6,7 +6,7 @@
       <h1>Browse related items</h1>
       <p>Starting at call number:
         <% if params[:barcode] %>
-          <%= @original_doc.holdings.find_by_barcode(params[:barcode]).callnumber %>
+          <%= @original_doc.holdings.find_by_barcode(params[:barcode])&.callnumber %>
         <% else %>
           <%= @original_doc.holdings.callnumbers.first.callnumber %>
         <% end %>


### PR DESCRIPTION
Fixes #2786, more or less. This seems to happen (mostly) when crawlers have old, cached data and an item barcode changes. There's probably something better we could do, but not breaking with a 500 error is at least a start.
