### PR TITLE
Try some things to help ensure the URL is clickable

### DIFF
--- a/app/presenters/sms_presenter.rb
+++ b/app/presenters/sms_presenter.rb
@@ -15,13 +15,13 @@ class SmsPresenter
   end
 
   def sms_content
-    "#{sms_text}\n#{short_url}"
+    "#{sms_text}\n#{short_url}\n"
   end
 
   private
 
   def sms_text
-    truncate(document.to_sms_text, length: text_length)
+    truncate(document.to_sms_text, length: text_length, escape: false)
   end
 
   def text_length

--- a/spec/presenters/sms_presenter_spec.rb
+++ b/spec/presenters/sms_presenter_spec.rb
@@ -20,9 +20,17 @@ describe SmsPresenter do
       it { expect(subject.sms_content.length).to be < 160 }
     end
 
+    context 'with special characters' do
+      let(:doc) { SolrDocument.new(eds_title: '< this & that >') }
+
+      it 'is not escaped' do
+        expect(subject.sms_content).to include '< this & that >'
+      end
+    end
+
     context 'when bitly returns ok' do
       it 'uses bitly shortened url' do
-        expect(subject.sms_content).to include 'http://bit.ly/2evYAOW'
+        expect(subject.sms_content).to include('http://bit.ly/2evYAOW').and end_with("\n")
       end
     end
 


### PR DESCRIPTION
We don't want carriers to digest messages, but if they do, we want to make sure there's trailing whitespace to separate our message from any wrapping they inject

SW-4130
