### PR TITLE
Stop using url_* and managed_purl_urls fields

### DIFF
--- a/app/helpers/xml_api_helper.rb
+++ b/app/helpers/xml_api_helper.rb
@@ -176,13 +176,4 @@ module XmlApiHelper
       end
     end
   end
-
-  def index_link_is_stanford_only?(doc, link)
-    if doc["url_restricted"]
-      doc["url_restricted"].each do |su_only|
-        return true if CGI.unescapeHTML(link.strip).include?("#{CGI.unescapeHTML(su_only.strip)}")
-      end
-    end
-    false
-  end
 end

--- a/app/models/concerns/druid.rb
+++ b/app/models/concerns/druid.rb
@@ -8,8 +8,8 @@ module Druid
   private
 
   def purls_from_urls
-    [self[:url_fulltext], self[:url_suppl]].flatten.compact.select do |url|
-      url =~ /purl\.stanford\.edu/
+    [index_links.fulltext, index_links.supplemental].flatten.compact.map(&:href).select do |href|
+      /purl\.stanford\.edu/.match?(href)
     end
   end
 end

--- a/app/models/concerns/marc_links.rb
+++ b/app/models/concerns/marc_links.rb
@@ -1,3 +1,6 @@
+# marc_links returns a SearchWorks::Links::Link object for each :marc_link_struct value.
+# marc_links are displayed along with other record metadata and have the default
+# link_text values vs. links created in the IndexLinks module that modifies the link_text values.
 module MarcLinks
   def marc_links
     @marc_links ||= SearchWorks::Links.new(fetch(:marc_links_struct, []).map do |data|

--- a/app/views/catalog/_index_default.mobile.builder
+++ b/app/views/catalog/_index_default.mobile.builder
@@ -21,7 +21,7 @@ if doc_is_a_database?(doc)
   if doc["summary_display"]
     xml.summary(truncate(doc["summary_display"].join(" "), length: 140))
   end
-  if doc["url_fulltext"]
-    xml.database_url("stanford_only" => index_link_is_stanford_only?(doc, doc["url_fulltext"].first.strip)) { xml.cdata!(doc["url_fulltext"].first.strip) }
+  if doc.index_links.fulltext.any?
+    xml.database_url("stanford_only" => doc.index_links.fulltext.first.stanford_only?) { xml.cdata!(doc.index_links.fulltext.first.href) }
   end
 end

--- a/app/views/catalog/_index_online_section.html.erb
+++ b/app/views/catalog/_index_online_section.html.erb
@@ -13,7 +13,7 @@
         </li>
       <% end %>
 
-      <% if document[:managed_purl_urls].blank? %>
+      <% if document.index_links.managed_purls.none? %>
         <% book_ids  = get_book_ids(document) %>
         <li class="hide google-books <%= (book_ids['isbn'] + book_ids['oclc'] + book_ids['lccn']).join(' ') %>">
           <a href="" class="full-view">Google Books (Full view)</a>

--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       document = SolrDocument.new(
         id: '123',
         item_display: ['123 -|- SPEC-COLL -|- STACKS -|- -|- -|- -|- -|- -|- ABC -|-'],
-        url_suppl: ["http://oac.cdlib.org/findaid/ark:/something-else"]
+        marc_links_struct: [{ href: "http://oac.cdlib.org/findaid/ark:/something-else", finding_aid: true }]
       )
       render_inline(described_class.new(document:))
     end
@@ -354,7 +354,7 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
         document = SolrDocument.new(
           id: '123',
           item_display: ['123 -|- HV-ARCHIVE -|- STACKS -|- -|- -|- -|- -|- -|- ABC -|-'],
-          url_suppl: ['http://oac.cdlib.org/findaid/ark:/something-else']
+          marc_links_struct: [{ href: "http://oac.cdlib.org/findaid/ark:/something-else", finding_aid: true }]
         )
         render_inline(described_class.new(document:))
       end

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -4,7 +4,7 @@ describe AccessPanels::OnlineComponent, type: :component do
   include ModsFixtures
   include Marc856Fixtures
 
-  let(:fulltext) { described_class.new(document: SolrDocument.new(marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true, stanford_only: nil, finding_aid: false, managed_purl: nil, file_id: nil, druid: nil }])) }
+  let(:fulltext) { described_class.new(document: SolrDocument.new(marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true }])) }
   let(:supplemental) { described_class.new(document: SolrDocument.new) }
   let(:eds_links) do
     described_class.new(
@@ -16,7 +16,10 @@ describe AccessPanels::OnlineComponent, type: :component do
 
   let(:sfx) do
     described_class.new(
-      document: SolrDocument.new(url_sfx: 'http://example.com/sfx-link', marcxml: fulltext_856)
+      document: SolrDocument.new(
+        marc_links_struct: [{ link_text: "Link text", href: "http://example.com/sfx-link", sfx: true }],
+        marcxml: fulltext_856
+      )
     )
   end
 
@@ -24,7 +27,7 @@ describe AccessPanels::OnlineComponent, type: :component do
     described_class.new(
       document: SolrDocument.new(
         collection: ['12345'],
-        marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true, stanford_only: nil, finding_aid: false, managed_purl: nil, file_id: nil, druid: nil }]
+        marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true }]
       )
     )
   end
