### PR TITLE
Use 'Request via Finding Aid' for Hoover Library items with finding aids

### DIFF
--- a/app/components/location_request_link_component.rb
+++ b/app/components/location_request_link_component.rb
@@ -7,7 +7,11 @@ class LocationRequestLinkComponent < ViewComponent::Base
   def self.for(document:, library:, location:, **kwargs)
     link_type = case library
                 when 'HOOVER'
-                  RequestLinks::HooverRequestLinkComponent
+                  if document&.index_links&.finding_aid&.first&.href
+                    RequestLinks::HooverArchiveRequestLinkComponent
+                  else
+                    RequestLinks::HooverRequestLinkComponent
+                  end
                 when 'HV-ARCHIVE'
                   RequestLinks::HooverArchiveRequestLinkComponent
                 when 'HOPKINS'

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -40,10 +40,6 @@ class Holdings
       @code == 'ZOMBIE'
     end
 
-    def hoover_archive?
-      @code == 'HV-ARCHIVE'
-    end
-
     def present?
       @items.any?(&:present?) ||
         (mhld.present? && mhld.any?(&:present?)) ||

--- a/spec/components/location_request_link_component_spec.rb
+++ b/spec/components/location_request_link_component_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
     it { expect(page).not_to have_link }
   end
 
+  context 'for Hoover items with finding aids' do
+    let(:document) do
+      SolrDocument.new(
+        marc_links_struct: [{ href: "http://oac.cdlib.org/ark:/abc123", finding_aid: true }]
+      )
+    end
+    let(:library) { 'HOOVER' }
+    let(:location) { 'STACKS' }
+    let(:items) { [] }
+
+    it { expect(page).to have_link 'Request via Finding Aid', href: 'http://oac.cdlib.org/ark:/abc123' }
+  end
+
   context 'for Hoover Archive items with finding aids' do
     let(:document) do
       SolrDocument.new(

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -83,14 +83,6 @@ describe Holdings::Library do
     end
   end
 
-  describe '#hoover_archive?' do
-    let(:hv_archive) { Holdings::Library.new('HV-ARCHIVE') }
-
-    it 'is true' do
-      expect(hv_archive.hoover_archive?).to be true
-    end
-  end
-
   describe '#as_json' do
     let(:callnumbers) do
       [


### PR DESCRIPTION
Hoover Library and Hoover Archives are being merged into one organization FOLIO. If there's a finding aid, patrons should use it to request items for anything in `HOOVER`.