### PR TITLE
Re-style buttons in Selection lists toolbar

### DIFF
--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -1,4 +1,4 @@
-#sortAndPerPage, .pagination-search-widgets {
+.sort-and-per-page .pagination-search-widgets {
   border-bottom: 1px solid $pagination-border;
   margin-bottom: 1em;
   padding-bottom: 1em;
@@ -10,11 +10,11 @@
   padding-bottom: $padding-base-vertical;
 }
 
-#sortAndPerPage .dropdown-toggle {
+.sort-and-per-page .dropdown-toggle {
   cursor: pointer;
 }
 
-.no-js #sortAndPerPage {
+.no-js .sort-and-per-page {
   & {
     @extend .clearfix;
   }

--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -57,3 +57,8 @@ small,
 summary {
   display: list-item;
 }
+
+// make the button-style links in the Selections toolbar more compact than default .btn padding
+#bookmarksWidgets > *, #bookmarksWidgets > #tools-dropdown > .btn {
+    padding: 4px 10px;
+}

--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -11,7 +11,7 @@ $btn-preview-border: darken($sul-btn-preview-bg, 9.8%);
   text-decoration: none;
 }
 
-.btn-sul-toolbar, #citeLink {
+.btn-sul-toolbar {
   color: $btn-sul-toolbar-bar-color !important;
   background-color: $btn-sul-toolbar-bar-bg;
   margin: 0 5px;

--- a/app/assets/stylesheets/modules/record-toolbar.scss
+++ b/app/assets/stylesheets/modules/record-toolbar.scss
@@ -80,10 +80,6 @@
   display: inline-block;
 }
 
-#citeLink {
-  padding: 10px 5px;
-}
-
 // Select dropdown
 div.record-toolbar > div > div > ul > li:nth-child(3) > form > div > label {
   &:hover, &:focus, &:active {

--- a/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
+++ b/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
@@ -1,11 +1,7 @@
-#sortAndPerPage {
+.sul-toolbar.sort-and-per-page { 
   padding: 4px 0;
   margin-top: .8em;
   border-bottom: none;
-
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 
   .dropdown-menu {
     @include toolbar-dropdown;
@@ -23,6 +19,39 @@
   #search-results-toolbar {
     ul li a i.active-icon {
       margin-left: -17px;
+    }
+  }
+}
+
+@media (min-width: $screen-xs-min) { 
+  .sort-and-per-page {
+    #search-results-toolbar {
+      position: relative;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+}
+
+@media (max-width: $screen-xs-max) { 
+  .sort-and-per-page {
+    padding: 4px 0;
+    margin-top: .8em;
+    border-bottom: none;
+    display: flex;
+    align-items: center;
+
+    #search-results-toolbar {
+      display: block;
+      margin-left: 8px;
+
+      #citeLink, #tools-dropdown, .clear-bookmarks {
+        margin: 3px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/print/styles.scss
+++ b/app/assets/stylesheets/print/styles.scss
@@ -24,7 +24,7 @@
 }
 
 // Do not display these elements
-.navbar, #topnav, #search-navbar-container, #facets, #sortAndPerPage, .record-toolbar, a.remove, .index-document-functions, footer, #sul-footer-container, #global-footer, .additional-results, .pagination, .side-nav-minimap, .library-location-heading img, .record-browse-nearby, .tech-details a, a.btn, .gallery-buttons, .preview-button-container, .google-preview {
+.navbar, #topnav, #search-navbar-container, #facets, .sort-and-per-page, .record-toolbar, a.remove, .index-document-functions, footer, #sul-footer-container, #global-footer, .additional-results, .pagination, .side-nav-minimap, .library-location-heading img, .record-browse-nearby, .tech-details a, a.btn, .gallery-buttons, .preview-button-container, .google-preview {
   display: none !important;
 }
 a[href]:after {

--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -1,6 +1,6 @@
 <span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
 <div id="tools-dropdown" class="btn-group">
-  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@bookmarks)).html_safe %>
   </button>
   <ul class="dropdown-menu" role="menu">

--- a/app/views/articles/_search_header.html.erb
+++ b/app/views/articles/_search_header.html.erb
@@ -1,11 +1,1 @@
-<div id="sortAndPerPage" class="sul-toolbar">
-  <%= render partial: "catalog/paginate_compact", object: @response %>
-  <div id="search-results-toolbar" class="search-widgets">
-    <%= render partial: 'catalog/view_type_group' %>
-    <%= render partial: 'sort_widget' %>
-    <%= render partial: 'shared/per_page_widget' %>
-    <% unless bookmarks? %>
-      <%= render partial: 'select_all_widget' %>
-    <% end %>
-  </div>
-</div>
+<%= render partial: "catalog/sort_and_per_page", object: @response %>

--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -1,6 +1,6 @@
 <span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
 <div id="tools-dropdown" class="btn-group">
-  <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@response)).html_safe %>
   </button>
   <ul class="dropdown-menu" role="menu">

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,16 +1,39 @@
 <% ivar_to_paginate =  article_selections? ? @bookmarks : @response %>
