### PR TITLE
[Refactor] Extract RequestLinkPolicy from RequestLinkComponent

### DIFF
--- a/app/components/location_request_link_component.rb
+++ b/app/components/location_request_link_component.rb
@@ -1,4 +1,4 @@
-class LocationRequestLinkComponent < ViewComponent::Base # rubocop:disable Metrics/ClassLength
+class LocationRequestLinkComponent < ViewComponent::Base
   attr_reader :document, :library, :location, :items, :link_params
 
   # @params [SolrDocument] document
@@ -44,16 +44,14 @@ class LocationRequestLinkComponent < ViewComponent::Base # rubocop:disable Metri
   end
 
   def render?
-    return false unless items.any? && !bound_with?
-    return @render unless @render.nil?
-
-    return folio_pageable? if folio_items?
-
-    @render = ((in_enabled_location? && any_items_circulate?) || in_mediated_pageable_location? || aeon_pageable?) &&
-              !all_in_disabled_current_location?
+    @render ||= policy.show?
   end
 
   private
+
+  def policy
+    @policy ||= RequestLinkPolicy.new(location:, library:, items:)
+  end
 
   def link_href
     helpers.request_url(
@@ -68,95 +66,11 @@ class LocationRequestLinkComponent < ViewComponent::Base # rubocop:disable Metri
   end
 
   def link_text
-    return I18n.t('searchworks.request_link.finding_aid') if has_finding_aid? && aeon_pageable?
-    return I18n.t('searchworks.request_link.aeon') if aeon_pageable?
+    return I18n.t('searchworks.request_link.finding_aid') if has_finding_aid? && policy.aeon_pageable?
+    return I18n.t('searchworks.request_link.aeon') if policy.aeon_pageable?
 
     t("searchworks.request_link.#{@library}", default: [:'searchworks.request_link.default'])
   end
 
   delegate :has_finding_aid?, to: :document
-
-  def bound_with?
-    Constants::BOUND_WITH_LOCS.include?(location)
-  end
-
-  def in_enabled_location?
-    in_mediated_pageable_location? ||
-      Settings.pageable_locations[library] == '*' ||
-      Settings.pageable_locations[library]&.include?(location)
-  end
-
-  def in_mediated_pageable_location?
-    Settings.mediated_locations[library] == '*' ||
-      Settings.mediated_locations[library]&.include?(location)
-  end
-
-  def aeon_pageable?
-    return folio_aeon_pageable? if folio_items?
-
-    Settings.aeon_locations[library] == '*' ||
-      Settings.aeon_locations.dig(library, location) == "*" ||
-      items.all? do |item|
-        Settings.aeon_locations.dig(library, location)&.include?(item.type)
-      end
-  end
-
-  def any_items_circulate?
-    return true if items.blank?
-
-    items.any?(&:circulates?)
-  end
-
-  def all_in_disabled_current_location?
-    return false if items.blank?
-
-    items.all? do |item|
-      disabled_current_locations.include?(item.current_location.code)
-    end
-  end
-
-  def disabled_current_locations
-    Settings.disabled_current_locations[library] || Settings.disabled_current_locations.default
-  end
-
-  def folio_items?
-    items.first.folio_item?
-  end
-
-  def folio_pageable?
-    return false unless folio_items?
-
-    !folio_disabled_status_location? &&
-      (folio_mediated_pageable? ||
-        folio_aeon_pageable? ||
-         Folio::CirculationRules::PolicyService.instance.item_request_policy(items.first)&.dig('requestTypes')&.include?('Page'))
-  end
-
-  # Special cases where we don't allow requests for special collections items in certain statuses
-  def folio_disabled_status_location?
-    return false unless library == 'SPEC-COLL'
-
-    items.all? { |item| [Constants::FolioStatus::MISSING, Constants::FolioStatus::IN_PROCESS].include?(item.folio_status) }
-  end
-
-  def folio_mediated_pageable?
-    return false unless folio_items? && folio_locations.any?
-
-    folio_locations.all? { |location| location.dig('details', 'pageMediationGroupKey') }
-  end
-
-  def folio_aeon_pageable?
-    return false unless folio_items? && folio_locations.any?
-
-    folio_locations.all? { |location| location.dig('details', 'pageAeonSite') }
-  end
-
-  # there probably is only one FOLIO location
-  def folio_locations
-    @folio_locations ||= begin
-      location_uuids = items.map(&:effective_location).map(&:id).uniq
-
-      Folio::Types.locations.values.select { |l| location_uuids.include?(l['id']) }
-    end
-  end
 end

--- a/app/policies/request_link_policy.rb
+++ b/app/policies/request_link_policy.rb
@@ -1,0 +1,107 @@
+# This determines whether we should display a request link to the user
+class RequestLinkPolicy
+  def initialize(location:, library:, items:)
+    @location = location
+    @library = library
+    @items = items
+  end
+
+  def show?
+    return false unless items.any? && !bound_with?
+
+    return folio_pageable? if folio_items?
+
+    (
+      (in_enabled_location? && any_items_circulate?) ||
+      in_mediated_pageable_location? || aeon_pageable?
+    ) && !all_in_disabled_current_location?
+  end
+
+  def aeon_pageable?
+    return folio_aeon_pageable? if folio_items?
+
+    Settings.aeon_locations[library] == '*' ||
+      Settings.aeon_locations.dig(library, location) == "*" ||
+      items.all? do |item|
+        Settings.aeon_locations.dig(library, location)&.include?(item.type)
+      end
+  end
+
+  private
+
+  attr_reader :location, :library, :items
+
+  def in_enabled_location?
+    in_mediated_pageable_location? ||
+      Settings.pageable_locations[library] == '*' ||
+      Settings.pageable_locations[library]&.include?(location)
+  end
+
+  def in_mediated_pageable_location?
+    Settings.mediated_locations[library] == '*' ||
+      Settings.mediated_locations[library]&.include?(location)
+  end
+
+  def any_items_circulate?
+    return true if items.blank?
+
+    items.any?(&:circulates?)
+  end
+
+  def all_in_disabled_current_location?
+    return false if items.blank?
+
+    items.all? do |item|
+      disabled_current_locations.include?(item.current_location.code)
+    end
+  end
+
+  def disabled_current_locations
+    Settings.disabled_current_locations[library] || Settings.disabled_current_locations.default
+  end
+
+  def bound_with?
+    Constants::BOUND_WITH_LOCS.include?(location)
+  end
+
+  def folio_items?
+    items.first.folio_item?
+  end
+
+  def folio_pageable?
+    return false unless folio_items?
+
+    !folio_disabled_status_location? &&
+      (folio_mediated_pageable? ||
+        folio_aeon_pageable? ||
+         Folio::CirculationRules::PolicyService.instance.item_request_policy(items.first)&.dig('requestTypes')&.include?('Page'))
+  end
+
+  # Special cases where we don't allow requests for special collections items in certain statuses
+  def folio_disabled_status_location?
+    return false unless library == 'SPEC-COLL'
+
+    items.all? { |item| [Constants::FolioStatus::MISSING, Constants::FolioStatus::IN_PROCESS].include?(item.folio_status) }
+  end
+
+  def folio_mediated_pageable?
+    return false unless folio_items? && folio_locations.any?
+
+    folio_locations.all? { |location| location.dig('details', 'pageMediationGroupKey') }
+  end
+
+  def folio_aeon_pageable?
+    return false unless folio_items? && folio_locations.any?
+
+    folio_locations.all? { |location| location.dig('details', 'pageAeonSite') }
+  end
+
+  # there probably is only one FOLIO location
+  def folio_locations
+    @folio_locations ||= begin
+      location_uuids = items.map(&:effective_location).map(&:id).uniq
+
+      Folio::Types.locations.values.select { |l| location_uuids.include?(l['id']) }
+    end
+  end
+end


### PR DESCRIPTION
This separates the "should we display" logic to a separate class from "how we display".  As these are both fairly complex, they each deserve their own class.
