### PR TITLE
Require the library parameter for stackmap

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -507,6 +507,7 @@ class CatalogController < ApplicationController
   end
 
   def stackmap
+    params.require(:library) # Sometimes bots are calling this service without providing required parameters. Raise an error in this case.
     render layout: !request.xhr?
   end
 

--- a/spec/requests/stackmap_spec.rb
+++ b/spec/requests/stackmap_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Stackmap' do
+  it 'renders the page' do
+    get '/view/1/stackmap', params: { library: 'GREEN' }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  context 'when the library parameter is missing' do
+    it 'raises an error' do
+      expect { get '/view/1/stackmap' }.to raise_error ActionController::ParameterMissing
+    end
+  end
+end


### PR DESCRIPTION
Bot have been calling this route with invalid parameters.  This check prevents us from trying to render when we don't have the necessary data. Fixes https://app.honeybadger.io/projects/50022/faults/96387675

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
