### PR TITLE
Make the location a scope='col' because rowgroup inflicts additional …

### DIFF
--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -26,7 +26,7 @@
         <tbody data-long-list data-list-type="location">
         <% location_request_link = LocationRequestLinkComponent.for(document: document, library: library.code, location: location.code, items: location.items) %>
         <tr class="location-info">
-          <th scope="rowgroup" rowspan="0">
+          <th scope="col">
             <%= render partial: "catalog/stackmap_link", locals: { document: document, location: location, location_name_class: '' } %>
             <% if location.mhld.present? %>
               <br/>

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -25,8 +25,8 @@ describe "catalog/_index_location" do
       it "is col on the status column" do
         expect(rendered).to have_css('th[scope="col"]', text: 'Status')
       end
-      it "is rowgroup on the location name" do
-        expect(rendered).to have_css('th[scope="rowgroup"]', text: 'Stacks')
+      it "is col on the location name" do
+        expect(rendered).to have_css('th[scope="col"]', text: 'Stacks')
       end
     end
   end


### PR DESCRIPTION
…styling in some browsers

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
