### PR TITLE
Display MARC 795 values and link to subject search

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -564,7 +564,7 @@ Metrics/MethodLength:
 # Offense count: 7
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 1328
+  Max: 1342
 
 # Offense count: 19
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -183,7 +183,7 @@
         $googleBooks.removeClass('hide').addClass('show');
         // Re-run responsive truncation on the list in case the google link takes us over the two-line threshold
         $googleBooks
-          .parents("[data-behavior='truncate-results-online-links']")
+          .parents("[data-behavior='truncate-results-metadata-links']")
           .responsiveTruncate({lines: 2, more: 'more...', less: 'less...'});
       }
     }

--- a/app/assets/javascripts/truncate.js
+++ b/app/assets/javascripts/truncate.js
@@ -2,7 +2,7 @@ Blacklight.onLoad(function(){
   $("[data-behavior='metadata-truncate']").responsiveTruncate(
     { height: 40, more: 'more...', less: 'less...' }
   );
-  $("[data-behavior='truncate-results-online-links']").responsiveTruncate({lines: 2, more: 'more...', less: 'less...'});
+  $("[data-behavior='truncate-results-metadata-links']").responsiveTruncate({lines: 2, more: 'more...', less: 'less...'});
   $("[data-behavior='truncate']").responsiveTruncate({height: 60});
   $("[data-behavior='trunk8']").trunk8({
     tooltip: false

--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -44,6 +44,14 @@
     margin: 0;
     padding: 10px 0;
 
+    ul {
+      padding-left: 0;
+    }
+
+    // Without this a dot is displayed before the first li
+    li::marker {
+        content: '';
+    }
 
     dd {
       margin-left: 2em;
@@ -52,6 +60,12 @@
     @media (min-width: $screen-sm-min) {
       dd {
         margin-left: 8.5em;
+      }
+
+      .responsiveTruncate {
+        dd {
+          margin-left: 4.25em;
+        }
       }
     }
   }

--- a/app/models/concerns/collection_titles.rb
+++ b/app/models/concerns/collection_titles.rb
@@ -1,0 +1,8 @@
+##
+# Mixin to add access to collection titles to the SolrDocument
+module CollectionTitles
+  def collection_titles
+    fetch(:collection_struct, []).map { |collection| collection.slice(:title, :vernacular).compact }
+                                 .reject(&:empty?)
+  end
+end

--- a/app/models/concerns/marc_metadata.rb
+++ b/app/models/concerns/marc_metadata.rb
@@ -73,4 +73,8 @@ module MarcMetadata
   def included_works
     @included_works ||= IncludedWorks.new(self)
   end
+
+  def linked_collection
+    @linked_collection ||= LinkedCollection.new(self)
+  end
 end

--- a/app/models/marc_fields/linked_collection.rb
+++ b/app/models/marc_fields/linked_collection.rb
@@ -1,0 +1,13 @@
+##
+# A class to handle MARC 795 field logic
+class LinkedCollection < MarcField
+  def to_partial_path
+    'marc_fields/linked_collection'
+  end
+
+  private
+
+  def tags
+    %w[795ap]
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,6 +30,7 @@ class SolrDocument
   include IiifConcern
   include DorContentMetadata
   include LiveLookupIds
+  include CollectionTitles
 
   include Blacklight::Solr::Document
   include SchemaDotOrg

--- a/app/views/catalog/_index_marc.html.erb
+++ b/app/views/catalog/_index_marc.html.erb
@@ -36,11 +36,26 @@
     <% end %>
 
     <% if document.index_parent_collections.present? %>
-      <dt>Collection</dt>
+      <dt>Digital collection</dt>
       <dd>
         <% document.index_parent_collections.each do |collection| %>
           <%= link_to(document_presenter(collection).heading, solr_document_path(collection))%>
         <% end %>
+      </dd>
+    <% end %>
+
+    <% if document.collection_titles.any? %>
+      <dt>Collection</dt>
+      <dd>
+        <ul data-behavior="truncate-results-metadata-links">
+          <% document.collection_titles.each do |collection| %>
+            <% collection.each do |_k, collection_title| %>
+              <li>
+                <%= link_to(collection_title.strip, search_catalog_path(search_field: :subject_terms, q: "\"#{collection_title.strip}\"")) %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
       </dd>
     <% end %>
   </dl>

--- a/app/views/catalog/_index_mods.html.erb
+++ b/app/views/catalog/_index_mods.html.erb
@@ -28,7 +28,7 @@
   <% end %>
 
   <% if document.index_parent_collections.present? %>
-    <dt>Collection</dt>
+    <dt>Digital collection</dt>
     <dd>
       <% document.index_parent_collections.each do |collection| %>
         <%= link_to(document_presenter(collection).heading, solr_document_path(collection))%>

--- a/app/views/catalog/_index_online_section.html.erb
+++ b/app/views/catalog/_index_online_section.html.erb
@@ -6,7 +6,7 @@
     <dt class="online-label">Online</dt>
   <% end %>
   <dd>
-    <ul class="online-links" data-behavior="truncate-results-online-links">
+    <ul class="online-links" data-behavior="truncate-results-metadata-links">
       <% document.preferred_online_links.each do |link| %>
         <li class="<%= 'stanford-only' if link.stanford_only? %>">
           <%= link.html.html_safe %>

--- a/app/views/catalog/record/_marc_upper_metadata_items.html.erb
+++ b/app/views/catalog/record/_marc_upper_metadata_items.html.erb
@@ -17,7 +17,7 @@
       <% end %>
     <%- end -%>
 
-    <% [:language, '344', '345', '346', '347', '250ab', :imprint, :production_notice, '3003abcefg', :marc_instrumentation, :linked_series].each do |tag| %>
+    <% [:language, '344', '345', '346', '347', '250ab', :imprint, :production_notice, '3003abcefg', :marc_instrumentation, :linked_series, :linked_collection].each do |tag| %>
       <%= render_if_present document.marc_field(tag) %>
     <% end %>
   </dl>

--- a/app/views/marc_fields/_linked_collection.html.erb
+++ b/app/views/marc_fields/_linked_collection.html.erb
@@ -1,0 +1,6 @@
+<% if linked_collection.values.present? %>
+  <dt><%= linked_collection.label %></dt>
+  <% linked_collection.values.each do |value| %>
+    <dd><%= link_to(value.strip, search_catalog_path(search_field: :subject_terms, q: "\"#{value.strip}\"")) %></dd>
+  <% end  %>
+<% end %>

--- a/app/views/selected_databases/_database.html.erb
+++ b/app/views/selected_databases/_database.html.erb
@@ -5,7 +5,7 @@
     <dl data-behavior="results-online-section" class="dl-horizontal results-online-section">
       <dt class="online-label">Search database</dt>
       <dd>
-        <div data-behavior="truncate-results-online-links">
+        <div data-behavior="truncate-results-metadata-links">
           <ul class="links">
             <% database.marc_links.each do |link| %>
               <li class="<%= 'stanford-only' if link.stanford_only? %>"><%= link.html.html_safe %></li>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -219,6 +219,8 @@ en:
         label: "Taxonomy"
       790:
         label: "Local subject"
+      795:
+        label: "Collection"
       796:
         label: "Contributor"
       797:

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -1053,7 +1053,8 @@
         toc_struct:[json],
         uniform_title_display_struct:[json],
         schema_dot_org_struct:[json],
-        holdings_json_struct:[json]
+        holdings_json_struct:[json],
+        collection_struct:[json]
       </str>
     </lst>
   </requestHandler>
@@ -1070,7 +1071,8 @@
         toc_struct:[json],
         uniform_title_display_struct:[json],
         schema_dot_org_struct:[json],
-        holdings_json_struct:[json]
+        holdings_json_struct:[json],
+        collection_struct:[json]
       </str>
       <int name="rows">1</int>
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -1398,4 +1398,19 @@ module MarcMetadataFixtures
       </record>
     xml
   end
+
+  def marc_795_fixture
+    <<-xml
+      <record>
+        <datafield ind1=' ' ind2=' ' tag='795'>
+          <subfield code='6'>880-05</subfield>
+          <subfield code='a'>Shao shu min zu she hui li shi diao cha</subfield>
+        </datafield>
+        <datafield ind1=' ' ind2=' ' tag='880'>
+          <subfield code='6'>795-05</subfield>
+          <subfield code='a'>少数民族社会历史调查</subfield>
+        </datafield>
+      </record>
+    xml
+  end
 end

--- a/spec/models/concerns/collection_titles_spec.rb
+++ b/spec/models/concerns/collection_titles_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CollectionTitles do
+  let(:document_data) { {} }
+
+  subject(:collection_titles) { SolrDocument.new(document_data).collection_titles }
+
+  context 'when there are no collection titles' do
+    it { expect(collection_titles).not_to be_present }
+  end
+
+  context 'when there is a collection title' do
+    let(:document_data) do
+      { collection_struct: [{ "title" => "Robert Creeley Papers Collection", "source" => "sirsi" }] }
+    end
+
+    it { expect(collection_titles).to eq [{ "title" => "Robert Creeley Papers Collection" }] }
+  end
+
+  context 'when the collection title has a linked vernacular field' do
+    let(:document_data) do
+      { collection_struct: [{ "title" => "Shao shu min zu she hui li shi diao cha",
+                              "source" => "sirsi",
+                              "vernacular" => "少数民族社会历史调查" }] }
+    end
+
+    it { expect(collection_titles).to eq [{ "title" => "Shao shu min zu she hui li shi diao cha", "vernacular" => "少数民族社会历史调查" }] }
+  end
+
+  context 'when the title is nil' do
+    let(:document_data) do
+      { "source" => "SDR-PURL",
+        "item_type" => "item",
+        "type" => "file:jx525pn5438%2Fjx525pn5438_img_1.jp2",
+        "druid" => "collection:sz746mt0652::ARS Disc Collection - LP",
+        "id" => nil,
+        "title" => nil }
+    end
+
+    it { expect(collection_titles).not_to be_present }
+  end
+end

--- a/spec/models/marc_fields/linked_collection_spec.rb
+++ b/spec/models/marc_fields/linked_collection_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe LinkedCollection do
+  include MarcMetadataFixtures
+  let(:document) { SolrDocument.new(marcxml: marc_795_fixture) }
+
+  subject { described_class.new(document) }
+
+  describe '#label' do
+    it 'is Collection' do
+      expect(subject.label).to eq 'Collection'
+    end
+  end
+
+  describe '#values' do
+    it 'returns values for each linkable field' do
+      expect(subject.values.length).to eq 2
+    end
+
+    it 'returns the collection titles' do
+      expect(subject.values.first).to eq 'Shao shu min zu she hui li shi diao cha'
+      expect(subject.values.last).to eq '少数民族社会历史调查'
+    end
+  end
+
+  describe '#to_partial_path' do
+    it 'is overriden from the base partial path' do
+      expect(subject.to_partial_path).to eq 'marc_fields/linked_collection'
+    end
+  end
+end

--- a/spec/views/catalog/_index_marc.html.erb_spec.rb
+++ b/spec/views/catalog/_index_marc.html.erb_spec.rb
@@ -116,4 +116,21 @@ describe "catalog/_index_marc" do
       expect(rendered).to have_css('dd a', text: 'Online Archive of California')
     end
   end
+
+  describe 'collection' do
+    let(:document) do
+      SolrDocument.new(
+        collection_struct: [{ 'title' => 'Robert Creeley Papers Collection', 'source' => 'sirsi' }]
+      )
+    end
+
+    before do
+      render
+    end
+
+    it 'should display the collection title and subject search link' do
+      expect(rendered).to have_css('dt', text: "Collection")
+      expect(rendered).to have_css('dd a', text: "Robert Creeley Papers Collection")
+    end
+  end
 end

--- a/spec/views/catalog/_index_mods.html.erb_spec.rb
+++ b/spec/views/catalog/_index_mods.html.erb_spec.rb
@@ -33,8 +33,8 @@ describe "catalog/_index_mods" do
     expect(rendered).to have_css("dt", text: "Description")
     expect(rendered).to have_css("dd", text: "The Physical Extent")
   end
-  it "should include the collection" do
-    expect(rendered).to have_css('dt', text: 'Collection')
+  it "should include the digital collection" do
+    expect(rendered).to have_css('dt', text: 'Digital collection')
   end
 
   it 'should include the summary' do

--- a/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
@@ -94,4 +94,17 @@ describe "catalog/record/_marc_upper_metadata_items" do
       expect(rendered).to have_css('dd', text: 'cowbell')
     end
   end
+
+  describe 'MARC 795' do
+    before do
+      assign(:document, SolrDocument.new(marcxml: marc_795_fixture))
+      render
+    end
+
+    it 'should render the collection titles as links' do
+      expect(rendered).to have_css('dt', text: 'Collection')
+      expect(rendered).to have_css('dd a', text: 'Shao shu min zu she hui li shi diao cha')
+      expect(rendered).to have_css('dd a', text: '少数民族社会历史调查')
+    end
+  end
 end

--- a/spec/views/preview/_show_mods.html.erb_spec.rb
+++ b/spec/views/preview/_show_mods.html.erb_spec.rb
@@ -34,8 +34,8 @@ describe "preview/_show_mods" do
     expect(rendered).to have_css('li', text: "Imprint Statement")
   end
 
-  it 'should display the collection' do
-    expect(rendered).to have_css('dt', text: 'Collection')
+  it 'should display the digital collection' do
+    expect(rendered).to have_css('dt', text: 'Digital collection')
     # Note: This is the object title because we're stubbing the presenter in this test
     expect(rendered).to have_css('dd a', text: 'Object Title')
   end


### PR DESCRIPTION
Closes #3150 

Show view with vernacular title:
<img width="1004" alt="Screenshot 2023-06-29 at 9 07 50 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/ceda9e40-65bc-4a46-b9d1-9d850c7bc6cd">

Index view with more/less widget:
<img width="657" alt="Screenshot 2023-06-29 at 9 08 33 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/ae3e47c2-43e7-411a-81ef-22abe83bd40e">

Still todo:

- [x] Get truncation more/less working in the results view for linked collection titles.
- [x] Figure out why [_marc_upper_metadata_items.html.erb_spec.rb](https://github.com/sul-dlss/SearchWorks/compare/3150-display-795?expand=1#diff-278e14b00de42b6f5adda6cacdebd783cf5e8c1e122b109a775332dbd94282be) is complaining about no matching route.
