### PR TITLE
Handle missing location names in stackmap links

### DIFF
--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -9,7 +9,10 @@ class Holdings
     end
 
     def name
-      Constants::LOCS[@code]
+      location_name = Constants::LOCS[@code]
+      Honeybadger.notify("Missing location name for code: #{@code}") if location_name.nil?
+
+      location_name || @code
     end
 
     def bound_with?


### PR DESCRIPTION
Sends a honeybadger notification if we try to fetch the name
for a location that doesn't have a code->name mapping.
