### PR TITLE
Fall back on the provided location code if a legacy code wasn't found

### DIFF
--- a/app/services/folio/locations_map.rb
+++ b/app/services/folio/locations_map.rb
@@ -13,7 +13,7 @@ module Folio
     # @param [String] location_code the Symphony location
     # @return [String] the Folio location code
     def self.for(library_code:, location_code:)
-      instance.data.dig(library_code, location_code)
+      instance.data.dig(library_code, location_code) || location_code
     end
 
     def data


### PR DESCRIPTION
Lane has no equivalent codes in Symphony, so their home location codes are passed through as-is from FOLIO.

E.g. https://searchworks-folio-dev.stanford.edu/view/L12