### PR TITLE
Guard against mangled urls when displaying constraints

### DIFF
--- a/app/components/blacklight/constraint_layout_component.html.erb
+++ b/app/components/blacklight/constraint_layout_component.html.erb
@@ -4,7 +4,7 @@
       <span class="filterName"><%= @label %></span>
     <% end %>
     <% if @value.present? %>
-      <%= content_tag :span, @value, class: 'filterValue', title: strip_tags(@value) %>
+      <%= content_tag :span, @value, class: 'filterValue', title: strip_tags(@value.to_s) %>
     <% end %>
   </span>
   <% if @remove_path.present? %>


### PR DESCRIPTION
This is a work-around for #2876, at least restoring parity with the old behavior. I though Blacklight handled the de-mangling, but maybe we've opted out of that somewhere along the line.

