### PR TITLE
Allow any branch to deploy to sandbox-f

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -3,3 +3,4 @@ collection:
   dir: config/solr_configs/
   name: blacklight-core
 port: 8983
+version: 8.11.1

--- a/config/deploy/preview_articles.rb
+++ b/config/deploy/preview_articles.rb
@@ -2,7 +2,8 @@ set :bundle_without, %w[sqlite development test].join(' ')
 
 server 'sw-webapp-sandbox-f.stanford.edu', user: 'blacklight', roles: %w[web db app]
 
-set :branch, 'linked-data-experiments'
+# NOTE: Branch no longer deploys because of mimemagic version issue
+# set :branch, 'linked-data-experiments'
 
 set :linked_files, fetch(:linked_files, []) << 'wof_lookup.json'
 


### PR DESCRIPTION
For now, allow any branch to deploy to sandbox-f. linked-data-experiments branch is out of date and uses a version of mimemagic that got removed from rubygems.