### PR TITLE
Defensively guard against missing library information

### DIFF
--- a/app/components/access_panels/library_component.html.erb
+++ b/app/components/access_panels/library_component.html.erb
@@ -3,7 +3,7 @@
     <div class="library-location-heading access-panel-heading">
       <%= thumb_for_library %>
       <div class="library-location-heading-text">
-        <h3 class="<%= "no-link" unless settings.about_url %>"><%= library.name %></h3>
+        <h3 class="<%= "no-link" unless library.about_url %>"><%= library.name %></h3>
         <div class="small location-hours-today">
           <% unless library.holding_library? %>
             (no holding library)

--- a/app/components/access_panels/library_component.rb
+++ b/app/components/access_panels/library_component.rb
@@ -2,14 +2,13 @@ module AccessPanels
   class LibraryComponent < ViewComponent::Base
     with_collection_parameter :library
 
-    attr_reader :library, :document, :settings
+    attr_reader :library, :document
 
     # @params [Holdings::Library] library the holdings for the item at a particular library
     # @params [SolrDocument] document
     def initialize(library:, document:)
       @library = library
       @document = document
-      @settings = Settings.libraries[library.code]
     end
 
     def thumb_for_library
@@ -26,7 +25,7 @@ module AccessPanels
     end
 
     def link_to_library_about_page(&)
-      link_to_if settings.about_url, capture(&), settings.about_url
+      link_to_if library.about_url, capture(&), library.about_url
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -268,6 +268,7 @@ libraries:
     name: Stanford Libraries
   default:
     ezproxy_host: https://stanford.idm.oclc.org/login?
+    name: Stanford Libraries
 
 
 selected_databases:

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -2,20 +2,14 @@ class Holdings
   class Library
     attr_reader :code, :items, :mhld
 
+    delegate :name, :about_url, to: :config
+
     # @params [String] code the library code (e.g. 'GREEN')
     # @params [Array<Holdings::Item>] items ([]) a list of items at this library.
     def initialize(code, items = [], mhld = [])
       @code = code
       @items = items
       @mhld = mhld
-    end
-
-    def name
-      config = Settings.libraries[@code]
-      return config.name if config
-
-      Honeybadger.notify("No library config", context: { code: @code })
-      nil
     end
 
     # @return [Array<Holdings::Location>] the locations with the holdings
@@ -75,6 +69,10 @@ class Holdings
         name:,
         library_instructions:
       }
+    end
+
+    def config
+      Settings.libraries[@code] || Settings.libraries.default
     end
   end
 end

--- a/spec/components/access_panels/library_component_spec.rb
+++ b/spec/components/access_panels/library_component_spec.rb
@@ -15,7 +15,18 @@ RSpec.describe AccessPanels::LibraryComponent, type: :component do
 
     it "should return the image tag (w/ png extension) for the ZOMBIE library" do
       render_inline(component)
+
       expect(page).to have_selector('img[src^="/assets/ZOMBIE"][data-hidpi-src^="/assets/ZOMBIE@2x"]')
+    end
+  end
+
+  context 'with an unknown library' do
+    let(:library) { Holdings::Library.new('no-such-library') }
+
+    it "returns a placeholder panel" do
+      render_inline(component)
+
+      expect(page).to have_selector('h3.no-link', text: 'Stanford Libraries')
     end
   end
 end


### PR DESCRIPTION
This fixes a regression introduced in #3156.