### PR TITLE
Add new HH-FOYER location to mappings

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -358,6 +358,7 @@ module Constants
     'HAS-RR' => 'Lane Reading Room: Ready reference',
     'HAS-SU' => 'Lane Reading Room: Stanford history',
     'HASRC' => 'Lane Reading Room: Reference',
+    'HH-FOYER' => 'Hohbach Hall: Foyer bookshelf',
     'HMS-PAGE' => 'In transit to main campus',
     'HMS-RETURN' => 'In transit to Hopkins',
     'HOLDS' => 'Ask at circulation desk',


### PR DESCRIPTION
Green Reference staff have requested a new Symphony location `HH-FOYER`.

Closes #3028 