@@ -32,7 +35,7 @@ describe AccessPanels::OnlineComponent, type: :component do
   let(:managed_purl_doc) do
     described_class.new(
       document: SolrDocument.new(
-        managed_purl_urls: ['https://library.stanford.edu']
+        marc_links_struct: [{ link_text: "Link text", href: "https://library.stanford.edu", fulltext: true, managed_purl: true }]
       )
     )
   end
@@ -41,7 +44,7 @@ describe AccessPanels::OnlineComponent, type: :component do
     described_class.new(
       document: SolrDocument.new(
         collection: ['12345'],
-        url_fulltext: 'https://purl.stanford.edu/'
+        marc_links_struct: [{ link_text: "Link text", href: "https://purl.stanford.edu/", fulltext: true, managed_purl: true }]
       )
     )
   end
@@ -132,7 +135,9 @@ describe AccessPanels::OnlineComponent, type: :component do
     end
 
     context 'when given an sfx document' do
-      let(:solr_document_data) { { url_sfx: ['https://example.com/sfx'] } }
+      let(:solr_document_data) do
+        { marc_links_struct: [{ link_text: "Link text", href: "https://example.com/sfx", sfx: true }] }
+      end
 
       it { expect(component.display_connection_problem_links?).to be true }
     end
@@ -189,7 +194,8 @@ describe AccessPanels::OnlineComponent, type: :component do
 
     context 'when the record has an SFX link' do
       it 'renders markup w/ attributes to fetch SFX data (and does not render the link)' do
-        document = SolrDocument.new(url_sfx: ['http://example.com/sfx-link'], marcxml: simple_856)
+        document = SolrDocument.new(marc_links_struct: [link_text: "Link text", href: "http://example.com/sfx-link", sfx: true],
+                                    marcxml: simple_856)
         render_inline(described_class.new(document:))
         expect(page).to     have_css('.panel-online')
         expect(page).not_to have_link('Find full text')

--- a/spec/components/location_request_link_component_spec.rb
+++ b/spec/components/location_request_link_component_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
   context 'for Hoover Archive items with finding aids' do
     let(:document) do
       SolrDocument.new(
-        url_suppl: ['http://oac.cdlib.org/ark:/abc123']
+        marc_links_struct: [{ href: "http://oac.cdlib.org/ark:/abc123", finding_aid: true }]
       )
     end
     let(:library) { 'HV-ARCHIVE' }
@@ -150,7 +150,10 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
 
     context 'when the item is also available via SFX' do
       let(:document) do
-        SolrDocument.new(url_sfx: 'https://library.stanford.edu', item_display: item_display_field)
+        SolrDocument.new(
+          item_display: item_display_field,
+          marc_links_struct: [{ href: "https://library.stanford.edu", sfx: true }]
+        )
       end
 
       it { expect(page).not_to have_link }
@@ -158,7 +161,10 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
 
     context 'when the full text is also available' do
       let(:document) do
-        SolrDocument.new(url_fulltext: 'https://library.stanford.edu', item_display: item_display_field)
+        SolrDocument.new(
+          marc_links_struct: [{ href: "https://library.stanford.edu", fulltext: true }],
+          item_display: item_display_field
+        )
       end
 
       it { expect(page).not_to have_link }
@@ -192,7 +198,7 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
     let(:document) do
       SolrDocument.new(
         id: '12345',
-        url_suppl: ['http://oac.cdlib.org/ark:/abc123']
+        marc_links_struct: [{ href: "http://oac.cdlib.org/ark:/abc123", finding_aid: true }]
       )
     end
 

--- a/spec/fixtures/solr_documents/29.yml
+++ b/spec/fixtures/solr_documents/29.yml
@@ -12,7 +12,6 @@
 :pub_date: 2014
 :beginning_year_isi: 2000
 :imprint_display: 1990
