### PR TITLE
Make it easier to export a whole bunch of records

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -39,6 +39,10 @@ class CatalogController < ApplicationController
   end
 
   before_action only: :index do
+    blacklight_config.max_per_page = 10000 if params[:export]
+  end
+
+  before_action only: :index do
     blacklight_config.facet_fields['access_facet'].collapse = false unless has_search_parameters?
   end
 


### PR DESCRIPTION
We don't want bots crawling too deep, or regular users asking for massive page sizes, but sometimes it's nice to get a whole bunch of records (as JSON, MARCXML, etc).