### PR TITLE
Group names are under the key 'group', not 'name'

### DIFF
--- a/app/services/folio/circulation_rules/policy_service.rb
+++ b/app/services/folio/circulation_rules/policy_service.rb
@@ -18,7 +18,7 @@ module Folio
       end
 
       def self.standard_patron_group_uuids(group_names = Settings.folio.standard_patron_group_names)
-        @standard_patron_group_uuids ||= Folio::Types.criteria['group'].select { |_k, v| group_names.include? v['name'] }.keys
+        @standard_patron_group_uuids ||= Folio::Types.criteria['group'].select { |_k, v| group_names.include? v['group'] }.keys
       end
 
       def self.instance


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
