### PR TITLE
Use collection_titles method on SolrDocument to render linked values in upper metadata section

### DIFF
--- a/app/models/marc_fields/linked_collection.rb
+++ b/app/models/marc_fields/linked_collection.rb
@@ -1,13 +1,11 @@
 ##
-# A class to handle MARC 795 field logic
+# A class to handle linked collection titles field logic
 class LinkedCollection < MarcField
   def to_partial_path
     'marc_fields/linked_collection'
   end
 
-  private
-
-  def tags
-    %w[795ap]
+  def values
+    document.collection_titles.map(&:values).flatten.map(&:strip)
   end
 end

--- a/app/views/marc_fields/_linked_collection.html.erb
+++ b/app/views/marc_fields/_linked_collection.html.erb
@@ -1,6 +1,8 @@
 <% if linked_collection.values.present? %>
   <dt><%= linked_collection.label %></dt>
   <% linked_collection.values.each do |value| %>
-    <dd><%= link_to(value.strip, search_catalog_path(search_field: :subject_terms, q: "\"#{value.strip}\"")) %></dd>
+    <dd>
+      <%= link_to(value, search_catalog_path(search_field: :subject_terms, q: "\"#{value}\"")) %>
+    </dd>
   <% end  %>
 <% end %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -219,8 +219,6 @@ en:
         label: "Taxonomy"
       790:
         label: "Local subject"
-      795:
-        label: "Collection"
       796:
         label: "Contributor"
       797:
@@ -229,6 +227,8 @@ en:
         label: "Contributor"
       799:
         label: "Related work"
+      linked_collection:
+        label: "Collection"
       included_works:
         label: Included work
       imprint:

--- a/spec/fixtures/marc_records/marc_metadata_fixtures.rb
+++ b/spec/fixtures/marc_records/marc_metadata_fixtures.rb
@@ -1398,19 +1398,4 @@ module MarcMetadataFixtures
       </record>
     xml
   end
-
-  def marc_795_fixture
-    <<-xml
-      <record>
-        <datafield ind1=' ' ind2=' ' tag='795'>
-          <subfield code='6'>880-05</subfield>
-          <subfield code='a'>Shao shu min zu she hui li shi diao cha</subfield>
-        </datafield>
-        <datafield ind1=' ' ind2=' ' tag='880'>
-          <subfield code='6'>795-05</subfield>
-          <subfield code='a'>少数民族社会历史调查</subfield>
-        </datafield>
-      </record>
-    xml
-  end
 end

--- a/spec/models/marc_fields/linked_collection_spec.rb
+++ b/spec/models/marc_fields/linked_collection_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe LinkedCollection do
   include MarcMetadataFixtures
-  let(:document) { SolrDocument.new(marcxml: marc_795_fixture) }
+  let(:document) do
+    SolrDocument.new(
+      { collection_struct: [{ 'title' => 'Shao shu min zu she hui li shi diao cha',
+                              'vernacular' => '少数民族社会历史调查',
+                              'source' => 'sirsi' }] }
+    )
+  end
 
   subject { described_class.new(document) }
 

--- a/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
@@ -95,16 +95,17 @@ describe "catalog/record/_marc_upper_metadata_items" do
     end
   end
 
-  describe 'MARC 795' do
+  describe 'Linked collection titles' do
     before do
-      assign(:document, SolrDocument.new(marcxml: marc_795_fixture))
+      assign(:document, SolrDocument.new(marcxml: metadata1,
+                                         collection_struct: [{ 'title' => 'Bruce & Rachel Jeffer Collection of WPA/Federal Writers Project and related New Deal material',
+                                                               'source' => 'sirsi' }]))
       render
     end
 
     it 'should render the collection titles as links' do
       expect(rendered).to have_css('dt', text: 'Collection')
-      expect(rendered).to have_css('dd a', text: 'Shao shu min zu she hui li shi diao cha')
-      expect(rendered).to have_css('dd a', text: '少数民族社会历史调查')
+      expect(rendered).to have_css('dd', text: 'Bruce & Rachel Jeffer Collection of WPA/Federal Writers Project and related New Deal material')
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where there is unneeded sanitization happening when getting the values from the SolrDocument's marc field, which results in displaying `&amp;` on the rendered page. Also, seems like a better approach? I'm not sure I'm understanding what the preferred patterns are in SearchWorks though.

Example record: https://searchworks.stanford.edu/view/34329

Before:
<img width="1011" alt="Screenshot 2023-07-20 at 9 22 52 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/b890962e-daa3-4f62-a9fd-2f4b08ebf512">

After:
<img width="1015" alt="Screenshot 2023-07-20 at 9 24 11 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/3b42007f-b400-4895-8c23-f2621a2119da">
