### PR TITLE
Create .folio_json export format

### DIFF
--- a/app/models/concerns/folio_json_export.rb
+++ b/app/models/concerns/folio_json_export.rb
@@ -1,0 +1,12 @@
+module FolioJsonExport
+  def self.extended(document)
+    document.will_export_as(:folio_json, 'application/json')
+  end
+
+  def export_as_folio_json
+    {
+      "holdings_json_struct" => JSON.parse(self[:holdings_json_struct].first),
+      "folio_json_struct" => JSON.parse(self[:folio_json_struct].first)
+    }.to_json
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -57,6 +57,10 @@ class SolrDocument
     document.key?(:eds_citation_exports) && document['eds_citation_exports']&.select { |e| e['id'] == 'RIS' }.any?
   end
 
+  use_extension(FolioJsonExport) do |document|
+    document.key?(:folio_json_struct)
+  end
+
   use_extension(ModsExport) do |document|
     document.key?(:modsxml)
   end

--- a/app/views/catalog/_folio_json_view.html.erb
+++ b/app/views/catalog/_folio_json_view.html.erb
@@ -4,7 +4,6 @@
             <summary>Holdings JSON</summary>
             <pre><%= JSON.pretty_generate(JSON.parse(@document.first(:holdings_json_struct))) %></pre>
         </details>
-
         <details>
             <summary>FOLIO JSON</summary>
             <pre><%= JSON.pretty_generate(JSON.parse(@document.first(:folio_json_struct))) %></pre>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,4 +3,5 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 Mime::Type.register_alias "text/xml", :mobile
+Mime::Type.register_alias "application/json", :folio_json
 Mime::Type.register_alias "application/x-Research-Info-Systems", :ris

--- a/spec/models/concerns/folio_json_export_spec.rb
+++ b/spec/models/concerns/folio_json_export_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe FolioJsonExport do
+  let(:document) do
+    SolrDocument.new(
+      id: '123',
+      holdings_json_struct: [{ 'holdings_key' => 'holdings_value' }.to_json],
+      folio_json_struct: [{ "folio_key" => "folio_value" }.to_json]
+    )
+  end
+  let(:empty_content_document) do
+    SolrDocument.new(id: '456', holdings_json_struct: [].to_json, folio_json_struct: [].to_json)
+  end
+  let(:no_key_document) do
+    SolrDocument.new(id: '789')
+  end
+
+  describe '#will_export_as' do
+    it 'true when folio_json_struct value contains content' do
+      expect(document.export_formats.key?(:folio_json)).to be true
+    end
+
+    it 'true when folio_json_struct value is an empty array' do
+      expect(empty_content_document.export_formats.key?(:folio_json)).to be true
+    end
+
+    it 'false when folio_json_struct key is missing' do
+      expect(no_key_document.export_formats.key?(:folio_json)).to be false
+    end
+  end
+
+  describe '#export_as_folio_json' do
+    it 'returns data when FOLIO JSON is present' do
+      expect(document.export_as_folio_json).to include 'holdings_value'
+      expect(document.export_as_folio_json).to include 'folio_value'
+    end
+  end
+end


### PR DESCRIPTION
This just enhances work for https://github.com/sul-dlss/SearchWorks/issues/2955 to make it easier to debug using browser JSON formatting / expand / collapse

You can navigate to e.g. `/view/13839521.folio_json` and see something like this:
![Screen Shot 2022-08-04 at 14 57 37](https://user-images.githubusercontent.com/1328900/182960037-b398b734-12e3-4db5-bf49-a32e2ed3d221.png)

The main question I have about this PR is from the [BL docs](https://www.rubydoc.info/gems/blacklight/6.0.1/Blacklight/Document/Export) about exports:

> The convention for methods contained in extensions that transform to an exportable file of some kind is “export_as_*”. For instance, “export_as_marc21” would return a String object containing valid marc21, and “export_as_marcxml” would return a String object containing valid marcxml. The tokens used after “export_as” should normally be the format names as registered with Rails Mime::Type.

^ So according to BL docs `folio_json` is a bad name since it is not a MIME type. But we already use plain `.json`, and need to do custom merging of fields rather than dumping the whole document for this folio_json.


📝 CHANGELOG update?
Create .folio_json export format