### PR TITLE
Stop using `permit_all_parameters` configuration

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -247,7 +247,7 @@ class ArticlesController < ApplicationController
   end
 
   def set_search_query_modifier
-    @search_modifier ||= SearchQueryModifier.new(params, blacklight_config)
+    @search_modifier ||= SearchQueryModifier.new(search_state)
   end
 
   # Reuse the EDS session token if available in the user's session data,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -533,7 +533,7 @@ class CatalogController < ApplicationController
   helper_method :augment_solr_document_json_response
 
   def set_search_query_modifier
-    @search_modifier ||= SearchQueryModifier.new(params, blacklight_config)
+    @search_modifier ||= SearchQueryModifier.new(search_state)
   end
 
   def advanced_search_form?(*args, **kwargs)

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -27,7 +27,7 @@ module CatalogHelper
 
   def new_documents_feed_path
     search_catalog_path(
-      params.except(:controller, :action, :page, :format, :sort).to_hash.merge(sort: 'new-to-libs', format: 'atom')
+      search_state.to_h.except(:controller, :action, :page, :format, :sort).to_hash.merge(sort: 'new-to-libs', format: 'atom')
     )
   end
 

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -19,11 +19,11 @@
 <div id="content" class="callnumber-browse">
   <% if @document_list.present? %>
     <div class="panel panel-default browse-toolbar">
-      <%= link_to(browse_index_path(params.merge(page: (params[:page] || 0).to_i-1)), class: 'btn btn-default btn-sm') do %>
+      <%= link_to(browse_index_path(params.to_unsafe_h.merge(page: (params[:page] || 0).to_i-1)), class: 'btn btn-default btn-sm') do %>
         <i class="fa fa-arrow-left" aria-hidden="true"></i><span class="sr-only">Previous</span>
       <% end %>
       <%= @document_list.first.holdings.callnumbers.first.callnumber %> - <%= @document_list.last.holdings.callnumbers.first.callnumber %>
-      <%= link_to(browse_index_path(params.merge(page: (params[:page] || 0).to_i+1)), class: 'btn btn-default btn-sm') do %>
+      <%= link_to(browse_index_path(params.to_unsafe_h.merge(page: (params[:page] || 0).to_i+1)), class: 'btn btn-default btn-sm') do %>
         <i class="fa fa-arrow-right" aria-hidden="true"></i><span class="sr-only">Next</span>
       <% end %>
       <div class='pull-right'>

--- a/app/views/catalog/_database_prefix.html.erb
+++ b/app/views/catalog/_database_prefix.html.erb
@@ -2,11 +2,11 @@
   <h2>Filter by database title</h2>
   <ul class="pagination">
     <li class="<%= 'active' unless params[:prefix] %>">
-      <%= link_to "Show all", params.merge(prefix: nil, page: nil)  %>
+      <%= link_to "Show all", params.to_unsafe_h.merge(prefix: nil, page: nil)  %>
     </li>
     <% facets_prefix_options.each do |prefix_option| %>
       <li class="<%= 'active' if params[:prefix] == prefix_option.downcase %>">
-        <%= link_to prefix_option, params.merge(prefix: prefix_option.downcase, page: nil,sort: 'title') %>
+        <%= link_to prefix_option, params.to_unsafe_h.merge(prefix: prefix_option.downcase, page: nil,sort: 'title') %>
       </li>
     <% end %>
   </ul>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -12,8 +12,8 @@
 
 <% content_for(:head) do -%>
   <%= render '/catalog/opensearch_response_metadata' %>
-  <%= auto_discovery_link_tag(:rss, url_for(params.merge(:format => 'rss')), :title => t('blacklight.search.rss_feed') ) %>
-  <%= auto_discovery_link_tag(:atom, url_for(params.merge(:format => 'atom')), :title => t('blacklight.search.atom_feed') ) %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
 <% end -%>
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,8 +50,6 @@ module SearchWorks
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.action_controller.permit_all_parameters = true
-
     config.middleware.insert 0, Rack::UTF8Sanitizer
 
     # This will not be required once we upgrade to Blacklight 7

