### PR TITLE
Limit EDS online links to just the fulltext

### DIFF
--- a/app/models/concerns/document_links.rb
+++ b/app/models/concerns/document_links.rb
@@ -5,7 +5,7 @@ module DocumentLinks
   include HathiLinks
 
   def preferred_online_links
-    sfx_links || marc_fulltext_links || non_stanford_hathi_links || eds_links || []
+    sfx_links || marc_fulltext_links || non_stanford_hathi_links || eds_links&.fulltext || []
   end
 
   private


### PR DESCRIPTION
This was a regression from the blacklight 7 upgrade. Previously we limited just to fulltext:

https://github.com/sul-dlss/SearchWorks/blob/v3.3.13/lib/access_panels/online.rb#L20