-:url_fulltext:
-  - "https://purl.stanford.edu/29"
-:url_suppl:
-  - "http://oac.cdlib.org/findaid/ark:/something-else"
+:marc_links_struct:
+ - '{ "href": "https://purl.stanford.edu/29", "fulltext": true }'
+ - '{ "href": "http://oac.cdlib.org/findaid/ark:/something-else", "finding_aid": true }'

--- a/spec/fixtures/solr_documents/40.yml
+++ b/spec/fixtures/solr_documents/40.yml
@@ -11,8 +11,8 @@
 :building_facet:
   - "Stanford Digital Repository"
 :modsxml: <%= mods_everything %>
-:url_fulltext:
-  - "https://purl.stanford.edu/40"
+marc_links_struct:
+  - '{ "href": "https://purl.stanford.edu/40", "fulltext": true }'
 :pub_date: 3204
 :beginning_year_isi: 3204
 :imprint_display: 3204

--- a/spec/fixtures/solr_documents/5608954.yml
+++ b/spec/fixtures/solr_documents/5608954.yml
@@ -5,8 +5,9 @@
 :title_sort: Selected Database 2
 :title_245a_display: Selected Database 2
 :language: English
-:url_fulltext: "https://searchworks.stanford.edu"
-:url_suppl: "https://library.stanford.edu"
+:marc_links_struct:
+  - '{ "href": "https://searchworks.stanford.edu", "fulltext": true }'
+  - '{ "href": "https://library.stanford.edu" }'
 :format: Database
 :format_main_ssim: Database
 :access_facet: Online

--- a/spec/fixtures/solr_documents/57.yml
+++ b/spec/fixtures/solr_documents/57.yml
@@ -3,4 +3,5 @@
 :title_display: SFX Catalog Item
 :format_main_ssim: Journal/Periodical
 :marcxml: <%= metadata1 %>
-:url_sfx: http://sfx.example.com/
+:marc_links_struct:
+ - '{ "href": "http://sfx.example.com/", "sfx": true }'

--- a/spec/fixtures/solr_documents/5749286.yml
+++ b/spec/fixtures/solr_documents/5749286.yml
@@ -4,23 +4,9 @@
 :title_display: Selected Database 3
 :title_sort: Selected Database 3
 :title_245a_display: Selected Database 3
-:url_fulltext:
-  - "https://library.stanford.edu"
-  - "https://searchworks.stanford.edu"
 :language: English
 :format: Database
 :format_main_ssim: Database
 :access_facet: Online
-:marc_links_struct: |
-    {
-       "managed_purl" : null,
-       "sort" : null,
-       "fulltext" : true,
-       "druid" : null,
-       "href" : "https://stanford.idm.oclc.org/login?url=http://search.ebscohost.com/login.aspx?authtype=ip,sso&custid=s4392798&profile=ehost&defaultdb=aph",
-       "finding_aid" : false,
-       "stanford_only" : 20,
-       "link_text" : "search.ebscohost.com",
-       "link_title" : "Available to Stanford-affiliated users only",
-       "file_id" : null
-    }
+:marc_links_struct:
+    - '{ "fulltext" : true, "href" : "https://stanford.idm.oclc.org/login?url=http://search.ebscohost.com/login.aspx?authtype=ip,sso&custid=s4392798&profile=ehost&defaultdb=aph", "stanford_only" : true, "link_text" : "search.ebscohost.com", "link_title" : "Available to Stanford-affiliated users only" }'

--- a/spec/fixtures/solr_documents/7626894.yml
+++ b/spec/fixtures/solr_documents/7626894.yml
@@ -5,7 +5,8 @@
 :title_sort: Selected Database 4
 :title_245a_display: Selected Database 4
 :language: English
-:url_fulltext: "https://stanford.idm.oclc.org/?url=https://searchworks.stanford.edu"
+:marc_links_struct:
+  - '{ "href": "https://stanford.idm.oclc.org/?url=https://searchworks.stanford.edu", "fulltext": true }'
 :format: Database
 :format_main_ssim: Database
 :access_facet: Online

--- a/spec/fixtures/solr_documents/8923346.yml
+++ b/spec/fixtures/solr_documents/8923346.yml
@@ -9,9 +9,6 @@
 :display_type:
   - sirsi
   - image
-:managed_purl_urls:
-  - https://purl.stanford.edu/ct493wg6431
-  - https://purl.stanford.edu/zg338xh5248
 marc_links_struct:
   - '{ "managed_purl": true, "href": "https://purl.stanford.edu/ct493wg6431", "druid": "ct493wg6431" }'
   - '{ "managed_purl": true, "href": "https://purl.stanford.edu/zg338xh5248", "druid": "zg338xh5248" }'

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -9,14 +9,14 @@ describe SearchWorksRecordMailer do
         id: '123',
         title_display: "Title1",
         item_display: ["12345 -|- GREEN -|- STACKS -|- -|- -|- -|- -|- -|- ABC 123"],
