### PR TITLE
Move HTML link generation into Link class (replaces attribute from Solr)

### DIFF
--- a/app/models/concerns/eds_links.rb
+++ b/app/models/concerns/eds_links.rb
@@ -58,12 +58,12 @@ module EdsLinks
 
     def to_searchworks_link(categories = [])
       SearchWorks::Links::Link.new(
-        text:     label,
-        href:     url,
-        fulltext: present? && show?(categories, category),
-        sfx:      sfx?,
-        ill:      ill?,
-        type:     type,
+        link_text: label,
+        href:      url,
+        fulltext:  present? && show?(categories, category),
+        sfx:       sfx?,
+        ill:       ill?,
+        type:      type,
         stanford_only: pdf?
       )
     end

--- a/app/models/concerns/hathi_links.rb
+++ b/app/models/concerns/hathi_links.rb
@@ -9,8 +9,7 @@ module HathiLinks
     return unless ht_links.present?
 
     SearchWorks::Links::Link.new(
-      html: "<a href=\"#{ht_links.url}\">Full text via HathiTrust</a>",
-      text: 'Full text via HathiTrust',
+      link_text: 'Full text via HathiTrust',
       href: ht_links.url,
       fulltext: true,
       stanford_only: !ht_links.publicly_available?,

--- a/app/models/concerns/index_links.rb
+++ b/app/models/concerns/index_links.rb
@@ -27,8 +27,7 @@ module IndexLinks
 
     def to_searchworks_link
       SearchWorks::Links::Link.new(
-        html: link_html,
-        text: link_text,
+        link_text: link_text,
         href: link_field,
         fulltext: link_is_fulltext?,
         stanford_only: link_is_stanford_only?,
@@ -39,10 +38,6 @@ module IndexLinks
     end
 
     private
-
-    def link_html
-      "<a href='#{link_field}'#{" class='sfx'".html_safe if link_is_sfx?}>#{link_text}</a>"
-    end
 
     def link_text
       if link_is_finding_aid?

--- a/lib/search_works/links.rb
+++ b/lib/search_works/links.rb
@@ -39,26 +39,38 @@ module SearchWorks
     end
 
     class Link
-      attr_accessor :html, :text, :href, :file_id, :druid, :type, :sort
+      include ActionView::Helpers::TagHelper
+
+      attr_accessor :href, :file_id, :druid, :type, :sort
 
       def initialize(options = {})
-        @html = options[:html]
-        @text = options[:text]
-        @href = options[:href]
-        @fulltext = options[:fulltext]
-        @stanford_only = options[:stanford_only]
-        @finding_aid = options[:finding_aid]
-        @sfx = options[:sfx]
-        @managed_purl = options[:managed_purl]
-        @file_id = options[:file_id]
+        @additional_text = options[:additional_text]
+        @casalini = options[:casalini]
         @druid = options[:druid]
+        @file_id = options[:file_id]
+        @finding_aid = options[:finding_aid]
+        @fulltext = options[:fulltext]
+        @href = options[:href]
         @ill = options[:ill]
-        @type = options[:type]
+        @link_text = options[:link_text]
+        @link_title = options[:link_title]
+        @managed_purl = options[:managed_purl]
+        @sfx = options[:sfx]
         @sort = options[:sort]
+        @stanford_only = options[:stanford_only]
+        @type = options[:type]
       end
 
       def ==(other)
-        [@html, @fulltext, @stanford_only, @finding_aid, @sfx] == [other.html, other.fulltext?, other.stanford_only?, other.finding_aid?, other.sfx?]
+        [@href, @fulltext, @stanford_only, @finding_aid, @sfx] == [other.href, other.fulltext?, other.stanford_only?, other.finding_aid?, other.sfx?]
+      end
+
+      def html
+        @html ||= [link_html, casalini_text, additional_text_html].compact.join(' ').strip
+      end
+
+      def text
+        @text ||= [@link_text, casalini_text, additional_text_html].compact.join(' ').strip
       end
 
       def fulltext?
@@ -83,6 +95,24 @@ module SearchWorks
 
       def ill?
         @ill
+      end
+
+      private
+
+      def additional_text_html
+        content_tag(:span, @additional_text, class: 'additional-link-text') if @additional_text
+      end
+
+      def casalini_text
+        '(source: Casalini)' if @casalini
+      end
+
+      def link_class
+        'sfx' if @sfx
+      end
+
+      def link_html
+        content_tag(:a, @link_text, href: @href, title: @link_title, class: link_class)
       end
     end
   end

--- a/lib/search_works/links.rb
+++ b/lib/search_works/links.rb
@@ -66,11 +66,11 @@ module SearchWorks
       end
 
       def html
-        @html ||= [link_html, casalini_text, additional_text_html].compact.join(' ').strip
+        @html ||= safe_join([link_html, casalini_text, additional_text_html].compact, ' ')
       end
 
       def text
-        @text ||= [@link_text, casalini_text, additional_text_html].compact.join(' ').strip
+        @text ||= safe_join([@link_text, casalini_text, additional_text_html].compact, ' ')
       end
 
       def fulltext?

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -4,7 +4,7 @@ describe AccessPanels::OnlineComponent, type: :component do
   include ModsFixtures
   include Marc856Fixtures
 
-  let(:fulltext) { described_class.new(document: SolrDocument.new(marc_links_struct: [{ html: "<a title='' href='https://library.stanford.edu'>Link text</a> ", text: "Link text", href: "https://library.stanford.edu", fulltext: true, stanford_only: nil, finding_aid: false, managed_purl: nil, file_id: nil, druid: nil }])) }
+  let(:fulltext) { described_class.new(document: SolrDocument.new(marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true, stanford_only: nil, finding_aid: false, managed_purl: nil, file_id: nil, druid: nil }])) }
   let(:supplemental) { described_class.new(document: SolrDocument.new) }
   let(:eds_links) do
     described_class.new(
@@ -24,7 +24,7 @@ describe AccessPanels::OnlineComponent, type: :component do
     described_class.new(
       document: SolrDocument.new(
         collection: ['12345'],
-        marc_links_struct: [{ html: "<a title='' href='https://library.stanford.edu'>Link text</a> ", text: "Link text", href: "https://library.stanford.edu", fulltext: true, stanford_only: nil, finding_aid: false, managed_purl: nil, file_id: nil, druid: nil }]
+        marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true, stanford_only: nil, finding_aid: false, managed_purl: nil, file_id: nil, druid: nil }]
       )
     )
   end
