### PR TITLE
Add EZproxy prefix only for links with specific 856$z notes

### DIFF
--- a/app/models/concerns/index_links.rb
+++ b/app/models/concerns/index_links.rb
@@ -5,7 +5,7 @@ module IndexLinks
   def index_links
     @index_links ||= Links.new(
       fetch(:marc_links_struct, []).map do |link_struct|
-        IndexLinkProcessor.new(self, link_struct).to_searchworks_link
+        IndexLinkProcessor.new(self, link_struct).to_index_link
       end
     )
   end
@@ -18,15 +18,11 @@ module IndexLinks
       @link_struct = link_struct
     end
 
-    def to_searchworks_link
+    def to_index_link
       Links::Link.new(link_struct.merge({ link_text:, href: }))
     end
 
     private
-
-    def href
-      @href ||= Links.ezproxy_url(link_struct[:href], document) || link_struct[:href]
-    end
 
     def link_text
       if link_struct[:finding_aid]
@@ -38,6 +34,16 @@ module IndexLinks
       else
         link_struct[:link_text]
       end
+    end
+
+    def href
+      proxied_url || link_struct[:href]
+    end
+
+    def proxied_url
+      Links::Ezproxy.new(
+        url: link_struct[:href], link_title: link_struct[:link_title], document:
+      ).to_proxied_url
     end
 
     def link_host

--- a/app/models/concerns/marc_links.rb
+++ b/app/models/concerns/marc_links.rb
@@ -3,8 +3,33 @@
 # link_text values vs. links created in the IndexLinks module that modifies the link_text values.
 module MarcLinks
   def marc_links
