### PR TITLE
Redirect FOLIO hrids that start with an `a` to their legacy url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   # redirect Symphony-migrated FOLIO HRIDs to their original Symphony URLs
   constraints(id: /a\d+/) do
-    get '/view/:id', to: redirect { |path_params, _req| "/view/#{path_params[:id].sub('a', '')}" }
+    get '/view/:id', to: redirect { |path_params, _req| "/view/#{path_params[:id].delete_prefix('a')}" }
   end
 
   get "view/:id/librarian_view" => "catalog#librarian_view", :as => :librarian_view

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   root to: "catalog#index"
 
+  # redirect Symphony-migrated FOLIO HRIDs to their original Symphony URLs
+  constraints(id: /a\d+/) do
+    get '/view/:id', to: redirect { |path_params, _req| "/view/#{path_params[:id].sub('a', '')}" }
+  end
+
   get "view/:id/librarian_view" => "catalog#librarian_view", :as => :librarian_view
   get "view/:id/stackmap" => "catalog#stackmap", :as => :stackmap
 

--- a/spec/requests/symphony_legacy_url_spec.rb
+++ b/spec/requests/symphony_legacy_url_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'Legacy Symphony catkey Routing' do
+  it 'redirects FOLIO hrids to the symphony equivalents' do
+    get '/view/a12345'
+
+    expect(response).to redirect_to('/view/12345')
+  end
+end


### PR DESCRIPTION
(I'm personally tired of deleting the `a`)