### PR TITLE
Sanitize MarcField display value output

### DIFF
--- a/app/models/marc_field.rb
+++ b/app/models/marc_field.rb
@@ -4,6 +4,7 @@
 ###
 class MarcField
   include ActionView::Helpers::OutputSafetyHelper
+  include ActionView::Helpers::SanitizeHelper
 
   attr_reader :document, :tags
 
@@ -72,7 +73,7 @@ class MarcField
   def display_value(field, subfields)
     return unless subfields.present?
 
-    safe_join subfields.map { |subfield| subfield_value(field, subfield) }, subfield_delimiter
+    safe_join subfields.map { |subfield| subfield_value(field, subfield) }.map { |v| sanitize_marc_value(v) }, subfield_delimiter
   end
 
   def subfield_value(_field, subfield)
@@ -82,5 +83,11 @@ class MarcField
     else
       subfield.value
     end
+  end
+
+  def sanitize_marc_value(value)
+    return value if value.html_safe?
+
+    sanitize(value.gsub(/</, '&lt;').gsub(/>/, '&gt;'))
   end
 end

--- a/spec/models/marc_field_spec.rb
+++ b/spec/models/marc_field_spec.rb
@@ -60,6 +60,24 @@ describe MarcField do
         expect(subject.values[7]).to eq '300 Unmatched Vernacular'
       end
     end
+
+    context 'when it contains unsafe characters' do
+      let(:tags) { %w(245) }
+      let(:marc) do
+        <<-XML
+          <record>
+            <datafield tag="245" ind1="1" ind2=" ">
+              <subfield code="a">Some value with 'quotes' and &lt;brackets&gt;</subfield>
+            </datafield>
+          </record>
+        XML
+      end
+
+      it 'sanitizes the values' do
+        expect(subject.values).to eq ["Some value with 'quotes' and &lt;brackets&gt;"]
+        expect(subject.values.first).to be_html_safe
+      end
+    end
   end
 
   describe '#to_partial_path' do


### PR DESCRIPTION
Prior to #2647, we didn't do any html sanitization. Turns out, `safe_join` is too aggressive with html entities (see e.g. SW-4131), so we actually have to do some proper sanitization.