### PR TITLE
Be a little cagier about the presence of a FOLIO item

### DIFF
--- a/app/policies/location_request_link_policy.rb
+++ b/app/policies/location_request_link_policy.rb
@@ -71,7 +71,7 @@ class LocationRequestLinkPolicy
 
   def folio_bound_with_or_analyzed_serial?
     (!folio_items? && items.first.document&.folio_holdings&.any?(&:bound_with?)) ||
-      (folio_items? && items.any? { |item| item.effective_location.see_other? })
+      (folio_items? && items.any? { |item| item.effective_location&.see_other? })
   end
 
   def folio_items?
@@ -107,7 +107,7 @@ class LocationRequestLinkPolicy
   # there probably is only one FOLIO location.
   def folio_locations
     @folio_locations ||= begin
-      location_uuids = items.map(&:effective_location).map(&:id).uniq
+      location_uuids = items.filter_map(&:effective_location).map(&:id).uniq
 
       Folio::Types.locations.values.select { |l| location_uuids.include?(l['id']) }
     end

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -10,7 +10,7 @@ class Holdings
     attr_reader :document
     attr_accessor :due_date
 
-    delegate :loan_type, :material_type, :effective_location, to: :folio_item
+    delegate :loan_type, :material_type, :effective_location, to: :folio_item, allow_nil: true
 
     def initialize(holding_info, document: nil)
       @holding_info = holding_info


### PR DESCRIPTION
Items with a blank barcode can't be matched up with their FOLIO item. Perhaps we should populate the item_display barcode field with the UUID if there's no barcode?