-<div id="sortAndPerPage" class="sul-toolbar">
-  <%= render partial: "paginate_compact", object: ivar_to_paginate %>
+<!-- Markup for sm screens and larger -->
+<div class="sort-and-per-page sul-toolbar selection-list-toolbar hidden-xs">
+  <div id="search-results-toolbar" class="search-widgets">
+    <%= render partial: "paginate_compact", object: ivar_to_paginate %>
+    <% if bookmarks? %>
+      <span id="bookmarksWidgets">
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(article_selections? ? :citation_articles : :citation_solr_documents, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-default', :data => {:ajax_modal => "trigger"}} %>
+        <%= render "tool_dropdown" %>
+        <%= link_to clear_bookmarks_path(type:  article_selections? ? 'article' : 'catalog'), method: :delete, class: 'btn btn-default', data: { confirm: t("searchworks.bookmarks.#{article_selections? ? 'article' : 'catalog'}.clear.action_confirm") } do %>
+          <i class="fa fa-times" aria-hidden="true"></i> Clear list
+        <% end %>
+      </span>
+    <% end %>
+    <span id="viewWidgets">
+      <%= render partial: 'view_type_group' %>
+      <%= render partial: 'sort_widget' %>
+      <%= render partial: 'shared/per_page_widget' %>
+      <% unless bookmarks? %>
+        <%= render partial: 'select_all_widget' %>
+      <% end %>
+    </span>
+  </div>
+</div>
 
+<!-- Markup for xs screens -->
+<div class="sort-and-per-page sul-toolbar visible-xs-block">
+  <%= render partial: "paginate_compact", object: ivar_to_paginate %>
   <div id="search-results-toolbar" class="search-widgets">
     <% if bookmarks? %>
-      <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(article_selections? ? :citation_articles : :citation_solr_documents, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-sul-toolbar', :data => {:ajax_modal => "trigger"}} %>
-      <%= render "tool_dropdown" %>
-      <%= link_to clear_bookmarks_path(type:  article_selections? ? 'article' : 'catalog'), method: :delete, class: 'btn btn-sul-toolbar', data: { confirm: t("searchworks.bookmarks.#{article_selections? ? 'article' : 'catalog'}.clear.action_confirm") } do %>
-        <i class="fa fa-times" aria-hidden="true"></i> Clear list
-      <% end %>
+        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(article_selections? ? :citation_articles : :citation_solr_documents, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-default', :data => {:ajax_modal => "trigger"}} %>
+        <%= render "tool_dropdown" %>
+        <%= link_to clear_bookmarks_path(type:  article_selections? ? 'article' : 'catalog'), method: :delete, class: 'btn btn-default clear-bookmarks', data: { confirm: t("searchworks.bookmarks.#{article_selections? ? 'article' : 'catalog'}.clear.action_confirm") } do %>
+          <i class="fa fa-times" aria-hidden="true"></i> Clear list
+        <% end %>
     <% end %>
-
     <%= render partial: 'view_type_group' %>
     <%= render partial: 'sort_widget' %>
     <%= render partial: 'shared/per_page_widget' %>

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -37,7 +37,13 @@ feature "Databases Access Point" do
     expect(page).to have_css('h2', text: '4 catalog results')
     expect(page).to have_css('h3', text: /Selected Database \d/, count: 4)
 
-    within '#sort-dropdown' do
+    # first is displayed only on desktop layout
+    within all('#sort-dropdown')[0] do
+      expect(page).to have_content('Sort by title')
+    end
+
+    # second is displayed only on mobile layout
+    within all('#sort-dropdown')[1] do
       expect(page).to have_content('Sort by title')
     end
   end

--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -12,7 +12,7 @@ feature "Results Toolbar", js: true do
     fill_in "q", with: ''
     click_button 'search'
 
-    within "#sortAndPerPage" do
+    within ".sort-and-per-page" do
       within "div.page_links" do
         expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: /Previous/)
         expect(page).to have_css("span.page_entries", text: /1 - 20/, visible: true)

--- a/spec/features/blacklight_customizations/sort_options_spec.rb
+++ b/spec/features/blacklight_customizations/sort_options_spec.rb
@@ -6,7 +6,17 @@ feature "Sort options" do
     fill_in 'q', with: ''
     click_button 'search'
 
-    within('#sort-dropdown') do
+    # first is displayed only on desktop layout
+    within(all('#sort-dropdown')[0]) do
+      expect(page).to have_css("li a", text: 'relevance')
+      expect(page).to have_css("li a", text: 'year (new to old)')
+      expect(page).to have_css("li a", text: 'year (old to new)')
+      expect(page).to have_css("li a", text: 'author')
+      expect(page).to have_css("li a", text: 'title')
+    end
+
+    # second is displayed only on mobile layout
+    within(all('#sort-dropdown')[1]) do
       expect(page).to have_css("li a", text: 'relevance')
       expect(page).to have_css("li a", text: 'year (new to old)')
       expect(page).to have_css("li a", text: 'year (old to new)')

--- a/spec/features/blacklight_customizations/view_options_spec.rb
+++ b/spec/features/blacklight_customizations/view_options_spec.rb
@@ -6,7 +6,20 @@ feature "View options" do
     fill_in 'q', with: ''
     click_button 'search'
 
-    within('#view-type-dropdown') do
+    # first is displayed only on desktop layout
+    within all('#view-type-dropdown')[0] do
+      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'normal')
+      expect(page).to have_css("li a.view-type-list i.fa.fa-th-list")
+
+      expect(page).to have_css("li a.view-type-gallery span.view-type-label", text: 'gallery')
+      expect(page).to have_css("li a.view-type-gallery i.fa.fa-th")
+
+      expect(page).to have_css("li a.view-type-brief span.view-type-label", text: 'brief')
+      expect(page).to have_css("li a.view-type-brief i.fa.fa-align-justify")
+    end
+
+    # second is displayed only on mobile layout
+    within all('#view-type-dropdown')[1] do
       expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'normal')
       expect(page).to have_css("li a.view-type-list i.fa.fa-th-list")
 

