### PR TITLE
Remove 2022 Access link from subnavbar.

### DIFF
--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -35,13 +35,6 @@
     padding-left: 20px;
   }
   .navbar-nav > li {
-    a.covid-status {
-      background-color: $poppy;
-      color: $black;
-      padding-left: 15px;
-      padding-right: 15px;
-    }
-
     a {
       background-color: $sul-subnavbar-bg-color;
       border: 0;
@@ -113,22 +106,6 @@
 
     .sul-top-menu {
       white-space: normal;
-    }
-  }
-
-  // Responsive fixes for COVID-19 status
-  @media screen and (max-width: $screen-md-min) {
-    .navbar-nav > li {
-      a {
-        font-size: 1.4em;
-      }
-    }
-
-    .dropdown-menu {
-      li a,
-      li span {
-        font-size: 1.4em;
-      }
     }
   }
 }

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -15,11 +15,6 @@
           </a>
           <%= render :partial => 'shared/search_navbar_services_menu' %>
         </li>
-        <li>
-          <a class="nav-link covid-status" href="https://library.stanford.edu/status">
-            2022 Access
-          </a>
-        </li>
       </ul>
       <% unless article_search? %>
         <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Closes #2827
