### PR TITLE
Set download attribute on ris and endnote export links to the filename of the download.

### DIFF
--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -17,7 +17,7 @@
       </li>
 
       <li class="ris" role="presentation">
-        <%= link_to t('blacklight.tools.ris_html'), search_state.to_h.merge(format: 'ris'), download: true, role: 'menuitem', tabindex: '-1' %>
+        <%= link_to t('blacklight.tools.ris_html'), search_state.to_h.merge(format: 'ris'), download: File.basename(url_for(search_state.to_h.merge(format: 'ris'))), role: 'menuitem', tabindex: '-1' %>
       </li>
     <% end %>
 

--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -16,7 +16,7 @@
 
     <% if @response.documents.any? {|d| d.exports_as? :endnote } %>
       <li role="presentation">
-        <%= link_to t('blacklight.tools.endnote_html'), bookmarks_path(:endnote, search_state.params_for_search), :id => "endnoteLink", role: 'menuitem', tabindex: '-1' %>
+        <%= link_to t('blacklight.tools.endnote_html'), bookmarks_path(:endnote, search_state.params_for_search), download: File.basename(bookmarks_path(:endnote, search_state.params_for_search)), :id => "endnoteLink", role: 'menuitem', tabindex: '-1' %>
       </li>
     <% end %>
 


### PR DESCRIPTION
Previously the `download` attribute had been set to `true` for the ris export link causing the downloaded file to be named `true`. We had not set the `download` attribute for endnote downloads, so for consistency I added the attribute there as well.

See download attribute reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download