### PR TITLE
Guard against missing library thumbnails (probably from bad data); fixes #2877

### DIFF
--- a/app/helpers/access_panel_helper.rb
+++ b/app/helpers/access_panel_helper.rb
@@ -14,6 +14,10 @@ module AccessPanelHelper
       "#{library.code}.jpg"
     end
     image_tag(image_name, class: "pull-left", alt: "", height: 50)
+  rescue Sprockets::Rails::Helper::AssetNotFound => e
+    Honeybadger.notify(e, error_message: "Missing library thumbnail for #{library.code}")
+
+    nil
   end
 
   def display_connection_problem_links?(document)


### PR DESCRIPTION
Pre-Blacklight 7:
![Screen Shot 2022-07-11 at 09 27 36](https://user-images.githubusercontent.com/111218/178312385-d1328f9d-2184-48b8-936b-fca2af813dae.png)

After this change:
![Screen Shot 2022-07-11 at 09 27 44](https://user-images.githubusercontent.com/111218/178312400-b20a7e5c-98eb-4589-93af-aa4d27b199cd.png)

