### PR TITLE
Look for :uniform_title_tag in the correct location in the uniform_title_display_struct

### DIFF
--- a/app/helpers/marc_helper.rb
+++ b/app/helpers/marc_helper.rb
@@ -13,7 +13,7 @@ module MarcHelper
     data = doc['uniform_title_display_struct'].first.with_indifferent_access
     field_data = data[:fields].first[:field]
 
-    search_field = if %w(130 730).include?(data[:uniform_title_tag])
+    search_field = if %w(130 730).include?(data[:fields].first[:uniform_title_tag])
                      'search_title'
                    else
                      'author_title'

--- a/spec/helpers/marc_helper_spec.rb
+++ b/spec/helpers/marc_helper_spec.rb
@@ -14,7 +14,13 @@ describe MarcHelper do
       doc = SolrDocument.new(uniform_title_display_struct: [{ fields: [{ field: { pre_text: 'xyz', link_text: 'Instrumental music Selections', post_text: '[print/digital]' }, vernacular: { vern: '' } }] }])
       title = get_uniform_title(doc)
       expect(title[:fields].length).to eq 1
-      expect(title[:fields].first[:field]).to match(%r{xyz <a href=.*>Instrumental music Selections</a> \[print/digital\]})
+      expect(title[:fields].first[:field]).to match(%r{xyz <a href=.*search_field=author_title">Instrumental music Selections</a> \[print/digital\]})
+    end
+
+    it 'selects search_title search_field if the MARC field tag is 130' do
+      doc = SolrDocument.new(uniform_title_display_struct: [{ fields: [{ uniform_title_tag: '130', field: { pre_text: 'xyz', link_text: 'Instrumental music Selections', post_text: '[print/digital]' }, vernacular: { vern: '' } }] }])
+      title = get_uniform_title(doc)
+      expect(title[:fields].first[:field]).to match(%r{xyz <a href=.*search_field=search_title">Instrumental music Selections</a> \[print/digital\]})
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/sul-dlss/searchworks_traject_indexer/issues/647

I had originally thought this was an issue on the indexing side, but it appears that the intent was for SearchWorks to select the right search field based the tag in the `uniform_title_display_struct` but was looking in the wrong place.
