### PR TITLE
Extract logic about whether to display an item request button to a separate class

### DIFF
--- a/app/components/access_panels/library_location_component.html.erb
+++ b/app/components/access_panels/library_location_component.html.erb
@@ -38,7 +38,7 @@
           <% end %>
         </td>
         <% if item.present? %>
-          <td class="item-availability" data-live-lookup-id="<%= document[:id] %>" data-status-target=".availability-icon" data-barcode="<%= item.barcode if item.live_status? %>" <%= "data-request-url='#{helpers.request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if !location_request_link.render? && item.circulates? && !item.request_link.render? %>>
+          <td class="item-availability" data-live-lookup-id="<%= document[:id] %>" data-status-target=".availability-icon" data-barcode="<%= item.barcode if item.live_status? %>" <%= "data-request-url='#{helpers.request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if !location_request_link.render? && item.circulates? && !item.request_link_policy.display? %>>
             <span class="availability-icon-wrapper">
               <i class="availability-icon <%= item.status.availability_class %>"></i>
               <span data-available-text="<%= t('searchworks.availability.available') %>" data-unavailable-text="<%= t('searchworks.availability.unavailable') %>" class='status-text'>
@@ -55,7 +55,7 @@
             <% end %>
             <% unless location_request_link.render? %>
               <span class="request-link">
-                <%= render item.request_link %>
+                <%= render ItemRequestLinkComponent.new(item: item) %>
               </span>
             <% end %>
           </td>

--- a/app/components/item_request_link_component.rb
+++ b/app/components/item_request_link_component.rb
@@ -19,9 +19,7 @@ class ItemRequestLinkComponent < ViewComponent::Base
   end
 
   def render?
-    return false if aeon_pageable? || in_mediated_pageable_location? || in_nonrequestable_location? || @item.on_reserve?
-
-    current_location_is_always_requestable?
+    @item.request_link_policy.display?
   end
 
   private
@@ -43,31 +41,5 @@ class ItemRequestLinkComponent < ViewComponent::Base
       locale_key,
       default: :'searchworks.request_link.default'
     )
-  end
-
-  def current_location
-    @item.current_location.code
-  end
-
-  def current_location_is_always_requestable?
-    return true if current_location.end_with?('-LOAN') && current_location != "SEE-LOAN"
-
-    (Settings.requestable_current_locations[library] || Settings.requestable_current_locations.default).include?(current_location) ||
-      (Settings.unavailable_current_locations[library] || Settings.unavailable_current_locations.default).include?(current_location)
-  end
-
-  def in_mediated_pageable_location?
-    Settings.mediated_locations[library] == '*' ||
-      Settings.mediated_locations[library]&.include?(home_location)
-  end
-
-  def aeon_pageable?
-    Settings.aeon_locations[library] == '*' ||
-      Settings.aeon_locations.dig(library, home_location) == "*" ||
-      Settings.aeon_locations.dig(library, home_location)&.include?(@item.type)
-  end
-
-  def in_nonrequestable_location?
-    (Settings.nonrequestable_locations[library] || Settings.nonrequestable_locations.default).include?(home_location)
   end
 end

--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -56,7 +56,7 @@
           <% location.items.each do |item| %>
             <tr>
               <td><%= item.callnumber %></td>
-              <td data-live-lookup-id="<%= document[:id] %>" data-status-target=".availability-icon" data-barcode="<%= item.barcode if item.live_status? %>" <%= "data-request-url='#{request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if !location_request_link.render? && item.circulates? && !item.request_link.render? %>>
+              <td data-live-lookup-id="<%= document[:id] %>" data-status-target=".availability-icon" data-barcode="<%= item.barcode if item.live_status? %>" <%= "data-request-url='#{request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if !location_request_link.render? && item.circulates? && !item.request_link_policy.display? %>>
                 <span class="availability-icon-wrapper">
                   <i class="availability-icon <%= item.status.availability_class %>"></i>
                   <span data-available-text="<%= t('searchworks.availability.available') %>" data-unavailable-text="<%= t('searchworks.availability.unavailable')  %>" class='status-text'>
@@ -72,7 +72,7 @@
                   <%= item.loan_period %>
                 <% end %>
                 <span class="request-link">
-                  <%= render item.request_link %>
+                  <%= render ItemRequestLinkComponent.new(item: item) %>
                 </span>
               </td>
             </tr>

--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -1,4 +1,5 @@
 require 'holdings/item'
+require 'holdings/item_request_link_policy'
 require 'holdings/library'
 require 'holdings/location'
 require 'holdings/mhld'

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -150,8 +150,8 @@ class Holdings
       }
     end
 
-    def request_link
-      @request_link ||= ItemRequestLinkComponent.new(item: self)
+    def request_link_policy
+      @request_link_policy ||= ItemRequestLinkPolicy.new(item: self)
     end
 
     # create sorting key for spine

--- a/lib/holdings/item_request_link_policy.rb
+++ b/lib/holdings/item_request_link_policy.rb
@@ -1,0 +1,40 @@
+class Holdings
+  # This contains the business logic around whether to display an item level request link
+  # This may say "no" even though an item is still requestable (aeon-paged or mediated-paged),
+  # we just don't show an item-level link for it because the location-level link takes care of it.
+  class ItemRequestLinkPolicy
+    def initialize(item:)
+      @item = item
+    end
+
+    delegate :current_location, :library, :home_location, :type, :on_reserve?, to: :@item
+
+    def display?
+      return false if aeon_pageable? || in_mediated_pageable_location? || in_nonrequestable_location? || on_reserve?
+
+      current_location_is_always_requestable?
+    end
+
+    def current_location_is_always_requestable?
+      return true if current_location.code.end_with?('-LOAN') && current_location.code != "SEE-LOAN"
+
+      (Settings.requestable_current_locations[library] || Settings.requestable_current_locations.default).include?(current_location.code) ||
+        (Settings.unavailable_current_locations[library] || Settings.unavailable_current_locations.default).include?(current_location.code)
+    end
+
+    def in_mediated_pageable_location?
+      Settings.mediated_locations[library] == '*' ||
+        Settings.mediated_locations[library]&.include?(home_location)
+    end
+
+    def aeon_pageable?
+      Settings.aeon_locations[library] == '*' ||
+        Settings.aeon_locations.dig(library, home_location) == "*" ||
+        Settings.aeon_locations.dig(library, home_location)&.include?(type)
+    end
+
+    def in_nonrequestable_location?
+      (Settings.nonrequestable_locations[library] || Settings.nonrequestable_locations.default).include?(home_location)
+    end
+  end
+end


### PR DESCRIPTION
We don't want the model to be aware of view layer (component) concerns.  We also don't want external consumers calling `ItemComponent#render?`