### PR TITLE
Fix icon rotation on toggle in mobile menu

### DIFF
--- a/app/assets/javascripts/jquery.rotatehelper.js
+++ b/app/assets/javascripts/jquery.rotatehelper.js
@@ -4,8 +4,6 @@
 
       Usage: $(selector).rotateHelper(option);
 
-    Available option values = '90cw' [default]
-
     This plugin :
       - listens for '[show|hide].bs[collapse|dropdown]' event on callee's
         parent or element specified in 'data-target' attribute
@@ -13,22 +11,15 @@
         specified option
   */
 
-  $.fn.rotateHelper = function(rotate) {
+  $.fn.rotateHelper = function() {
     return this.each(function() {
       var $button = $(this),
           $toRotate,
           $parent,
-          cssRotate90cw = 'search-navbar-dropdown-btn-rotate-90',
           cssRotate270cw = 'search-navbar-dropdown-btn-rotate-270',
-          cssRotate;
 
-      cssRotate   = getRotateCssClass();
       $parent     = getParent();
       $toRotate = getRotatableElement();
-
-      // in SearchWorks the main Menu in .navbar-header (mobile) uses data-toggle="collapse" 
-      $parent.on('show.bs.collapse', function() { $toRotate.addClass(cssRotate90cw); });
-      $parent.on('hide.bs.collapse', function() { $toRotate.removeClass(cssRotate90cw); });
 
       // in SearchWorks nested menu items beneath the main menu (mobile) use data-toggle="dropdown" 
       // Because they are nested, stop event propation so they only impact the intended element
@@ -57,16 +48,6 @@
         if ($Icon.length !== 0) $toRotate = $Icon;
 
         return $toRotate;
-      }
-
-      function getRotateCssClass() {
-        cssRotate = cssRotate90cw; // default
-
-        if (typeof rotate !== 'undefined') {
-          if (rotate === '90cw') cssRotate = cssRotate90cw;
-        }
-
-        return cssRotate;
       }
 
     });

--- a/app/assets/javascripts/jquery.rotatehelper.js
+++ b/app/assets/javascripts/jquery.rotatehelper.js
@@ -19,16 +19,27 @@
           $toRotate,
           $parent,
           cssRotate90cw = 'search-navbar-dropdown-btn-rotate-90',
+          cssRotate270cw = 'search-navbar-dropdown-btn-rotate-270',
           cssRotate;
 
       cssRotate   = getRotateCssClass();
       $parent     = getParent();
       $toRotate = getRotatableElement();
 
-      $parent.on('show.bs.collapse', function() { $toRotate.addClass(cssRotate); });
-      $parent.on('show.bs.dropdown', function() { $toRotate.addClass(cssRotate); });
-      $parent.on('hide.bs.collapse', function() { $toRotate.removeClass(cssRotate); });
-      $parent.on('hide.bs.dropdown', function() { $toRotate.removeClass(cssRotate); });
+      // in SearchWorks the main Menu in .navbar-header (mobile) uses data-toggle="collapse" 
+      $parent.on('show.bs.collapse', function() { $toRotate.addClass(cssRotate90cw); });
+      $parent.on('hide.bs.collapse', function() { $toRotate.removeClass(cssRotate90cw); });
+
+      // in SearchWorks nested menu items beneath the main menu (mobile) use data-toggle="dropdown" 
+      // Because they are nested, stop event propation so they only impact the intended element
+      $parent.on('show.bs.dropdown', function(e) {
+        e.stopImmediatePropagation(); 
+        $toRotate.removeClass(cssRotate270cw); 
+      });
+      $parent.on('hide.bs.dropdown', function(e) {  
+        e.stopImmediatePropagation(); 
+        $toRotate.addClass(cssRotate270cw); 
+      });
 
       function getParent() {
         var $parent = $button.parent(),

--- a/app/assets/javascripts/search_navbar_services_menu.js
+++ b/app/assets/javascripts/search_navbar_services_menu.js
@@ -1,6 +1,10 @@
 Blacklight.onLoad(function() {
 
-  $('#search-navbar .navbar-header .dropdown-toggle').rotateHelper();
+  // top level Menu in navbar-header
   $('.navbar-toggle').rotateHelper();
+
+  // inner dropdown toggles such as Help under the Menu
+  // initial state is caret triangle pointed right at 270deg
+  $('#search-subnavbar-collapse .navbar-nav .dropdown-toggle').addClass('search-navbar-dropdown-btn-rotate-270').rotateHelper();
 
 });

--- a/app/assets/javascripts/search_navbar_services_menu.js
+++ b/app/assets/javascripts/search_navbar_services_menu.js
@@ -1,10 +1,8 @@
 Blacklight.onLoad(function() {
 
-  // top level Menu in navbar-header
-  $('.navbar-toggle').rotateHelper();
-
   // inner dropdown toggles such as Help under the Menu
-  // initial state is caret triangle pointed right at 270deg
+  // initial/closed state is caret triangle pointed right at 270deg
+  // expanded/open state removes the rotation
   $('#search-subnavbar-collapse .navbar-nav .dropdown-toggle').addClass('search-navbar-dropdown-btn-rotate-270').rotateHelper();
 
 });

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -17,10 +17,6 @@
     padding: 0;
   }
 
-  button.navbar-toggle.search-navbar-dropdown-btn-rotate-90 span.fa {
-    @extend .fa-rotate-90;
-  }
-
   // initial/unopened state is 270deg, triangle pointing to the right
   #search-subnavbar-collapse .navbar-nav .dropdown-toggle.search-navbar-dropdown-btn-rotate-270 span.caret {
     @extend .fa-rotate-270;

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -21,6 +21,11 @@
     @extend .fa-rotate-90;
   }
 
+  // initial/unopened state is 270deg, triangle pointing to the right
+  #search-subnavbar-collapse .navbar-nav .dropdown-toggle.search-navbar-dropdown-btn-rotate-270 span.caret {
+    @extend .fa-rotate-270;
+  }
+
   button.navbar-toggle {
     color: $white;
   }


### PR DESCRIPTION
Fixes #1461

Currently the carets in the mobile menu don't rotate at all,
and when you toggle inner menu items, it causes the main Menu hamburger to incorrectly toggle (see live gif in issue)

This PR updates some incorrect jQuery selectors and stops event propagation from the inner menu items.

current (help caret not moving)
![Screen Shot 2022-08-04 at 16 40 24](https://user-images.githubusercontent.com/1328900/182973285-7f503507-3a4b-428f-85c7-8e84aa07b3a4.png)

fix
![Screen Shot 2022-08-04 at 16 32 45](https://user-images.githubusercontent.com/1328900/182973307-47c0b357-b36e-48d6-bf94-a1756f546383.png)

current (main menu icon is in "closed" state even though it is open)
![Screen Shot 2022-08-04 at 16 42 50](https://user-images.githubusercontent.com/1328900/182973450-b5877656-9977-43e1-bf10-12853d02d010.png)


fix
![Screen Shot 2022-08-04 at 16 44 09](https://user-images.githubusercontent.com/1328900/182973492-5d0fbc4f-0659-4175-ab6f-e148ce548ff3.png)





📝 CHANGELOG update?
Fix icon rotation in mobile menu
