### PR TITLE
Add FOLIO codes to unavailable locations

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -759,6 +759,14 @@ unavailable_current_locations:
     - TECH-SER
     - TECH-SERV
     - TEMP-LL
+    - TS-CC-REPAIR
+    - TS-CC-BINDERYPREP
+    - TS-CC-BOOKJACKET
+    - TS-CC-KASEMAKE
+    - TS-COLLECTIONCARE
+    - TS-CC-SPECIALPROJECTS
+    - TS-CONSERVATION
+    - TS-PROCESSING
 
 requestable_current_locations:
   default:

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -862,7 +862,15 @@ module Constants
                       'TECH-PROC',
                       'TECH-SER',
                       'TECH-SERV',
-                      'TEMP-LL']
+                      'TEMP-LL',
+                      'TS-CC-REPAIR',
+                      'TS-CC-BINDERYPREP',
+                      'TS-CC-BOOKJACKET',
+                      'TS-CC-KASEMAKE',
+                      'TS-COLLECTIONCARE',
+                      'TS-CC-SPECIALPROJECTS',
+                      'TS-CONSERVATION',
+                      'TS-PROCESSING']
 
   FORCE_AVAILABLE_CURRENT_LOCS = [
     'ART-AT-ENG',


### PR DESCRIPTION
There are some new FOLIO temporary location codes that do not map to legacy codes. They're specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/1TCWHj45Yb7_7kHst0Cg0Wrk9vGcRX86qYeAqhX1lYvA/edit#gid=0) and mapped in the indexer from [temp_locations.tsv](https://github.com/sul-dlss/searchworks_traject_indexer/pull/977).

Closes #3154 