### PR TITLE
Only guard catalog search (+ result) paths using rack-attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,7 +17,7 @@ class Rack::Attack
   # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
   if Settings.THROTTLE_TRAFFIC
     throttle('req/ip', limit: 300, period: 5.minutes) do |req|
-      req.ip unless req.path.start_with?('/assets')
+      req.ip if req.path.start_with?('/catalog', '/view', '/articles')
     end
   end
 end


### PR DESCRIPTION
We're currently blocking some legit users, e.g. using "select all" with large result sets

See SW-3894