--- a/lib/search_query_modifier.rb
+++ b/lib/search_query_modifier.rb
@@ -1,7 +1,8 @@
 class SearchQueryModifier
-  def initialize(params, config)
-    @params = params
-    @config = config
+  def initialize(search_state)
+    @search_state = search_state
+    @params = @search_state.params
+    @config = @search_state.blacklight_config
   end
 
   def present?

--- a/spec/controllers/concerns/advanced_search_params_mapping_spec.rb
+++ b/spec/controllers/concerns/advanced_search_params_mapping_spec.rb
@@ -17,7 +17,7 @@ describe AdvancedSearchParamsMapping do
 
     it 'moves old advanced search queries to the new adv search clauses' do
       expect(params[:author]).not_to be_present
-      expect(params[:clause].values).to include({ field: :search_author, query: "Author" })
+      expect(params[:clause].values).to include(field: 'search_author', query: "Author")
     end
   end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -34,16 +34,20 @@ describe CatalogHelper do
   end
 
   describe 'new_documents_feed_path' do
+    before do
+      allow(helper).to receive(:search_state).and_return(Blacklight::SearchState.new({}, CatalogController.blacklight_config))
+    end
+
     it 'returns the search url to an atom feed' do
-      expect(new_documents_feed_path).to match %r{^/catalog.atom\?}
+      expect(helper.new_documents_feed_path).to match %r{^/catalog.atom\?}
     end
 
     it 'includes the new-to-libs sort key' do
-      expect(new_documents_feed_path).to match(/sort=new-to-libs/)
+      expect(helper.new_documents_feed_path).to match(/sort=new-to-libs/)
     end
 
     it 'removes the page parameter' do
-      expect(helper).to receive(:params).and_return(page: 5)
+      allow(helper).to receive(:search_state).and_return(Blacklight::SearchState.new({ page: 5}, CatalogController.blacklight_config))
       expect(helper.new_documents_feed_path).not_to match(/page=/)
     end
   end

--- a/spec/lib/search_query_modifier_spec.rb
+++ b/spec/lib/search_query_modifier_spec.rb
@@ -2,31 +2,31 @@ require "spec_helper"
 
 describe SearchQueryModifier do
   let(:default_config) { {} }
-  let(:stopwords_query) { SearchQueryModifier.new({ q: "And we have stopwords oF THE month", other: 'something' }, default_config) }
+  let(:stopwords_query) { SearchQueryModifier.new(Blacklight::SearchState.new({ q: "And we have stopwords oF THE month", other: 'something' }, default_config)) }
 
   describe "#present?" do
     it "should return true when there is a facet and query" do
-      expect(SearchQueryModifier.new({ q: "hello", f: { something: '' } }, default_config)).to be_present
+      expect(SearchQueryModifier.new(Blacklight::SearchState.new({ q: "hello", f: { something: '' } }, default_config))).to be_present
     end
     it "should return true when the search is fielded" do
       config = OpenStruct.new(default_search_field: OpenStruct.new(field: 'search'))
-      expect(SearchQueryModifier.new({ q: "hello", search_field: 'someting_else' }, config)).to be_present
+      expect(SearchQueryModifier.new(Blacklight::SearchState.new({ q: "hello", search_field: 'someting_else' }, config))).to be_present
     end
     it "should return true when there are stopwords" do
       expect(stopwords_query).to be_present
     end
     it "should return false when there is only a facet OR query" do
-      expect(SearchQueryModifier.new({ q: "hello" }, default_config)).not_to be_present
-      expect(SearchQueryModifier.new({ f: { something: '' } }, default_config)).not_to be_present
+      expect(SearchQueryModifier.new(Blacklight::SearchState.new({ q: "hello" }, default_config))).not_to be_present
+      expect(SearchQueryModifier.new(Blacklight::SearchState.new({ f: { something: '' } }, default_config))).not_to be_present
     end
   end
 
   describe "stopwords" do
