### PR TITLE
Revert Aeon configuration temporarily

### DIFF
--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -267,6 +267,11 @@ en:
       request_on_site: Request on-site access
       finding_aid: Request via Finding Aid
       aeon: Request via Aeon
+      # specific libraries can be removed once aeon is re-enabled
+      HOOVER: Request on-site access
+      HV-ARCHIVE: Request via Finding Aid
+      RUMSEYMAP: Request on-site access
+      SPEC-COLL: Request on-site access
   blacklight:
     advanced_search:
       page_title: 'Advanced search in SearchWorks catalog'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,6 @@ EMAIL_THRESHOLD: 5
 GENERATE_SITEMAP: true
 DISABLE_SESSIONS: false
 THROTTLE_TRAFFIC: false
-OAC_REQUEST_LINKS: false
 OCLC:
   API_KEY: the-oclc-api-key
   BASE_URL: http://www.worldcat.org/webservices/catalog/content/citations
@@ -392,25 +391,27 @@ mediated_locations:
     - LOCKED-STK
   SAL3:
     - PAGE-MP
+  RUMSEYMAP: "*"  # remove once aeon is re-enabled below
+  SPEC-COLL: "*"  # remove once aeon is re-enabled below
 
-aeon_locations:
-  RUMSEYMAP: "*"
-  SPEC-COLL: "*"
-  HOOVER: "*"
-  ARS:
-    RECORDINGS: "*"
-  EAST-ASIA:
-    LOCKED-STK: "*"
-    LOCK-STK-O: "*"
-    LOCK-CHN: "*"
-  SAL:
-    L-PAGE-EA:
-    - NH-INHOUSE
-  SAL3:
-    PAGE-AS: 
-    - NH-INHOUSE
-    PAGE-EA:
-    - LCKSTK
+aeon_locations: {}
+#   RUMSEYMAP: "*"
+#   SPEC-COLL: "*"
+#   HOOVER: "*"
+#   ARS:
+#     RECORDINGS: "*"
+#   EAST-ASIA:
+#     LOCKED-STK: "*"
+#     LOCK-STK-O: "*"
+#     LOCK-CHN: "*"
+#   SAL:
+#     L-PAGE-EA:
+#     - NH-INHOUSE
+#   SAL3:
+#     PAGE-AS: 
+#     - NH-INHOUSE
+#     PAGE-EA:
+#     - LCKSTK
 
 circulating_item_types:
   ARS:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,19 @@
-OAC_REQUEST_LINKS: true
+# Can be removed once Aeon is re-enabled in main settings
+aeon_locations:
+  RUMSEYMAP: "*"
+  SPEC-COLL: "*"
+  HOOVER: "*"
+  ARS:
+    RECORDINGS: "*"
+  EAST-ASIA:
+    LOCKED-STK: "*"
+    LOCK-STK-O: "*"
+    LOCK-CHN: "*"
+  SAL:
+    L-PAGE-EA:
+    - NH-INHOUSE
+  SAL3:
+    PAGE-AS: 
+    - NH-INHOUSE
+    PAGE-EA:
+    - LCKSTK

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,4 +9,23 @@ EXHIBITS_ACCESS_PANEL:
   enabled: true
 LIB_GUIDES:
   MINI_BENTO_ENABLED: true
-OAC_REQUEST_LINKS: true
+
+# Can be removed once Aeon is re-enabled in main settings
+aeon_locations:
+  RUMSEYMAP: "*"
+  SPEC-COLL: "*"
+  HOOVER: "*"
+  ARS:
+    RECORDINGS: "*"
+  EAST-ASIA:
+    LOCKED-STK: "*"
+    LOCK-STK-O: "*"
+    LOCK-CHN: "*"
+  SAL:
+    L-PAGE-EA:
+    - NH-INHOUSE
+  SAL3:
+    PAGE-AS: 
+    - NH-INHOUSE
+    PAGE-EA:
+    - LCKSTK


### PR DESCRIPTION
This reverts the request link related configuration to a pre-Aeon state
until the Aeon libraries are ready for implementation. It keeps the
Aeon config active in the dev and test environment settings so that
tests will pass.

Also removes the OAC_REQUEST_LINKS config, which is made redundant by
Aeon work and no longer referenced.
