### PR TITLE
Move the AdvancedSearchParamsMapping param manipulation earlier in the stack

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,13 +5,13 @@ class CatalogController < ApplicationController
 
   include ReplaceSpecialQuotes
 
+  include AdvancedSearchParamsMapping
+
   include Blacklight::Catalog
 
   include Blacklight::Marc::Catalog
 
   include BlacklightRangeLimit::ControllerOverride
-
-  include AdvancedSearchParamsMapping
 
   include DatabaseAccessPoint
 

--- a/app/controllers/concerns/advanced_search_params_mapping.rb
+++ b/app/controllers/concerns/advanced_search_params_mapping.rb
@@ -25,12 +25,12 @@ module AdvancedSearchParamsMapping
   # https://github.com/sul-dlss/SearchWorks/pull/792/files
   def advanced_search_legacy_field_mapping
     {
-      author: :search_author,
-      title: :search_title,
-      subject: :subject_terms,
-      description: :search,
-      pub_info: :pub_search,
-      number: :isbn_search
+      author: 'search_author',
+      title: 'search_title',
+      subject: 'subject_terms',
+      description: 'search',
+      pub_info: 'pub_search',
+      number: 'isbn_search'
     }
   end
 end


### PR DESCRIPTION
Fixes #2873

Also, blacklight fields are strings, not symbols.