-    @marc_links ||= Links.new(fetch(:marc_links_struct, []).map do |data|
-      Links::Link.new(data.merge(href: Links.ezproxy_url(data[:href], self) || data[:href]))
+    @marc_links ||= Links.new(fetch(:marc_links_struct, []).map do |link_struct|
+      MarcLinkProcessor.new(self, link_struct).to_marc_link
     end)
+  end
+
+  class MarcLinkProcessor
+    attr_reader :document, :link_struct
+
+    def initialize(document, link_struct)
+      @document = document
+      @link_struct = link_struct
+    end
+
+    def to_marc_link
+      Links::Link.new(link_struct.merge({ href: }))
+    end
+
+    private
+
+    def href
+      proxied_url || link_struct[:href]
+    end
+
+    def proxied_url
+      Links::Ezproxy.new(
+        url: link_struct[:href], link_title: link_struct[:link_title], document:
+      ).to_proxied_url
+    end
   end
 end

--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -1,40 +1,10 @@
 class Links
   include Enumerable
 
-  def self.ezproxied_hosts
-    @ezproxied_hosts ||= {
-      'LAW' => Rails.root.join('config/ezproxy/law_proxy_file.txt').read.split("\n"),
-      'LANE-MED' => Rails.root.join('config/ezproxy/lane_proxy_file.txt').read.split("\n"),
-      default: Rails.root.join('config/ezproxy/sul_proxy_file.txt').read.split("\n")
-    }
-  end
-
-  def self.ezproxy_url(url, document)
-    link_host = begin
-      URI.parse(url).host
-    rescue StandardError
-      nil
-    end
-    return unless link_host
-
-    libraries = document.holdings.libraries.map(&:code)
-
-    ezproxy_host = if libraries.include?('LAW') && ezproxied_hosts['LAW'].any?(link_host)
-                     Settings.libraries.LAW.ezproxy_host
-                   elsif libraries.include?('LANE-MED') && ezproxied_hosts['LANE-MED'].any?(link_host)
-                     Settings.libraries['LANE-MED'].ezproxy_host
-                   elsif ezproxied_hosts[:default].any?(link_host)
-                     Settings.libraries.default.ezproxy_host
-                   end
-
-    # EZproxy requires the use of the `qurl` param instead of `url` when the value is an encoded URL
-    # See: https://help.oclc.org/Library_Management/EZproxy/Troubleshooting/Why_am_I_getting_the_EZproxy_menu_page_when_using_an_encoded_URL_as_the_target_URL
-    "#{ezproxy_host}#{{ qurl: url }.to_param}" if ezproxy_host
-  end
-
   PROXY_REGEX = /stanford\.idm\.oclc\.org/
 
   delegate :each, :present?, :blank?, to: :all
+
   def initialize(links = [])
     @links = links
   end

--- a/app/models/links/ezproxy.rb
+++ b/app/models/links/ezproxy.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Links::Ezproxy decides whether a URL should have a proxy prefix added
+#  and which prefix to apply.
+class Links
+  class Ezproxy
+    SUL_RESTRICTED_REGEX = /available[ -]?to[ -]?stanford[ -]?affiliated[ -]?users[ -]?a?t?[:;.]?/i
+    LANE_RESTRICTED_REGEX = /Access restricted to Stanford community/i
+
+    attr_reader :url, :link_title, :document
+
+    def initialize(url:, link_title:, document:)
+      @url = url
+      @link_title = link_title
+      @document = document
+    end
+
+    # @return [String, nil] the proxy-prefixed URL or nil if the URL should not be proxied.
+    def to_proxied_url
+      return unless ezproxy_host
+
+      # EZproxy requires the use of the `qurl` param instead of `url` when the value is an encoded URL
+      # See: https://help.oclc.org/Library_Management/EZproxy/Troubleshooting/Why_am_I_getting_the_EZproxy_menu_page_when_using_an_encoded_URL_as_the_target_URL
+      "#{ezproxy_host}#{{ qurl: url }.to_param}"
+    end
+
+    private
+
+    def ezproxy_host
+      if apply_law_proxy_prefix?
+        Settings.libraries.LAW.ezproxy_host
+      elsif apply_lane_proxy_prefix?
+        Settings.libraries['LANE-MED'].ezproxy_host
+      elsif apply_sul_proxy_prefix?
+        Settings.libraries.default.ezproxy_host
+      end
+    end
+
+    def apply_law_proxy_prefix?
+      libraries.include?('LAW') &&
+        ezproxied_hosts['LAW'].any?(link_host)
+    end
+
+    def apply_lane_proxy_prefix?
+      libraries.include?('LANE-MED') &&
+        ezproxied_hosts['LANE-MED'].any?(link_host) &&
+        lane_restricted?
+    end
+
+    def apply_sul_proxy_prefix?
+      ezproxied_hosts[:default].any?(link_host) &&
+        sul_restricted?
+    end
+
+    def libraries
+      @libraries ||= document.holdings.libraries.map(&:code)
+    end
+
+    def ezproxied_hosts
+      @ezproxied_hosts ||= {
+        'LAW' => Rails.root.join('config/ezproxy/law_proxy_file.txt').read.split("\n"),
+        'LANE-MED' => Rails.root.join('config/ezproxy/lane_proxy_file.txt').read.split("\n"),
+        default: Rails.root.join('config/ezproxy/sul_proxy_file.txt').read.split("\n")
+      }
+    end
+
+    def link_host
+      @link_host ||= begin
+        URI.parse(url).host
+      rescue StandardError
+        nil
+      end
+    end
+
+    def lane_restricted?
+      LANE_RESTRICTED_REGEX.match?(link_title)
+    end
+
+    def sul_restricted?
+      SUL_RESTRICTED_REGEX.match?(link_title)
+    end
+  end
+end

--- a/spec/models/concerns/marc_links_spec.rb
+++ b/spec/models/concerns/marc_links_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe MarcLinks do
+RSpec.describe MarcLinks do
   include Marc856Fixtures
   it "should return an empty array for non marc records" do
     expect(SolrDocument.new.marc_links.all).to eq []
@@ -32,7 +32,8 @@ describe MarcLinks do
       let(:document) do
         SolrDocument.new(
           marc_links_struct: [{
-            href: 'http://ch.ucpress.edu/whatever'
+            href: 'http://ch.ucpress.edu/whatever',
+            link_title: 'Available to Stanford-affiliated users.'
           }]
         )
       end

--- a/spec/models/links/ezproxy_spec.rb
+++ b/spec/models/links/ezproxy_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+
+RSpec.describe Links::Ezproxy do
+  subject(:ezproxy) do
+    Links::Ezproxy.new(url:, link_title:, document:)
+  end
+
+  describe '#to_proxied_url' do
+    context 'SUL record' do
+      let(:document) do
+        SolrDocument.new({ item_display: ['barcode -|- SUL'] })
+      end
+
+      context 'with a url matching a SUL proxied host' do
+        let(:url) { 'http://ch.ucpress.edu/whatever' }
+
+        context 'link title is a SUL restriction note' do
+          let(:link_title) { 'Available to Stanford Affiliated users' }
+
+          it 'adds the proxy prefix' do
+            expect(ezproxy.to_proxied_url).to eq 'https://stanford.idm.oclc.org/login?qurl=http%3A%2F%2Fch.ucpress.edu%2Fwhatever'
+          end
+        end
+
+        context 'link title is NOT a SUL restriction note' do
+          let(:link_title) { 'Some other link note' }
+
+          it { expect(ezproxy.to_proxied_url).to be_nil }
+        end
+      end
+
+      context 'with a url matching a LAW proxied host' do
+        let(:url) { 'https://www.iareporter.com/whatever' }
+        let(:link_title) { 'Available to Stanford Affiliated users' }
+
+        it { expect(ezproxy.to_proxied_url).to be_nil }
+      end
+
+      context 'with a url matching a LANE proxied host' do
+        let(:url) { 'https://who.int/whatever' }
+        let(:link_title) { 'Access restricted to Stanford community' }
+
+        it { expect(ezproxy.to_proxied_url).to be_nil }
+      end
+
+      context 'with a url NOT matching a SUL proxied host' do
+        let(:url) { 'https://stanford.idm.oclc.org/login?url=https://library.stanford.edu' }
+        let(:link_title) { 'Available to Stanford Affiliated users' }
+
+        it { expect(ezproxy.to_proxied_url).to be_nil }
+      end
+    end
+
+    context 'LAW record' do
+      let(:document) do
+        SolrDocument.new({ item_display: ['barcode -|- LAW'] })
+      end
+
+      context 'with a url matching a LAW proxied host' do
+        let(:url) { 'https://www.iareporter.com/whatever' }
+        let(:link_title) { 'Some other link note' }
+
+        it 'adds the proxy prefix' do
+          expect(ezproxy.to_proxied_url).to eq 'http://ezproxy.law.stanford.edu/login?qurl=https%3A%2F%2Fwww.iareporter.com%2Fwhatever'
+        end
+      end
+
+      context 'with a url matching a SUL proxied host' do
+        let(:url) { 'http://ch.ucpress.edu/whatever' }
+
+        context 'link title is a SUL restriction note' do
+          let(:link_title) { 'Available to Stanford Affiliated users' }
+
+          it 'adds the proxy prefix' do
+            expect(ezproxy.to_proxied_url).to eq 'https://stanford.idm.oclc.org/login?qurl=http%3A%2F%2Fch.ucpress.edu%2Fwhatever'
+          end
+        end
+
+        context 'link title is NOT a SUL restriction note' do
+          let(:link_title) { 'Some other link note' }
+
+          it { expect(ezproxy.to_proxied_url).to be_nil }
+        end
+      end
+
+      context 'with a url NOT matching any proxied host' do
+        let(:url) { 'https://stanford.idm.oclc.org/login?url=https://library.stanford.edu' }
+        let(:link_title) { 'Available to Stanford Affiliated users' }
+
+        it { expect(ezproxy.to_proxied_url).to be_nil }
+      end
+    end
+
+    context 'LANE record' do
+      let(:document) do
+        SolrDocument.new({ item_display: ['barcode -|- LANE-MED'] })
+      end
+
+      context 'with a url matching a LANE proxied host' do
+        let(:url) { 'https://who.int/whatever' }
+
+        context 'link title is a LANE restriction note' do
+          let(:link_title) { 'Access restricted to Stanford community' }
+
+          it 'adds the proxy prefix' do
+            expect(ezproxy.to_proxied_url).to eq 'https://login.laneproxy.stanford.edu/login?qurl=https%3A%2F%2Fwho.int%2Fwhatever'
+          end
+        end
+
+        context 'link title is NOT a LANE restriction note' do
+          let(:link_title) { 'Some other link note' }
+
+          it { expect(ezproxy.to_proxied_url).to be_nil }
+        end
+      end
+
+      context 'with a url matching a SUL proxied host' do
+        let(:url) { 'http://ch.ucpress.edu/whatever' }
+
+        context 'link title is a SUL restriction note' do
+          let(:link_title) { 'Available to Stanford Affiliated users' }
+
+          it 'adds the proxy prefix' do
+            expect(ezproxy.to_proxied_url).to eq 'https://stanford.idm.oclc.org/login?qurl=http%3A%2F%2Fch.ucpress.edu%2Fwhatever'
+          end
+        end
+
+        context 'link title is NOT a SUL restriction note' do
+          let(:link_title) { 'Some other link note' }
+
+          it { expect(ezproxy.to_proxied_url).to be_nil }
+        end
+      end
+
+      context 'with a url NOT matching any proxied host' do
+        let(:url) { 'https://stanford.idm.oclc.org/login?url=https://library.stanford.edu' }
+        let(:link_title) { 'Available to Stanford Affiliated users' }
+
+        it { expect(ezproxy.to_proxied_url).to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a Links::Ezproxy class to wrap logic related to deciding whether to add a proxy prefix and which prefix to add.
Closes #3112