--- a/spec/features/responsive/results_toolbar_spec.rb
+++ b/spec/features/responsive/results_toolbar_spec.rb
@@ -7,7 +7,7 @@ describe "Responsive results toolbar", js: true, feature: true do
       fill_in "q", with: ''
       click_button 'search'
 
-      within "#sortAndPerPage" do
+      within ".sort-and-per-page" do
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Next", visible: true)
         expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: true)
         expect(page).to have_css("button.btn.btn-sul-toolbar i.fa.fa-th-list", visible: true)
@@ -25,7 +25,7 @@ describe "Responsive results toolbar", js: true, feature: true do
       fill_in "q", with: ''
       click_button 'search'
 
-      within "#sortAndPerPage" do
+      within ".sort-and-per-page" do
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Next", visible: true)
         expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: true)
         expect(page).not_to have_css("button.btn.btn-sul-toolbar i.fa.fa-th-list", visible: true)
@@ -42,7 +42,7 @@ describe "Responsive results toolbar", js: true, feature: true do
       fill_in "q", with: ''
       click_button 'search'
 
-      within "#sortAndPerPage" do
+      within ".sort-and-per-page" do
         expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Next", visible: false)
         expect(page).not_to have_css("a.btn.btn-sul-toolbar", text: "Previous", visible: false)
         expect(page).not_to have_css("button.btn.btn-sul-toolbar i.fa.fa-th-list", visible: true)

