### PR TITLE
Throttle article searching more aggressively to protect EDS API

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -37,4 +37,7 @@ if Settings.THROTTLE_TRAFFIC
 
     [429, headers, ["Throttled\n"]]
   end
+
+  # Disable throttling for Stanford-local users
+  Rack::Attack.safelist_ip("171.64.0.0/14")
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,23 +1,40 @@
 ##
 # See https://github.com/kickstarter/rack-attack/blob/master/docs/example_configuration.md
 # for more configuration options
-class Rack::Attack
-  ### Throttle Spammy Clients ###
 
-  # If any single client IP is making tons of requests, then they're
-  # probably malicious or a poorly-configured scraper. Either way, they
-  # don't deserve to hog all of the app server's CPU. Cut them off!
-  #
-  # Note: If you're serving assets through rack, those requests may be
-  # counted by rack-attack and this throttle may be activated too
-  # quickly. If so, enable the condition to exclude them from tracking.
+### Throttle Spammy Clients ###
 
-  # Throttle all requests by IP (60rpm)
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-  if Settings.THROTTLE_TRAFFIC
-    throttle('req/ip', limit: 300, period: 5.minutes) do |req|
-      req.ip if req.path.start_with?('/catalog', '/view', '/articles')
-    end
+# If any single client IP is making tons of requests, then they're
+# probably malicious or a poorly-configured scraper. Either way, they
+# don't deserve to hog all of the app server's CPU. Cut them off!
+#
+# Note: If you're serving assets through rack, those requests may be
+# counted by rack-attack and this throttle may be activated too
+# quickly. If so, enable the condition to exclude them from tracking.
+
+if Settings.THROTTLE_TRAFFIC
+  # Throttle catalog search and result requests by IP (60rpm)
+  Rack::Attack.throttle('req/ip', limit: 300, period: 5.minutes) do |req|
+    req.ip if req.path.start_with?('/catalog', '/view')
+  end
+
+  # Throttle article searching more aggressively to protect EDS API (12rpm)
+  Rack::Attack.throttle('articles/ip', limit: 60, period: 5.minutes) do |req|
+    req.ip if req.path.start_with?('/articles')
+  end
+
+  # Inform throttled clients about limits and when they will get out of jail
+  Rack::Attack.throttled_response_retry_after_header = true
+  Rack::Attack.throttled_responder = lambda do |request|
+    match_data = request.env['rack.attack.match_data']
+    now = match_data[:epoch_time]
+
+    headers = {
+      'RateLimit-Limit' => match_data[:limit].to_s,
+      'RateLimit-Remaining' => '0',
+      'RateLimit-Reset' => (now + (match_data[:period] - (now % match_data[:period]))).to_s
+    }
+
+    [429, headers, ["Throttled\n"]]
   end
 end


### PR DESCRIPTION
Ref #1766

This borrows DLME's rack-attack config to send headers to clients informing them about throttle settings and when they'll get unblocked. It applies a stricter throttle (12 requests per minute) to article searching but disables all throttling for Stanford local clients.