### PR TITLE
Remove unused method

### DIFF
--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -24,12 +24,6 @@ class Holdings
       library == 'LANE-MED'
     end
 
-    def request_link
-      return if items.empty? || bound_with?
-
-      @request_link ||= RequestLink.for(library:, location: @code, items:)
-    end
-
     def location_link
       return unless external_location?
 


### PR DESCRIPTION
This code will break if it is called:
```
bin/rails c
Loading development environment (Rails 7.0.6)
irb(main):001:0> RequestLink
(irb):1:in `<main>': uninitialized constant RequestLink (NameError)

RequestLink
^^^^^^^^^^^
```