### PR TITLE
Use before/after shelfkey offsets to drive browse nearby pagination

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,6 @@ RSpec/DescribeClass:
 Metrics/ParameterLists:
   Exclude:
     - 'app/components/**/*'
+
+RSpec/MessageSpies:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -900,12 +900,6 @@ RSpec/LetSetup:
     - 'spec/controllers/recent_selections_controller_spec.rb'
     - 'spec/presenters/facet_options_presenter_spec.rb'
 
-# Offense count: 102
-# Configuration parameters: .
-# SupportedStyles: have_received, receive
-RSpec/MessageSpies:
-  EnforcedStyle: receive
-
 # Offense count: 4
 RSpec/MultipleDescribes:
   Exclude:

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -19,7 +19,7 @@ class BrowseController < ApplicationController
   def nearby
     respond_to do |format|
       format.html do
-        render browse: @document_list, layout: false
+        render layout: false
       end
     end
   end

--- a/app/models/concerns/solr_holdings.rb
+++ b/app/models/concerns/solr_holdings.rb
@@ -44,6 +44,8 @@ module SolrHoldings
     end
   end
 
+  attr_writer :preferred_callnumber
+
   def cdl?
     druid && holdings.callnumbers.any? { |call| call.home_location == 'CDL' }
   end

--- a/app/models/nearby_on_shelf.rb
+++ b/app/models/nearby_on_shelf.rb
@@ -1,117 +1,64 @@
 class NearbyOnShelf
-  attr_reader :item_display, :barcode, :per, :page, :search_service
+  def self.around_callnumber(callnumber, search_service:, per: 24, **kwargs)
+    return [] unless callnumber
 
-  delegate :shelfkey, :reverse_shelfkey, to: :current_callnumber
+    before = NearbyOnShelf.reverse(search_service: search_service).callnumbers(callnumber.reverse_shelfkey, per: per / 2, **kwargs)
+    current_and_after = NearbyOnShelf.forward(search_service: search_service).callnumbers(callnumber.shelfkey, per: per / 2, incl: true, **kwargs)
 
-  def initialize(item_display:, barcode:, search_service:, per: 24, page: 0)
-    @item_display = Array(item_display)
-    @barcode = barcode
-    @per = per
-    @page = page
+    # it's possible a document occurs before + after the current callnumber, so we have to re-uniq the result
+    (before + current_and_after).uniq { |x| x.document&.id }
+  end
+
+  def self.forward(field: 'shelfkey', **kwargs)
+    NearbyOnShelf.new(field: field, **kwargs)
+  end
+
+  def self.reverse(field: 'reverse_shelfkey', **kwargs)
+    NearbyOnShelf.new(field: field, **kwargs)
+  end
+
+  attr_reader :field, :search_service
+
+  delegate :repository, to: :search_service
+
+  def initialize(field:, search_service:)
+    @field = field
     @search_service = search_service
   end
 
-  def document_list
-    return [] unless current_callnumber
+  # given a shelfkey or reverse shelfkey (for a lopped call number), get the
+  #  text for the next window of items
+  # @return [Array<Holdings::Callnumber>] a sorted array of callnumbers
+  def callnumbers(starting_value, per: 24, incl: false, max_docs: 100)
+    desired_values = fetch_next_terms('terms.limit' => per, 'terms.lower' => starting_value, 'terms.lower.incl' => incl)
 
-    # De-dup the list of items since duplicate records in the browse view
-    # breaks the preview feature and we're pretty sure showing the same
-    # record more than once isn't helpful.
-    nearby_items.pluck(:doc).uniq(&:id)
+    # Get the documents for a set of shelf keys
+    response, = search_service.search_results do |builder|
+      builder.rows = max_docs
+      builder.where(field => desired_values.compact)
+    end
+
+    # Get only the callnumber objects that match the shelfkeys
+    spines = response.documents.flat_map(&:callnumbers).select do |callnumber|
+      desired_values.include?(callnumber.send(field))
+    end
+
+    spines.uniq(&:spine_sort_key).uniq { |x| x.document&.id }.sort_by(&:spine_sort_key).each do |callnumber|
+      callnumber.document.preferred_callnumber = callnumber
+    end
   end
 
   private
 