-    let(:no_stopwords_query) { SearchQueryModifier.new({ q: "This query does not have stopwords", other: 'something' }, default_config) }
+    let(:no_stopwords_query) { SearchQueryModifier.new(Blacklight::SearchState.new({ q: "This query does not have stopwords", other: 'something' }, default_config)) }
 
     describe "#params_without_stopwords" do
       it "should replace the 'q' parameter in the options with one that doesn't contain stopwords" do
-        expect(stopwords_query.params_without_stopwords).to eq({ q: "we have stopwords month", other: 'something' })
+        expect(stopwords_query.params_without_stopwords).to eq({ 'q' => "we have stopwords month", 'other' => 'something' })
       end
     end
 
@@ -42,10 +42,10 @@ describe SearchQueryModifier do
 
   describe "fielded search" do
     let(:config) { OpenStruct.new(default_search_field: OpenStruct.new(field: 'search')) }
-    let(:fielded_search) { SearchQueryModifier.new({ search_field: "search_title", q: 'something', f: 'else' }, config) }
-    let(:no_query_search) { SearchQueryModifier.new({ search_field: 'search_title' }, config) }
-    let(:no_fielded_search) { SearchQueryModifier.new({ q: 'something' }, config) }
-    let(:default_fielded_search) { SearchQueryModifier.new({ search_field: "search", q: 'something' }, config) }
+    let(:fielded_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ search_field: "search_title", q: 'something', f: 'else' }, config)) }
+    let(:no_query_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ search_field: 'search_title' }, config)) }
+    let(:no_fielded_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ q: 'something' }, config)) }
+    let(:default_fielded_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ search_field: "search", q: 'something' }, config)) }
 
     describe "#fielded_search?" do
       it "should return true when a fielded search is selected" do
@@ -93,9 +93,9 @@ describe SearchQueryModifier do
         config.add_facet_field 'fieldB', label: 'Another field'
       end
     }
-    let(:filtered_search) { SearchQueryModifier.new({ f: { 'fieldA' => ['Something'], 'fieldB' => ['Something Else'] }, q: 'something' }, facet_config) }
-    let(:ranged_search) { SearchQueryModifier.new({ range: { 'range_field' => { 'begin' => '1234', 'end' => '4321' } }, q: 'something' }, facet_config) }
-    let(:no_filter_search) { SearchQueryModifier.new({ q: 'something' }, default_config) }
+    let(:filtered_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ f: { 'fieldA' => ['Something'], 'fieldB' => ['Something Else'] }, q: 'something' }, facet_config)) }
+    let(:ranged_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ range: { 'range_field' => { 'begin' => '1234', 'end' => '4321' } }, q: 'something' }, facet_config)) }
+    let(:no_filter_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ q: 'something' }, default_config)) }
 
     describe "#has_filters?" do
       it "should return true when a search has filters" do

--- a/spec/views/shared/_zero_results.html.erb_spec.rb
+++ b/spec/views/shared/_zero_results.html.erb_spec.rb
@@ -9,12 +9,16 @@ describe "shared/_zero_results" do
     end
   }
 
-  before do
-    assign(:search_modifier, SearchQueryModifier.new({
+  let(:search_state) do
+    Blacklight::SearchState.new({
       q: "A query",
       f: { 'fieldA' => ["ValueA"], 'fieldB' => ['ValueB'] },
       search_field: 'search_title'
-    }, config))
+    }, config)
+  end
+
+  before do
+    assign(:search_modifier, SearchQueryModifier.new(search_state))
     allow(view).to receive(:controller_name).and_return('catalog')
     allow(view).to receive(:label_for_search_field).and_return('Title')
   end


### PR DESCRIPTION
Generally a good idea for security, and also fixes #2876 so we let Blacklight de-mangle URLs "normalized" by PHP.