@@ -91,7 +91,7 @@ describe AccessPanels::OnlineComponent, type: :component do
       links = sfx.links
       expect(links.length).to eq 1
       expect(links.first).to be_sfx
-      expect(links.first.html).to match %r{^<a href=.*class='sfx'>Find full text<\/a>$}
+      expect(links.first.html).to match %r{^<a href=.*class="sfx">Find full text<\/a>$}
     end
 
     it 'returns fulltext links for collection members' do
@@ -167,21 +167,21 @@ describe AccessPanels::OnlineComponent, type: :component do
 
   describe "marc record" do
     it "should render the panel with a link" do
-      document = SolrDocument.new(marc_links_struct: [{ html: '<a href="...">Link text</a>', fulltext: true }])
+      document = SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }])
       render_inline(described_class.new(document: document))
       expect(page).to have_css(".panel-online")
       expect(page).to have_css(".panel-heading", text: "Available online")
       expect(page).to have_css("ul.links li a", text: "Link text")
     end
     it "should add the stanford-only class to Stanford only resources" do
-      document = SolrDocument.new(marc_links_struct: [{ html: "<a href='...'>Link text</a>'<span class='additional-link-text'>4 at one time</span>", fulltext: true, stanford_only: true }])
+      document = SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', additional_text: '4 at one time', fulltext: true, stanford_only: true }])
       render_inline(described_class.new(document: document))
       expect(page).to have_css(".panel-online")
       expect(page).to have_css("ul.links li span.stanford-only")
       expect(page).to have_css("span.additional-link-text", text: "4 at one time")
     end
     it 'renders a different heading for SDR items' do
-      document = SolrDocument.new(marcxml: simple_856, marc_links_struct: [{ html: '<a href="...">Link text</a>', fulltext: true }], druid: 'ng161qh7958')
+      document = SolrDocument.new(marcxml: simple_856, marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }], druid: 'ng161qh7958')
       render_inline(described_class.new(document: document))
       expect(page).to have_css '.panel-online'
       expect(page).to have_css '.panel-heading', text: 'Also available at'
@@ -210,7 +210,7 @@ describe AccessPanels::OnlineComponent, type: :component do
 
     describe "database" do
       let(:document) do
-        SolrDocument.new(marc_links_struct: [{ html: '<a href="...">Link text</a>', fulltext: true }], format_main_ssim: ["Database"])
+        SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }], format_main_ssim: ["Database"])
       end
 
       it "should render a special panel heading" do

