### PR TITLE
changing tfoot element to tbody, multiple tfoot elements will appear …

### DIFF
--- a/app/assets/javascripts/jquery.long-lists.js
+++ b/app/assets/javascripts/jquery.long-lists.js
@@ -39,7 +39,7 @@
           $googleBooks.before($more);
         }else{
           if ($list.is('tbody')) {
-            var tfoot = $('<tfoot><tr><td></td></tr></tfoot>').insertAfter($list);
+            var tfoot = $('<tbody><tr><td></td></tr></tbody>').insertAfter($list);
             tfoot.find('td').append($more);
           } else {
             $list.append($more);

--- a/app/assets/javascripts/jquery.long-lists.js
+++ b/app/assets/javascripts/jquery.long-lists.js
@@ -39,8 +39,8 @@
           $googleBooks.before($more);
         }else{
           if ($list.is('tbody')) {
-            var tfoot = $('<tbody><tr><td></td></tr></tbody>').insertAfter($list);
-            tfoot.find('td').append($more);
+            var tbody = $('<tbody><tr><td></td></tr></tbody>').insertAfter($list);
+            tbody.find('td').append($more);
           } else {
             $list.append($more);
           }

--- a/app/assets/stylesheets/modules/availability.scss
+++ b/app/assets/stylesheets/modules/availability.scss
@@ -11,8 +11,7 @@
   }
 
   thead,
-  tbody,
-  tfoot {
+  tbody {
     tr {
       th {
         border-top: 1px solid $sul-availability-table-cell-border;


### PR DESCRIPTION
On the search results page, clicking "check availability" shows multiple "show more" buttons together at the bottom of the table when there are multiple locations in the same location group with long lists of call numbers (e.g. "Green library" and "Miller Library or Green Library" under SAL3).  The correct behavior would be to have each "show all" display immediately below its related section.  The reason for this display error is that the "show more" buttons are added in <tfoot> elements.  A table should have only one <tfoot> element.  When there are multiple <tfoot> elements, they will appear at the bottom of the table.  This pull request replaces <tfoot> wit <tbody>. 

Addresses #3087 
Changes https://github.com/sul-dlss/SearchWorks/blob/master/app/assets/javascripts/jquery.long-lists.js#L42 to use <tbody> instead of <tfoot>
