### PR TITLE
Upgrades the production assets to the rails 7 defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gem "sprockets-rails"
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sassc-rails'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 2.7.2'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -598,8 +598,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -702,7 +700,6 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   turbolinks (~> 5)
-  uglifier (>= 2.7.2)
   view_component (< 2.75)
   web-console (>= 4.1.0)
   webdrivers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,10 +24,8 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
   # Compress CSS using a preprocessor.
-  config.assets.css_compressor = :sass
+  # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
Uglifier is no longer recommened for Rails 7. See https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt\#L29-L36