-        url_sfx: ["https://library.stanford.edu"],
+        marc_links_struct: [{ href: "https://library.stanford.edu", sfx: true }],
         modsxml: mods_everything
       ),
       SolrDocument.new(
         id: '321',
         title_display: "Title2",
         item_display: ["54321 -|- SAL3 -|- STACKS -|- -|- -|- -|- -|- -|- ABC 321"],
-        url_sfx: ["https://stacks.stanford.edu"],
+        marc_links_struct: [{ href: "https://stacks.stanford.edu", sfx: true }],
         marcxml: metadata1
       )
     ]

--- a/spec/models/concerns/druid_spec.rb
+++ b/spec/models/concerns/druid_spec.rb
@@ -1,9 +1,26 @@
 require "spec_helper"
 
 describe Druid do
-  let(:explicit_druid) { SolrDocument.new(druid: "321cba", url_fulltext: ["https://purl.stanford.edu/abc123"]) }
-  let(:document) { SolrDocument.new(url_fulltext: ["https://purl.stanford.edu/abc123"], url_suppl: ["https://stanford.edu/blah"]) }
-  let(:another_document) { SolrDocument.new(url_fulltext: ["https://stanford.edu/blah"], url_suppl: ["https://purl.stanford.edu/abc123"]) }
+  let(:explicit_druid) do
+    SolrDocument.new(
+      druid: "321cba",
+      marc_links_struct: [{ href: "https://purl.stanford.edu/abc123", fulltext: true }]
+    )
+  end
+
+  let(:document) do
+    SolrDocument.new(
+      marc_links_struct: [{ href: "https://purl.stanford.edu/abc123", fulltext: true },
+                          { href: "https://stanford.edu/blah" }]
+    )
+  end
+
+  let(:another_document) do
+    SolrDocument.new(
+      marc_links_struct: [{ href: "https://stanford.edu/blah", fulltext: true },
+                          { href: "https://purl.stanford.edu/abc123" }]
+    )
+  end
 
   it "should return the druid from the druid field if available" do
     expect(explicit_druid.druid).to eq "321cba"

--- a/spec/models/hathi_trust_links_spec.rb
+++ b/spec/models/hathi_trust_links_spec.rb
@@ -20,7 +20,14 @@ describe HathiTrustLinks do
     end
 
     context 'when the document has fulltext' do
-      before { document_data[:url_fulltext] = ['http://example.com'] }
+      before do
+        document_data[:marc_links_struct] = [{
+          href: "https://example.com",
+          link_text: "The Link",
+          fulltext: true,
+          stanford_only: true
+        }]
+      end
 
       it { expect(ht_links).not_to be_present }
     end

--- a/spec/models/json_results_document_presenter_spec.rb
+++ b/spec/models/json_results_document_presenter_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe JsonResultsDocumentPresenter do
 
     context 'when the source document is available online' do
       before do
-        document_data['url_sfx'] = 'https://example.com'
+        document_data['marc_links_struct'] = [{
+          "href": "https://example.com",
+          "link_text": "The Link",
+          "sfx": true,
+          "stanford_only": true
+        }]
       end
 
       it 'includes the fulltext_link_html field' do

--- a/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
@@ -34,9 +34,9 @@ describe "catalog/_index_online_section" do
           document: SolrDocument.new(
             id: '12345',
             isbn_display: [123],
-            managed_purl_urls: [
-              'https://purl.stanford.edu/ct493wg6431',
-              'https://purl.stanford.edu/zg338xh5248'
+            marc_links_struct: [
+              { href: 'https://purl.stanford.edu/ct493wg6431', managed_purl: true },
+              { href: 'https://purl.stanford.edu/zg338xh5248', managed_purl: true }
             ]
           )
         )

--- a/spec/views/catalog/_index_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_index_marc.html.erb_spec.rb
@@ -103,7 +103,7 @@ describe "catalog/_index_marc" do
     let(:document) do
       SolrDocument.new(
         marcxml: metadata1,
-        url_fulltext: ['http://oac.cdlib.org/findaid/ark:/12345']
+        marc_links_struct: [{ href: "http://oac.cdlib.org/ark:/abc123", finding_aid: true }]
       )
     end
 


### PR DESCRIPTION
This removes our dependence on legacy link fields: `url_fulltext`, `url_restricted`, `url_suppl`, `url_sfx`, and `managed_purl_urls`, relying instead on the `marc_links_struct` field.

Closes #3131
Unblocks #3112 and https://github.com/sul-dlss/searchworks_traject_indexer/issues/856