### PR TITLE
Remove the obsolete retina_tag gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,6 @@ gem "faraday"
 gem "config"
 gem "mods_display", "~> 1.1"
 gem "font-awesome-rails"
-gem "retina_tag"
 gem 'jquery-datatables-rails'
 gem 'roadie-rails', '~> 3'
 gem 'rack-utf8_sanitizer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,8 +472,6 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    retina_tag (1.4.1)
-      rails (>= 3.1)
     retriable (3.1.2)
     rexml (3.2.5)
     rinku (2.0.6)
@@ -691,7 +689,6 @@ DEPENDENCIES
   rails (~> 7.0)
   rails-controller-testing
   recaptcha (>= 5.4.1)
-  retina_tag
   rinku
   roadie-rails (~> 3)
   rsolr

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery
 //= require honeybadger
-//= require retina_tag
 
 //= require rails-ujs
 //= require turbolinks

--- a/app/components/access_panels/library_component.rb
+++ b/app/components/access_panels/library_component.rb
@@ -12,12 +12,15 @@ module AccessPanels
     end
 
     def thumb_for_library
+      srcset = {}
       image_name = if library.zombie?
+        srcset["#{library.code}@2x.png"] = '2x'
         "#{library.code}.png"
       else
+        srcset["#{library.code}@2x.jpg"] = '2x'
         "#{library.code}.jpg"
       end
-      image_tag(image_name, class: "pull-left", alt: "", height: 50)
+      image_tag(image_name, srcset:, class: "pull-left", alt: "", height: 50)
     rescue Sprockets::Rails::Helper::AssetNotFound => e
       Honeybadger.notify(e, error_message: "Missing library thumbnail for #{library.code}")
 

--- a/spec/components/access_panels/library_component_spec.rb
+++ b/spec/components/access_panels/library_component_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe AccessPanels::LibraryComponent, type: :component do
   let(:document) { SolrDocument.new }
   let(:library) { Holdings::Library.new('GREEN') }
 
-  it "should return the image tag for the thumbnail for the specified library" do
+  it "returns the image tag for the thumbnail for the specified library" do
     render_inline(component)
-    expect(page).to have_selector('img[src^="/assets/GREEN"][data-hidpi-src^="/assets/GREEN@2x"]')
+    expect(page).to have_selector('img[src^="/assets/GREEN"][srcset^="/assets/GREEN@2x"]')
   end
 
   context 'with a ZOMBIE library' do
     let(:library) { Holdings::Library.new('ZOMBIE') }
 
-    it "should return the image tag (w/ png extension) for the ZOMBIE library" do
+    it "returns the image tag (w/ png extension) for the ZOMBIE library" do
       render_inline(component)
 
-      expect(page).to have_selector('img[src^="/assets/ZOMBIE"][data-hidpi-src^="/assets/ZOMBIE@2x"]')
+      expect(page).to have_selector('img[src^="/assets/ZOMBIE"][srcset^="/assets/ZOMBIE@2x"]')
     end
   end
 


### PR DESCRIPTION
This used the data-hidpi-src attribute, but all modern browsers use the srcset attribute, which is natively supported by Rails.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
