### PR TITLE
Remove unused logic around unavailable_current_location per library

### DIFF
--- a/app/components/item_request_link_component.rb
+++ b/app/components/item_request_link_component.rb
@@ -53,7 +53,7 @@ class ItemRequestLinkComponent < ViewComponent::Base
     return true if current_location.end_with?('-LOAN') && current_location != "SEE-LOAN"
 
     (Settings.requestable_current_locations[library] || Settings.requestable_current_locations.default).include?(current_location) ||
-      (Settings.unavailable_current_locations[library] || Settings.unavailable_current_locations.default).include?(current_location)
+      Settings.unavailable_current_locations.include?(current_location)
   end
 
   def in_mediated_pageable_location?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -546,32 +546,31 @@ nonrequestable_locations:
     - TECH-DESK
 
 unavailable_current_locations:
-  default:
-    - AT-REPAIR
-    - AVAIL_SOON
-    - B&F-HOLD
-    - BILLED-OD
-    - BINDERY
-    - CPM-HOLDS
-    - ENDPROCESS
-    - INPROCESS
-    - INTRANSIT
-    - LOST-ASSUM
-    - MISSING
-    - ON-ORDER
-    - PUB-TECH
-    - REPAIR
-    - SAL-RETURN
-    - SPEC-INPRO
-    - SUL-BIND
-    - SULBIND-WA
-    - TECH-ACQ
-    - TECH-CAT
-    - TECH-CONS
-    - TECH-PROC
-    - TECH-SER
-    - TECH-SERV
-    - TEMP-LL
+  - AT-REPAIR
+  - AVAIL_SOON
+  - B&F-HOLD
+  - BILLED-OD
+  - BINDERY
+  - CPM-HOLDS
+  - ENDPROCESS
+  - INPROCESS
+  - INTRANSIT
+  - LOST-ASSUM
+  - MISSING
+  - ON-ORDER
+  - PUB-TECH
+  - REPAIR
+  - SAL-RETURN
+  - SPEC-INPRO
+  - SUL-BIND
+  - SULBIND-WA
+  - TECH-ACQ
+  - TECH-CAT
+  - TECH-CONS
+  - TECH-PROC
+  - TECH-SER
+  - TECH-SERV
+  - TEMP-LL
 
 requestable_current_locations:
   default:

--- a/lib/holdings/status/unavailable.rb
+++ b/lib/holdings/status/unavailable.rb
@@ -28,8 +28,7 @@ class Holdings
       end
 
       def unavailable_current_location?
-        current_location_ends_with_loan? ||
-        (Settings.unavailable_current_locations[library] || Settings.unavailable_current_locations.default).include?(current_location)
+        current_location_ends_with_loan? || Settings.unavailable_current_locations.include?(current_location)
       end
 
       def current_location_ends_with_loan?

--- a/spec/lib/holdings/status/unavailable_spec.rb
+++ b/spec/lib/holdings/status/unavailable_spec.rb
@@ -22,8 +22,8 @@ describe Holdings::Status::Unavailable do
   end
 
   describe "unavailable current locations" do
-    it "should be unavailable" do
-      Settings.unavailable_current_locations.default.each do |location|
+    it "is unavailable for all configured locations" do
+      Settings.unavailable_current_locations.each do |location|
         expect(Holdings::Status::Unavailable.new(OpenStruct.new(current_location: Holdings::Location.new(location)))).to be_unavailable
       end
     end


### PR DESCRIPTION
It is only ever used globally.  This simplifies the lookup and makes the code easier to read

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
