### PR TITLE
Show S (stanford-only) icon in article index view

### DIFF
--- a/app/presenters/article_fulltext_link_presenter.rb
+++ b/app/presenters/article_fulltext_link_presenter.rb
@@ -24,6 +24,10 @@ class ArticleFulltextLinkPresenter
     "<span class='online-label'>Full text</span>"
   end
 
+  def stanford_only_icon
+    "<span class='stanford-only'></span>"
+  end
+
   def online_access_panel?
     document.access_panels.online?
   end
@@ -52,6 +56,7 @@ class ArticleFulltextLinkPresenter
       #{(link_to('View on detail page', article_url(document)) if document_has_fulltext?)}
       #{image_tag(image_url('pdf-icon.svg'), height: '20px', alt: 'PDF')}
       #{link_to(link.text, article_fulltext_link_url(id: document.id, type: link.type), data: { 'turbolinks' => false })}
+      #{stanford_only_icon}
     HTML
   end
 end

--- a/app/views/articles/_index_brief_default.html.erb
+++ b/app/views/articles/_index_brief_default.html.erb
@@ -26,6 +26,9 @@
           <span class="online-label">Full text</span>
           <%= link_to(link.text, link.href) %>
         <% end %>
+        <% if link.stanford_only? %>
+          <span class="stanford-only"></span>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/spec/presenters/article_fulltext_link_presenter_spec.rb
+++ b/spec/presenters/article_fulltext_link_presenter_spec.rb
@@ -45,6 +45,27 @@ describe ArticleFulltextLinkPresenter do
       end
     end
 
+    context 'when the document has a stanford-only link' do
+      let(:document) do
+        SolrDocument.new(
+          'id' => '00001',
+          'eds_fulltext_links' => [
+            { 'url' => 'detail', 'label' => 'PDF Full Text', 'type' => 'pdf' }
+          ]
+        )
+      end
+
+      before do
+        allow(presenter).to receive(:article_fulltext_link_url).and_return('http://example.com')
+        allow(presenter).to receive(:image_url)
+        allow(presenter).to receive(:image_tag)
+      end
+
+      it 'includes a span with stanford-only class' do
+        expect(Capybara.string(presenter.links.first)).to have_css('span.stanford-only')
+      end
+    end
+
     context 'when the document does not have a link but does include full-text' do
       let(:document) { SolrDocument.new(id: 'abc123', 'eds_html_fulltext_available' => true) }
 


### PR DESCRIPTION
Looking at #2771 again, I remain confused about which EDS links should have the "S" icon displayed -- it seems broader than just downloadable PDFs. This PR doesn't really address that issue, but it does display the "S" icon on the index view for links that are identified as "stanford-only." All this is to say, I think more work is needed to determine exactly which EDS links should be identified as "stanford-only."