--- a/spec/features/sort_and_per_page_dropdown_spec.rb
+++ b/spec/features/sort_and_per_page_dropdown_spec.rb
@@ -9,7 +9,7 @@ describe 'Sort and per page toolbar', js: true, feature: true do
     end
 
     it 'should display active icon on the current active view' do
-      within '#sortAndPerPage' do
+      within '.sort-and-per-page' do
         page.find('button.btn.btn-sul-toolbar', text: 'View').click
 
         expect(page).to have_css('a.view-type-list i.active-icon')
@@ -17,7 +17,7 @@ describe 'Sort and per page toolbar', js: true, feature: true do
 
       visit search_catalog_path(q: '', view: 'gallery', search_field: 'search')
 
-      within '#sortAndPerPage' do
+      within '.sort-and-per-page' do
         page.find('button.btn.btn-sul-toolbar', text: 'View').click
 
         expect(page).not_to have_css('a.view-type-list i.active-icon')
@@ -35,13 +35,13 @@ describe 'Sort and per page toolbar', js: true, feature: true do
     end
 
     it 'should display default correctly' do
-      within '#sortAndPerPage' do
+      within '.sort-and-per-page' do
         expect(page).to have_css('button.btn.btn-sul-toolbar', text: 'Sort by relevance', visible: true)
       end
     end
 
     it 'should change to current sort' do
-      within '#sortAndPerPage' do
+      within '.sort-and-per-page' do
         expect(page).not_to have_css('button.btn.btn-sul-toolbar', text: 'Sort by author', visible: true)
         page.find('button.btn.btn-sul-toolbar', text: 'Sort by relevance').click
         within 'a', text: 'relevance' do
@@ -68,7 +68,7 @@ describe 'Sort and per page toolbar', js: true, feature: true do
     end
 
     it 'should display active icon on the current active per page' do
-      within '#sortAndPerPage' do
+      within '.sort-and-per-page' do
         page.find('button.btn.btn-sul-toolbar', text: '20 per page').click
         within 'a', text: '20' do
           expect(page).to have_css('i.active-icon')

--- a/spec/features/tabbed_selections_spec.rb
+++ b/spec/features/tabbed_selections_spec.rb
@@ -81,10 +81,11 @@ RSpec.describe 'Tabbed selections UI', type: :feature do
   end
 
   describe 'clearing lists' do
-    it 'clears article lists' do
+    it 'clears article lists desktop' do
       visit '/selections/articles'
 
-      within('#sortAndPerPage') do
+      # first .sort-and-per-page is desktop layout
+      within(first('.sort-and-per-page')) do
         click_link 'Clear list'
       end
 
@@ -95,7 +96,8 @@ RSpec.describe 'Tabbed selections UI', type: :feature do
     it 'clears catalog lists' do
       visit '/selections'
 
-      within('#sortAndPerPage') do
+      # first .sort-and-per-page is desktop layout
+      within(first('.sort-and-per-page')) do
         click_link 'Clear list'
       end
 


### PR DESCRIPTION
Fixes #2151 
-- according to this[ umbrella ticket](https://github.com/sul-dlss/SearchWorks/issues/1885), was based on user feedback

~~I didn't know what "centering" meant, so just styled the buttons. @ggeisler I'd be interested in your feedback and input especially considering this ticket is so old!~~

**Edit 9.1.22:** updated with centering and modified mobile view (reviewed/approved by @ggeisler yesterday, thank you!)

Before:
![Screen Shot 2022-08-15 at 16 30 52](https://user-images.githubusercontent.com/1328900/184755804-2300761e-b9e1-46fe-b9e0-ad76f2aab2d4.png)

After:
![Screen Shot 2022-09-01 at 09 31 28](https://user-images.githubusercontent.com/1328900/187966000-c608cfa2-f9be-4808-872c-2b76347995b4.png)



Before mobile:
![Screen Shot 2022-08-15 at 16 58 31](https://user-images.githubusercontent.com/1328900/184755905-27dd8ed8-86a4-4047-a49b-d5c6ac16328e.png)


After mobile:

![Screen Shot 2022-08-31 at 17 02 00](https://user-images.githubusercontent.com/1328900/187966013-1a0ae16e-afc9-4a10-9138-d1320541230f.png)

