### PR TITLE
Add padding around grouped citations

### DIFF
--- a/app/views/catalog/_grouped_citations.html.erb
+++ b/app/views/catalog/_grouped_citations.html.erb
@@ -1,4 +1,13 @@
-<div class='grouped-citations'>
+<div class="modal-header">
+  <% if request.xhr? %>
+    <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  <% end %>
+  <h2 class="modal-title">Citations</h2>
+</div>
+
+<div class='modal-body grouped-citations'>
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active">
       <a href="#all" aria-controls="all" role="tab" data-toggle="tab">By title</a>
@@ -10,11 +19,20 @@
 
   <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="all">
+      <% # "By title" tab pane %>
       <% @documents.each do |document| %>
-        <%= render partial: 'catalog/single_citation', locals: { document: document } %>
+        <h3><%= document_presenter(document).heading %></h3>
+        <% document.citations.each do |format, citation| %>
+          <% unless format == 'NULL' %>
+            <h4><%= format %></h4>
+          <% end %>
+          <%= citation %>
+        <% end %>
       <% end %>
     </div>
+
     <div role="tabpanel" class="tab-pane" id="biblio">
+      <% # "By citation format" tab pane %>
       <% grouped_citations(@documents).each do |format, citations| %>
         <% unless format == 'NULL' %>
           <h4><%= format %></h4>

--- a/spec/fixtures/mods_records/mods_fixtures.rb
+++ b/spec/fixtures/mods_records/mods_fixtures.rb
@@ -101,6 +101,7 @@ module ModsFixtures
         <targetAudience displayLabel="Who?">Cat loverz</targetAudience>
         <note>Pick up milk</note>
         <note displayLabel="Notez">Pick up milkz</note>
+        <note type="preferred citation">Qu, J., Han, X., Sakamoto, S., Jia, C., Liu, J., Li, H., Guan, D., Zeng, Y., Schüler, M., Kirchmann, P., Moritz, B., Hussain, Z., Devereaux, T., Shen, Z., and Sobota, J. (2023). Data for "Reversal of spin-polarization near the Fermi level of the Rashba semiconductor BiTeCl". Stanford Digital Repository. Available at https://purl.stanford.edu/cb936xf9075. https://doi.org/10.25740/cb936xf9075.</note>
         <relatedItem>
           <titleInfo>
             <title>The collection of everything</title>


### PR DESCRIPTION
Closes #3077

Updated to look like:
<img width="619" alt="Screenshot 2023-04-20 at 1 30 23 PM" src="https://user-images.githubusercontent.com/92044/233455899-14ba75a9-7f6e-4f13-9343-569c6443fe68.png">
<img width="611" alt="Screenshot 2023-04-20 at 1 30 36 PM" src="https://user-images.githubusercontent.com/92044/233455955-b5069792-7518-41f4-af20-d11183f50200.png">
