### PR TITLE
Library does not play a part in link_text generation

### DIFF
--- a/app/components/item_request_link_component.rb
+++ b/app/components/item_request_link_component.rb
@@ -38,12 +38,9 @@ class ItemRequestLinkComponent < ViewComponent::Base
   end
 
   def link_text
-    locale_key = "searchworks.request_link.#{library || 'default'}"
+    locale_key = 'searchworks.request_link.default'
     locale_key = 'searchworks.request_link.request_on_site' if Constants::REQUEST_ONSITE_LOCATIONS.include?(home_location)
 
-    t(
-      locale_key,
-      default: :'searchworks.request_link.default'
-    )
+    t(locale_key)
   end
 end


### PR DESCRIPTION
See https://github.com/sul-dlss/SearchWorks/blob/master/config/locales/searchworks.en.yml\#L266-L271

It used to be used when it was added, but we don't need it anymore:

https://github.com/sul-dlss/SearchWorks/commit/18e115241f9569e81c46ae9661ef6fd7e397cd38