### PR TITLE
EDS PDF download links display with "S" icon (Stanford Only).

### DIFF
--- a/app/models/concerns/eds_links.rb
+++ b/app/models/concerns/eds_links.rb
@@ -35,6 +35,10 @@ module EdsLinks
       %w[customlink-fulltext pdf ebook-pdf ebook-epub].include?(type) && label.present?
     end
 
+    def pdf?
+      category == 2
+    end
+
     def sfx?
       category == 3
     end
@@ -59,7 +63,8 @@ module EdsLinks
         fulltext: present? && show?(categories, category),
         sfx:      sfx?,
         ill:      ill?,
-        type:     type
+        type:     type,
+        stanford_only: pdf?
       )
     end
 

--- a/app/views/articles/access_panels/_online.html.erb
+++ b/app/views/articles/access_panels/_online.html.erb
@@ -7,7 +7,7 @@
   <div class="panel-body">
     <ul class='document-metadata dl-horizontal dl-invert'>
       <% document.access_panels.online.links.each do |link| %>
-        <li>
+        <li class="<%= 'stanford-only' if link.stanford_only? %>">
           <% if link.href == 'detail' %>
             <%= link_to(link.text, article_fulltext_link_path(id: document.id, type: link.type), data: { 'turbolinks' => false }) %>
           <% else %>

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -81,6 +81,28 @@ RSpec.describe EdsLinks do
     end
   end
 
+  context 'stanford only links' do
+    it 'sets PDF download links to stanford only' do
+      document['eds_fulltext_links'].first['label'] = 'PDF full text'
+      expect(document.eds_links.all.first).to be_stanford_only
+    end
+
+    it 'sets eBook PDF download links to stanford only' do
+      document['eds_fulltext_links'].first['label'] = 'PDF eBook Full Text'
+      expect(document.eds_links.all.first).to be_stanford_only
+    end
+
+    it 'does not set HTML links to stanford only' do
+      document['eds_fulltext_links'].first['label'] = 'HTML full text'
+      expect(document.eds_links.all.first).not_to be_stanford_only
+    end
+
+    it 'does not set SFX links to stanford only' do
+      document['eds_fulltext_links'].first['label'] = 'Check SFX for full text'
+      expect(document.eds_links.all.first).not_to be_stanford_only
+    end
+  end
+
   context 'non customlink-fulltext links' do
     it 'ignores other link types' do
       document['eds_fulltext_links'].first['type'] = 'unknown'

--- a/spec/views/article/access_panels/_online.html.erb_spec.rb
+++ b/spec/views/article/access_panels/_online.html.erb_spec.rb
@@ -32,11 +32,19 @@ RSpec.describe 'articles/access_panels/_online.html.erb' do
       )
     end
 
+    let(:content) do
+      Capybara.string(rendered.to_s)
+    end
+
     it 'links to the article_fulltext_link route instead of "detail"' do
-      content = Capybara.string(rendered.to_s)
       link = content.find('.panel-body li a')
       expect(link['href']).not_to include('detail')
       expect(link['href']).to match(%r{abc123\/pdf\/fulltext})
+    end
+
+    it 'the list item has the stanford-only class' do
+      list_item = content.find('.panel-body li')
+      expect(list_item['class']).to include('stanford-only')
     end
   end
 


### PR DESCRIPTION
Set category 2 links (PDF and PDF E-Book) to Stanford only and add "S" icon in show view when displaying these links.

QUESTION: Not sure whether we should be showing the "S" icon on the index view as well?

Partially addresses #2771
