### PR TITLE
Treat items with the type 'ONLINE' as internet resources

### DIFF
--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -214,7 +214,7 @@ class Holdings
     private
 
     def internet_resource?
-      home_location == 'INTERNET'
+      home_location == 'INTERNET' || type == 'ONLINE'
     end
 
     def eresv?

--- a/spec/lib/holdings/item_spec.rb
+++ b/spec/lib/holdings/item_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Holdings::Item do
 
   describe '#callnumber' do
     let(:item_without_callnumber) { Holdings::Item.from_item_display_string('barcode -|- library -|- home_location -|- current_location -|- type -|- truncated_callnumber -|- shelfkey -|- reverse_shelfkey -|- -|- full_shelfkey ') }
+    let(:lane_online_item) { Holdings::Item.from_item_display_string(' -|- LANE-MED -|- LANE-ECOLL -|- -|- ONLINE -|- -|- abc123 -|- xyz987 -|- -|- -|- -|- LC') }
 
     it "should return '(no call number) if the callnumber is blank" do
       expect(item_without_callnumber.callnumber).to eq '(no call number)'
@@ -90,6 +91,10 @@ RSpec.describe Holdings::Item do
 
     it 'returns "eResource" when the home location is INTERNET' do
       expect(internet_item.callnumber).to eq 'eResource'
+    end
+
+    it 'returns "eResource" when the item type is ONLINE' do
+      expect(lane_online_item.callnumber).to eq 'eResource'
     end
   end
 


### PR DESCRIPTION
Lane has item-level resources for e-resources in a variety of locations.