### PR TITLE
Lower-case the view labels in the i18n file instead of doing it on-the-fly with css

### DIFF
--- a/app/assets/stylesheets/modules/view-type-group.scss
+++ b/app/assets/stylesheets/modules/view-type-group.scss
@@ -1,8 +1,0 @@
-#view-type-dropdown {
-
-  .dropdown-menu {
-    li span.view-type-label {
-      text-transform: lowercase;
-    }
-  }
-}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -76,5 +76,4 @@
 @import 'modules/top-navbar';
 @import 'modules/tech-details';
 @import 'modules/thumbnail';
-@import 'modules/view-type-group';
 @import 'modules/zero-results';

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -29,8 +29,9 @@ en:
       searchworks_results_title: '%{num_results} in %{application_name}'
       view:
         label: 'View'
-        brief: 'Brief'
-        list: 'Normal'
+        brief: 'brief'
+        gallery: 'gallery'
+        list: 'normal'
       per_page:
         button_label_html: '%{count}<span class="hidden-xs hidden-sm"> per page</span>'
       pagination_info:

--- a/spec/features/blacklight_customizations/view_options_spec.rb
+++ b/spec/features/blacklight_customizations/view_options_spec.rb
@@ -7,13 +7,13 @@ feature "View options" do
     click_button 'search'
 
     within('#view-type-dropdown') do
-      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'Normal')
+      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'normal')
       expect(page).to have_css("li a.view-type-list i.fa.fa-th-list")
 
-      expect(page).to have_css("li a.view-type-gallery span.view-type-label", text: 'Gallery')
+      expect(page).to have_css("li a.view-type-gallery span.view-type-label", text: 'gallery')
       expect(page).to have_css("li a.view-type-gallery i.fa.fa-th")
 
-      expect(page).to have_css("li a.view-type-brief span.view-type-label", text: 'Brief')
+      expect(page).to have_css("li a.view-type-brief span.view-type-label", text: 'brief')
       expect(page).to have_css("li a.view-type-brief i.fa.fa-align-justify")
     end
   end


### PR DESCRIPTION
I can't see any other context where those labels need to be upper-case 🤷‍♂️ 