### PR TITLE
Suppress embed for MODS resources when :dor_resource_count_isi field exists and is 0

### DIFF
--- a/app/models/concerns/dor_content_metadata.rb
+++ b/app/models/concerns/dor_content_metadata.rb
@@ -1,0 +1,9 @@
+module DorContentMetadata
+  # Document has (or could have) published content if:
+  #   dor_resource_count_isi field is present and positive (resource has published content)
+  #   OR if dor_resource_count_isi field is not present (could have published content --
+  #   for records that have not been re-indexed)
+  def published_content?
+    self['dor_resource_count_isi']&.positive? || !key?('dor_resource_count_isi')
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,6 +28,7 @@ class SolrDocument
   include EdsSubjects
   include MarcSubjects
   include IiifConcern
+  include DorContentMetadata
 
   include Blacklight::Solr::Document
   include SchemaDotOrg

--- a/app/views/catalog/_show_mods.html.erb
+++ b/app/views/catalog/_show_mods.html.erb
@@ -4,7 +4,7 @@
 
 <div class="col-md-12 upper-record-metadata row">
   <%= render 'catalog/record/mods_upper_metadata_section' %>
-  <% if document.druid && (document['dor_resource_count_isi']&.positive? || !document.key?('dor_resource_count_isi')) %>
+  <% if document.druid && document.published_content? %>
     <h2>Digital content</h2>
     <div class="purl-embed-viewer">
       <div data-behavior="purl-embed" data-embed-url="<%= embed_path(document.druid) %>"></div>

--- a/app/views/catalog/_show_mods.html.erb
+++ b/app/views/catalog/_show_mods.html.erb
@@ -4,7 +4,7 @@
 
 <div class="col-md-12 upper-record-metadata row">
   <%= render 'catalog/record/mods_upper_metadata_section' %>
-  <% if document.druid %>
+  <% if document.druid && (document['dor_resource_count_isi']&.positive? || !document.key?('dor_resource_count_isi')) %>
     <h2>Digital content</h2>
     <div class="purl-embed-viewer">
       <div data-behavior="purl-embed" data-embed-url="<%= embed_path(document.druid) %>"></div>

--- a/spec/models/concerns/dor_content_metadata_spec.rb
+++ b/spec/models/concerns/dor_content_metadata_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe DorContentMetadata do
+  let(:published_content) { SolrDocument.new(dor_resource_count_isi: 1) }
+  let(:no_published_content) { SolrDocument.new(dor_resource_count_isi: 0) }
+  let(:field_missing) { SolrDocument.new }
+
+  describe '#published_content?' do
+    it 'returns true if there is published content' do
+      expect(published_content.published_content?).to be true
+    end
+
+    it 'returns false if there is no published content' do
+      expect(no_published_content.published_content?).to be false
+    end
+
+    it 'returns true if the dor_resource_count_isi field is missing' do
+      expect(field_missing.published_content?).to be true
+    end
+  end
+end

--- a/spec/views/catalog/_show_mods.html.erb_spec.rb
+++ b/spec/views/catalog/_show_mods.html.erb_spec.rb
@@ -11,11 +11,34 @@ describe 'catalog/_show_mods' do
   end
 
   context 'when a document has a druid' do
-    let(:document) { SolrDocument.new(druid: 'abc123', modsxml: mods_001) }
+    context 'there is published content' do
+      let(:document) do
+        SolrDocument.new(druid: 'abc123', dor_resource_count_isi: 1, modsxml: mods_001)
+      end
 
-    it 'includes the purl-embed-viewer element' do
-      expect(rendered).to have_css('.purl-embed-viewer')
+      it 'includes the purl-embed-viewer element' do
+        expect(rendered).to have_css('.purl-embed-viewer')
+      end
     end
+
+    context 'there is no published content' do
+      let(:document) do
+        SolrDocument.new(druid: 'abc123', dor_resource_count_isi: 0, modsxml: mods_001)
+      end
+
+      it 'does not include the purl-embed-viewer element' do
+        expect(rendered).not_to have_css('.purl-embed-viewer')
+      end
+    end
+
+    context 'dor_resource_count_isi is not defined' do
+      let(:document) { SolrDocument.new(druid: 'abc123', modsxml: mods_001) }
+
+      it 'includes the purl-embed-viewer element' do
+        expect(rendered).to have_css('.purl-embed-viewer')
+      end
+    end
+
     context 'with a iiif manifest' do
       let(:document) do
         SolrDocument.new(druid: 'abc123', modsxml: mods_001, iiif_manifest_url_ssim: ['example.com'])


### PR DESCRIPTION
This will suppress the embed and header for MODS resources if we know there is no published content (`:dor_resource_count_isi` field is present and not a positive number). Because this is a new field requiring re-indexing, the logic allows the embed to display if the `:dor_resource_count_isi` field is not yet set on the record.

Partially addresses #2885 
