### PR TITLE
Remove outdated modal z-index workaround

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -34,13 +34,6 @@
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-// Temporarily added since
-// our modal-dialog is not
-// getting its z-index set
-.modal-dialog {
-  z-index: 1040;
-}
-
 .dl-horizontal dt {
   text-align: left;
   width: 10em;


### PR DESCRIPTION
If people agree with my writeup in the ticket, this PR closes #1004
 
I believe the Bootstrap folks fixed the underlying issue that this workaround addressed. The reported bug only occurred in production though, so not sure the best way to test.
 
