### PR TITLE
De-dup call number browse list; fix preview arrow placement on full page view.

### DIFF
--- a/app/assets/javascripts/jquery.preview-gallery.js
+++ b/app/assets/javascripts/jquery.preview-gallery.js
@@ -51,7 +51,8 @@
         $target.append($arrow);
 
         maxLeft = $target.width() - $arrow.width() - 1,
-        arrowLeft = parseInt($item.position().left + ($item.width()/2) - 20);
+        offset = ($('body').width() - $('#documents').width()) / 2;
+        arrowLeft = parseInt($item.position().left + ($item.width() / 2) - offset);
 
         if (arrowLeft < 0) arrowLeft = 0;
         if (arrowLeft > maxLeft) arrowLeft = maxLeft;

--- a/app/models/nearby_on_shelf.rb
+++ b/app/models/nearby_on_shelf.rb
@@ -13,11 +13,10 @@ class NearbyOnShelf
   end
 
   def items
-    @items ||= if type == "ajax"
-                 get_next_spines_from_field(options[:start], options[:field], options[:num], nil)
-               else
-                 get_nearby_items(options[:item_display], options[:preferred_barcode], options[:before], options[:after], options[:page])
-               end
+    # De-dup the list of items since duplicate records in the browse view
+    # breaks the preview feature and we're pretty sure showing the same
+    # record more than once isn't helpful.
+    @items ||= find_items.uniq { |i| i[:doc]['id'] }
   end
 
   private
@@ -28,6 +27,14 @@ class NearbyOnShelf
 
   def params
     {}
+  end
+
+  def find_items
+    if type == "ajax"
+      get_next_spines_from_field(options[:start], options[:field], options[:num], nil)
+    else
+      get_nearby_items(options[:item_display], options[:preferred_barcode], options[:before], options[:after], options[:page])
+    end
   end
 
   def get_nearby_items(itm_display, barcode, before, after, page)


### PR DESCRIPTION
De-dup item list for call number browse fixes issue where preview would not display:
<img width="1213" alt="Screen Shot 2022-08-03 at 10 29 05 AM" src="https://user-images.githubusercontent.com/458247/182644858-e4e10376-8fe6-4977-868d-de774a9327de.png">

Fix for preview arrow placement:

Before:
<img width="1393" alt="Screen Shot 2022-08-03 at 10 27 05 AM" src="https://user-images.githubusercontent.com/458247/182645230-39e0a238-8c47-46f5-9118-7ff029583421.png">

After:
<img width="1226" alt="Screen Shot 2022-08-03 at 10 27 19 AM" src="https://user-images.githubusercontent.com/458247/182645262-ff95cd20-4e47-4f9a-8b89-b9df18400240.png">

