### PR TITLE
Use a legal selector for external links

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -36,7 +36,7 @@ Blacklight.onLoad(function() {
   })
 
   // Track external link clicks
-  document.querySelectorAll('a[href]:not([href^="/"],[href^="#"],[data-behavior="requests-modal"],[href=""])').forEach(function(el) {
+  document.querySelectorAll('a[href*="://"]').forEach(function(el) {
     el.addEventListener('click', function(e) {
       sendAnalyticsEvent({
         category: 'External link',


### PR DESCRIPTION
Here we're looking for an href attribute that has a protocol separator in it.  I'm fairly certain that there is no part of the application that has the data-behavor='requests-modal' attribute set.

Fixes #3260