--- a/spec/fixtures/solr_documents/24.yml
+++ b/spec/fixtures/solr_documents/24.yml
@@ -14,4 +14,4 @@
 :access_facet: Online
 :building_facet: Hoover Library
 :marc_links_struct:
-  - '{ "fulltext": true, "html": "...", "text": "..." }'
+  - '{ "fulltext": true, "href": "...", "link_text": "..." }'

--- a/spec/fixtures/solr_documents/5749286.yml
+++ b/spec/fixtures/solr_documents/5749286.yml
@@ -16,11 +16,11 @@
        "managed_purl" : null,
        "sort" : null,
        "fulltext" : true,
-       "html" : "<a title='Available to Stanford-affiliated users only' href='https://stanford.idm.oclc.org/login?url=http://search.ebscohost.com/login.aspx?authtype=ip,sso&custid=s4392798&profile=ehost&defaultdb=aph'>search.ebscohost.com</a> ",
        "druid" : null,
        "href" : "https://stanford.idm.oclc.org/login?url=http://search.ebscohost.com/login.aspx?authtype=ip,sso&custid=s4392798&profile=ehost&defaultdb=aph",
        "finding_aid" : false,
        "stanford_only" : 20,
-       "text" : "search.ebscohost.com",
+       "link_text" : "search.ebscohost.com",
+       "link_title" : "Available to Stanford-affiliated users only",
        "file_id" : null
     }

--- a/spec/lib/links_spec.rb
+++ b/spec/lib/links_spec.rb
@@ -56,12 +56,20 @@ describe SearchWorks::Links do
       )
     end
 
-    it 'it assembles the html link' do
+    it 'assembles the html link' do
       expect(link.html).to eq '<a href="http://link.edu" class="sfx">Link Text</a>'
     end
 
-    it 'it assembles the text' do
+    it 'makes an html_safe html link' do
+      expect(link.html).to be_html_safe
+    end
+
+    it 'assembles the text' do
       expect(link.text).to eq 'Link Text'
+    end
+
+    it 'makes an html_safe text link' do
+      expect(link.text).to be_html_safe
     end
 
     it 'should parse the href option' do

--- a/spec/lib/links_spec.rb
+++ b/spec/lib/links_spec.rb
@@ -52,12 +52,20 @@ describe SearchWorks::Links do
   describe 'Link' do
     let(:link) do
       SearchWorks::Links::Link.new(
-        html: 'text', fulltext: true, stanford_only: true, finding_aid: true, sfx: true, managed_purl: true
+        href: 'http://link.edu', link_text: 'Link Text', fulltext: true, stanford_only: true, finding_aid: true, sfx: true, managed_purl: true
       )
     end
 
-    it 'should parse the text option' do
-      expect(link.html).to eq 'text'
+    it 'it assembles the html link' do
+      expect(link.html).to eq '<a href="http://link.edu" class="sfx">Link Text</a>'
+    end
+
+    it 'it assembles the text' do
+      expect(link.text).to eq 'Link Text'
+    end
+
+    it 'should parse the href option' do
+      expect(link.href).to eq 'http://link.edu'
     end
 
     it 'should parse the fulltext option' do

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe EdsLinks do
 
     it 'handles Check SFX for full text' do
       document['eds_fulltext_links'].first['label'] = 'Check SFX for full text'
-      expect(document.eds_links.all.first.text).to eq('View on content provider\'s site')
+      expect(document.eds_links.all.first.text).to eq('View on content provider&#39;s site')
     end
 
     it 'handles View request options' do

--- a/spec/models/concerns/index_links_spec.rb
+++ b/spec/models/concerns/index_links_spec.rb
@@ -96,7 +96,7 @@ describe IndexLinks do
       expect(finding_aid_links_alternate.all.first).to be_finding_aid
       expect(finding_aid_links.finding_aid.length).to eq 1
       expect(finding_aid_links.finding_aid.first.html).to match(
-        %r{<a href='.*oac\.cdlib\.org\/findaid\/ark:\/something-else'>Online Archive of California<\/a>}
+        %r{<a href=".*oac\.cdlib\.org\/findaid\/ark:\/something-else">Online Archive of California<\/a>}
       )
     end
 
@@ -123,7 +123,7 @@ describe IndexLinks do
       expect(sfx_links.all.first).to be_sfx
       expect(sfx_links.sfx.length).to eq 1
       expect(sfx_links.sfx.first).to be_sfx
