### PR TITLE
Make the circ rule debug info in librarian view easier to read

### DIFF
--- a/app/services/folio/circulation_rules/rule.rb
+++ b/app/services/folio/circulation_rules/rule.rb
@@ -28,7 +28,7 @@ module Folio
       # group: faculty & material-type: periodical & loan-type: any & location-institution: any & location-campus: any & location-library: SAL & location-location: any => loan: 14day-1renew-1daygrace, request: Allow All, notice: Short-term loans, overdue: No fines policy, lost-item: $100 lost fee policy (line 257)
       # ```
       def to_debug_s
-        "#{to_criteria_debug_s} => #{to_policy_debug_s} (line #{line})"
+        "#{to_criteria_debug_s}\n#{to_policy_debug_s}\n(line #{line})"
       end
 
       private
@@ -46,11 +46,11 @@ module Folio
                           type_map.call(v)
                         end
           "#{k}: #{debug_value}"
-        end.join(" & ")
+        end.join("\n")
       end
 
       def to_policy_debug_s
-        policy.map { |k, v| "#{k}: #{Folio::Types.policies.dig(k.to_sym, v, 'name')&.strip || v}" }.join(", ")
+        policy.map { |k, v| "=> #{k}: #{Folio::Types.policies.dig(k.to_sym, v, 'name')&.strip || v}" }.join("\n")
       end
     end
   end


### PR DESCRIPTION
Adds some newlines and formatting so that the parts of the rule are clearer. When inside a `<pre>`, it's hard to tell the parts apart and figure out what's a rule vs. a policy.

Before:
<img width="584" alt="Screenshot 2023-06-22 at 14 47 38" src="https://github.com/sul-dlss/SearchWorks/assets/4924494/b8f7d00a-91f2-4ba1-9c28-eb9edd96baf9">

After:
<img width="586" alt="Screenshot 2023-06-22 at 14 46 04" src="https://github.com/sul-dlss/SearchWorks/assets/4924494/1714c7d2-125f-4434-ae1b-89816ea4ccdf">
