### PR TITLE
Only show circ rule debug information if we have an actual folio item…

### DIFF
--- a/app/views/catalog/_folio_json_view.html.erb
+++ b/app/views/catalog/_folio_json_view.html.erb
@@ -8,7 +8,7 @@
             <summary>FOLIO JSON</summary>
             <pre><%= JSON.pretty_generate(JSON.parse(@document.first(:folio_json_struct))) %></pre>
         </details>
-        <% if @document.preferred_item %>
+        <% if @document.preferred_item&.folio_item? %>
         <details>
             <summary>Circulation rules</summary>
             <pre><%= Folio::CirculationRules::PolicyService.instance.item_rule(@document.preferred_item).to_debug_s %></pre>


### PR DESCRIPTION
… (e.g. not a bound with, on-order, etc)
Fixes #3204 