-      expect(sfx_links.sfx.first.html).to match(%r{^<a href=.*class='sfx'>Find full text<\/a>$})
+      expect(sfx_links.sfx.first.html).to match(%r{^<a href=.*class="sfx">Find full text<\/a>$})
     end
   end
 end

--- a/spec/models/concerns/marc_links_spec.rb
+++ b/spec/models/concerns/marc_links_spec.rb
@@ -9,17 +9,17 @@ describe MarcLinks do
   describe 'with a SolrDocument with structured data extracted from the marc' do
     let(:document) do
       SolrDocument.new(marc_links_struct: [
-        { text: 'fulltext', fulltext: true },
-        { text: 'stanford only',  stanford_only: true },
-        { html: 'finding aid', finding_aid: true },
-        { text: 'druid', managed_purl: true, file_id: 'x', druid: 'abc' }
+        { link_text: 'fulltext', fulltext: true },
+        { link_text: 'stanford only',  stanford_only: true },
+        { href: 'http://example.com', link_text: 'finding aid', finding_aid: true },
+        { link_text: 'druid', managed_purl: true, file_id: 'x', druid: 'abc' }
       ])
     end
 
     it 'decodes structured data in the document' do
       expect(document.marc_links.all.length).to eq 4
       expect(document.marc_links.fulltext.first.text).to eq 'fulltext'
-      expect(document.marc_links.finding_aid.first.html).to eq 'finding aid'
+      expect(document.marc_links.finding_aid.first.html).to eq '<a href="http://example.com">finding aid</a>'
       expect(document.marc_links.supplemental.first).to be_stanford_only
       expect(document.marc_links.managed_purls.first.text).to eq 'druid'
       expect(document.marc_links.managed_purls.first.file_id).to eq 'x'

--- a/spec/models/json_results_document_presenter_spec.rb
+++ b/spec/models/json_results_document_presenter_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe JsonResultsDocumentPresenter do
     context 'when the source document is available online to only Stanford users' do
       before do
         document_data['marc_links_struct'] = [{
-          "html": "<a href='https://example.com'>The Link</a> ",
+          "href": "https://example.com",
+          "link_text": "The Link",
           "fulltext": true,
           "stanford_only": true
         }]

--- a/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
@@ -11,10 +11,10 @@ describe "catalog/_index_online_section" do
             id: '12345',
             isbn_display: [123],
             marc_links_struct: [
-              { html: 'a', fulltext: true },
-              { html: 'b', fulltext: true },
-              { html: 'c', fulltext: true },
-              { html: 'd', fulltext: true }
+              { href: 'a', fulltext: true },
+              { href: 'b', fulltext: true },
+              { href: 'c', fulltext: true },
+              { href: 'd', fulltext: true }
             ]
           )
         )

--- a/spec/views/catalog/_show_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_show_marc.html.erb_spec.rb
@@ -10,7 +10,7 @@ describe 'catalog/_show_marc' do
   end
 
   context 'when a document has a managed purl' do
-    let(:document) { SolrDocument.new(id: '123', marcxml: managed_purl_fixture, marc_links_struct: [{ text: 'Some Part Label', managed_purl: true }, { managed_purl: true }]) }
+    let(:document) { SolrDocument.new(id: '123', marcxml: managed_purl_fixture, marc_links_struct: [{ link_text: 'Some Part Label', managed_purl: true }, { managed_purl: true }]) }
 
     it 'includes the managed purl panel and upper metadata elements' do
       expect(rendered).to have_css('.managed-purl-panel')

--- a/spec/views/catalog/record/_marc_contents_summary.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_contents_summary.html.erb_spec.rb
@@ -31,7 +31,7 @@ describe "catalog/record/_marc_contents_summary" do
 
   describe "finding aids" do
     before do
-      assign(:document, SolrDocument.new(marcxml: finding_aid_856, marc_links_struct: [{ finding_aid: true, html: '<a href="...">FINDING AID: Link text</a>' }]))
+      assign(:document, SolrDocument.new(marcxml: finding_aid_856, marc_links_struct: [{ finding_aid: true, href: '...', link_text: 'FINDING AID: Link text' }]))
     end
 
     it "should be displayed when present" do


### PR DESCRIPTION
Closes #2969 

sul-bento-app displays links that are generated in SearchWorks and appear in the JSON search results in `fulltext_link_html` so no changes are needed in bento: 

https://searchworks.stanford.edu/?f[access_facet][]=Online&search_field=search&q=Air+and+Marine+Operations+vision+and+strategy&format=json

