### PR TITLE
Throw a `download` attribute on the RIS Download link

### DIFF
--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -17,7 +17,7 @@
       </li>
 
       <li class="ris" role="presentation">
-        <%= link_to t('blacklight.tools.ris_html'), search_state.to_h.merge(format: 'ris'), role: 'menuitem', tabindex: '-1' %>
+        <%= link_to t('blacklight.tools.ris_html'), search_state.to_h.merge(format: 'ris'), download: true, role: 'menuitem', tabindex: '-1' %>
       </li>
     <% end %>
 


### PR DESCRIPTION
Fixes #2959

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