-  def nearby_items
-    if page == 0
-      # get preceding bookspines
-      preceding_spines_from_field +
-        # multiple bib records can have the same shelfkey, so we need to
-        # query solr to get all (some?) of them before looking at the
-        # other shelfkeys.
-        spines_from_field_values("shelfkey", [shelfkey]) +
-        # get following bookspines
-        following_spines_from_field
-    elsif page < 0 # page is negative so we need to get the preceding docs
-      preceding_spines_from_field
-    elsif page > 0 # page is positive, so we need to get the following bookspines
-      following_spines_from_field
-    end
-  end
-
-  def preceding_spines_from_field
-    next_spines_from_field('reverse_shelfkey', reverse_shelfkey)
-  end
-
-  def following_spines_from_field
-    next_spines_from_field('shelfkey', shelfkey)
-  end
-
-  # given a shelfkey or reverse shelfkey (for a lopped call number), get the
-  #  text for the next window of nearby items
-  def next_spines_from_field(field_name, starting_value)
-    number_of_shelfkeys_to_request = per * page.abs + (per / 2).floor
-
-    desired_values = fetch_next_terms(field_name, starting_value, number_of_shelfkeys_to_request).keys
-
-    # perform client-side windowing to get the desired number of items
-    # because the solr terms component will include everything between the current
-    # item and the last item needed for the range
-    desired_values = desired_values.last(per) unless page.zero?
-
-    spines_from_field_values(field_name, desired_values)
-  end
-
-  def spines_from_field_values(field_name, desired_values)
-    # Get the documents for a set of shelf keys
-    response, docs = search_service.search_results do |builder|
-      builder.where(field_name => desired_values.compact)
-    end
-
-    spines = docs.flat_map do |doc|
-      spines_from_doc(doc, field_name, desired_values.compact)
-    end
-
-    spines.uniq { |spine| spine[:sort_key] }.sort_by { |spine| spine[:sort_key] }
-  end
-
-  # @param [SolrDocument] doc
-  # @param [String] field_name
-  # @param [Array<String>] desired_values the shelfkeys or reverse shelfkeys to filter on
-  def spines_from_doc(doc, field_name, desired_values)
-    # This winnows down the holdings hashs on only ones where the desired values includes the shelfkey or reverse shelfkey using a very quick select statment
-    item_array = doc.holdings.callnumbers.select do |callnumber|
-      desired_values.include?(callnumber.send(field_name))
-    end
-
-    item_array.map do |callnumber|
-      { doc: doc, sort_key: callnumber.spine_sort_key }
-    end
-  end
-
-  def fetch_next_terms(field_name, curr_value, how_many)
+  def fetch_next_terms(params)
     # TermsComponent Query to get the terms
     solr_params = {
-      'terms.fl' => field_name,
-      'terms.lower' => curr_value,
-      'terms.lower.incl' => false,
+      'terms.fl' => field,
       'terms.sort' => 'index',
-      'terms.limit' => how_many,
       'json.nl' => 'map'
-    }
+    }.merge(params)
 
-    solr_response = Blacklight.default_index.connection.alphaTerms({ params: solr_params })
-
-    solr_response.dig('terms', field_name) || {}
-  end
-
-  def current_callnumber
-    return if barcode.blank?
-
-    @current_callnumber ||= begin
-      callnumbers = item_display.map { |item| Holdings::Callnumber.new(item) }
-
-      callnumbers.find { |callnumber| callnumber.barcode.starts_with?(barcode) }
-    end
+    solr_response = repository.send_and_receive('alphaTerms', solr_params)
+    solr_response.dig('terms', field)&.keys || []
   end
 end

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -17,19 +17,19 @@
 <% end %>
 
 <div id="content" class="callnumber-browse">
-  <% if @document_list.present? %>
+  <% if @callnumbers.present? %>
     <div class="panel panel-default browse-toolbar">
-      <%= link_to(browse_index_path(browse_params.merge(page: browse_params[:page].to_i-1)), class: 'btn btn-default btn-sm') do %>
+      <%= link_to(browse_index_path(browse_params.merge(before: @callnumbers.first.reverse_shelfkey, after: nil)), class: 'btn btn-default btn-sm') do %>
         <i class="fa fa-arrow-left" aria-hidden="true"></i><span class="sr-only">Previous</span>
       <% end %>
-      <%= @document_list.first.holdings.callnumbers.first.callnumber %> - <%= @document_list.last.holdings.callnumbers.first.callnumber %>
-      <%= link_to(browse_index_path(browse_params.merge(page: browse_params[:page].to_i+1)), class: 'btn btn-default btn-sm') do %>
+      <%= @callnumbers.first.callnumber %> - <%= @callnumbers.last.callnumber %>
+      <%= link_to(browse_index_path(browse_params.merge(before: nil, after: @callnumbers.last.shelfkey)), class: 'btn btn-default btn-sm') do %>
         <i class="fa fa-arrow-right" aria-hidden="true"></i><span class="sr-only">Next</span>
       <% end %>
       <div class='pull-right'>
         <%= render 'catalog/view_type_group' %>
       </div>
     </div>
