### PR TITLE
Keep view option aligned when active and remove extraneous border

### DIFF
--- a/app/assets/stylesheets/modules/browse-toolbar.scss
+++ b/app/assets/stylesheets/modules/browse-toolbar.scss
@@ -3,6 +3,14 @@
   color: $sul-toolbar-color;
   font-size: $font-size-h3;
   padding: 10px;
+
+  ul li a {
+    border-bottom: 0px;
+
+    i.active-icon {
+      margin-left: -17px;
+    }
+  }
 }
 
 .record-browse-nearby {


### PR DESCRIPTION
Closes #1115

Before:
<img width="1293" alt="Screen Shot 2022-07-13 at 3 05 53 PM" src="https://user-images.githubusercontent.com/458247/178811987-75a5105b-132b-4df2-9738-f1fcaf87f0e9.png">

After:
<img width="1274" alt="Screen Shot 2022-07-13 at 2 57 18 PM" src="https://user-images.githubusercontent.com/458247/178811527-96d40ee3-4641-41f5-8460-8639492069f6.png">
