### PR TITLE
Ensure Safari does not apply a list-style to collection title links

### DIFF
--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -45,6 +45,7 @@
     padding: 10px 0;
 
     ul {
+      list-style: none;
       padding-left: 0;
     }
 


### PR DESCRIPTION
Before:
<img width="795" alt="Screenshot 2023-07-12 at 9 28 48 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/d0952701-d786-4e4d-9023-326b65046135">

After:

<img width="797" alt="Screenshot 2023-07-12 at 9 28 31 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/71b33208-8a42-4334-8689-8b022ebce1bf">