-    <%= render_document_index(@document_list) %>
+    <%= render_document_index(@callnumbers.map(&:document)) %>
   <% end %>
 </div>

--- a/app/views/browse/nearby.html.erb
+++ b/app/views/browse/nearby.html.erb
@@ -1,3 +1,3 @@
-  <% if @document_list.present? %>
-    <%= render_document_index(@document_list) %>
+  <% if @callnumbers.present? %>
+    <%= render_document_index(@callnumbers.map(&:document)) %>
   <% end %>

--- a/spec/models/nearby_on_shelf_spec.rb
+++ b/spec/models/nearby_on_shelf_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe NearbyOnShelf do
+  subject(:service) { described_class.new(field: field, search_service: search_service) }
+
+  let(:field) { 'shelfkey' }
+  let(:blacklight_config) { BrowseController.blacklight_config }
+  let(:search_service) { Blacklight::SearchService.new(config: blacklight_config, search_state: search_state) }
+  let(:search_state) { Blacklight::SearchState.new({}, blacklight_config, context) }
+  let(:context) { instance_double(BrowseController, controller_name: 'browse', action_name: 'index') }
+  let(:repository) { instance_double(Blacklight::Solr::Repository) }
+
+  let(:document_response) do
+    instance_double(Blacklight::Solr::Response, grouped?: false, documents: documents)
+  end
+  let(:documents) do
+    [
+      SolrDocument.new(id: '1', title_sort: '', pub_date: '', item_display: ['000 -|- -|- -|- -|- -|- -|- A', '001 -|- -|- -|- -|- -|- -|- A']),
+      SolrDocument.new(id: '3', title_sort: '', pub_date: '', item_display: ['002 -|- -|- -|- -|- -|- -|- C']),
+      SolrDocument.new(id: '2', title_sort: '', pub_date: '', item_display: ['003 -|- -|- -|- -|- -|- -|- NOT_RELATED', '004 -|- -|- -|- -|- -|- -|- B'])
+    ]
+  end
+
+  let(:terms_response) do
+    { terms: { field => { 'A' => 1, 'B' => 2, 'C' => 3 } } }.with_indifferent_access
+  end
+
+  before do
+    allow(blacklight_config).to receive(:repository).and_return(repository)
+    allow(repository).to receive(:send_and_receive).with('alphaTerms', hash_including('terms.fl' => field)).and_return(terms_response)
+    allow(repository).to receive(:search).and_return(document_response)
+  end
+
+  describe '#callnumbers' do
+    it 'grabs the next set of terms from Solr' do
+      service.callnumbers('A', incl: true, per: 3)
+
+      expect(repository).to have_received(:send_and_receive).with('alphaTerms', hash_including('terms.fl' => 'shelfkey', 'terms.lower' => 'A', 'terms.limit' => 3))
+    end
+
+    it 'queries solr to get the documents that contain the next call numbers' do
+      service.callnumbers('A', incl: true, per: 3)
+
+      expect(repository).to have_received(:search).with(have_attributes(to_h: hash_including('q' => '{!lucene}shelfkey:(A OR B OR C)')))
+    end
+
+    it 'de-dupes shelfkeys + documents' do
+      expect(service.callnumbers('A', incl: true, per: 3)).to have_attributes(length: 3)
+    end
+
+    it 'excludes call numbers that are not in the terms response' do
+      expect(service.callnumbers('A', incl: true, per: 3)).not_to include(have_attributes(shelfkey: 'NOT_RELATED'))
+    end
+
+    it 'resorts the documents by their callnumber' do
+      expect(service.callnumbers('A', incl: true, per: 3).map(&:shelfkey)).to eq %w[A B C]
+    end
+
+    it 'set the preferred callnumber on the document so it can be used in the view' do
+      expect(service.callnumbers('A', incl: true, per: 3).map(&:document).map(&:preferred_callnumber).map(&:shelfkey)).to eq %w[A B C]
+    end
+  end
+end


### PR DESCRIPTION
Update browse nearby to use before/after shelfkey offsets (replacing forward/backward pagination from a known point). This   ensures consistent + complete pagination through high-count shelfkeys (but may also need https://github.com/sul-dlss/searchworks_traject_indexer/pull/679 for best display)
