### PR TITLE
Refactor to fix database 0-9 filter.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -22,17 +22,12 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def database_prefix_search(solr_params)
-    if page_location.databases? && blacklight_params[:prefix]
-      if blacklight_params[:prefix] == "0-9"
-        query = ("0".."9").map do |number|
-          "title_sort:#{number}*"
-        end.join(" OR ")
-      else
-        query = "title_sort:#{blacklight_params[:prefix]}*"
-      end
-      solr_params[:qt] = blacklight_config.lucene_req_handler
-      solr_params[:q] = [query, blacklight_params[:q]].compact.join(" AND ")
-    end
+    return unless page_location.databases? &&
+                  blacklight_params[:prefix] &&
+                  blacklight_params[:prefix].match?(/^(0-9|[a-z])$/i)
+
+    solr_params[:fq] ||= []
+    solr_params[:fq] << "title_sort:/[#{blacklight_params[:prefix]}].*/"
   end
 
   def modifiable_params_keys

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -20,21 +20,17 @@ describe SearchBuilder do
     it "should handle 0-9 filters properly" do
       blacklight_params[:prefix] = "0-9"
       search_builder.database_prefix_search(solr_params)
-      (0..9).to_a.each do |number|
-        expect(solr_params[:q]).to match /title_sort:#{number}\*/
-      end
-      expect(solr_params[:q]).to match /^title_sort:0\*.*title_sort:9\*$/
+      expect(solr_params[:fq]).to include("title_sort:/[0-9].*/")
     end
     it "should handle alpha filters properly" do
-      blacklight_params[:prefix] = "B"
+      blacklight_params[:prefix] = "b"
       search_builder.database_prefix_search(solr_params)
-      expect(solr_params[:q]).to eq "title_sort:B*"
+      expect(solr_params[:fq]).to include("title_sort:/[b].*/")
     end
-    it "should AND user supplied queries" do
-      blacklight_params[:prefix] = "B"
-      blacklight_params[:q] = "My Query"
+    it "should do nothing if prefix param is invalid" do
+      blacklight_params[:prefix] = "*"
       search_builder.database_prefix_search(solr_params)
-      expect(solr_params[:q]).to eq "title_sort:B* AND My Query"
+      expect(solr_params[:fq]).to be_nil
     end
   end
 


### PR DESCRIPTION
- Apply database title prefix query to `:fq` instead of `:q`
- Validate value of `:prefix` param before generating the query
- Adjust tests
- Remove `:qt` param assignment

Closes #2790 

Shown working on stage:

<img width="1006" alt="Screen Shot 2022-01-06 at 10 35 17 AM" src="https://user-images.githubusercontent.com/458247/148408494-b1dee223-1dce-4d28-b8ba-8635fd3aefd6.png">

