### PR TITLE
Handle nil values in the Holding::Item better

### DIFF
--- a/app/components/access_panels/library_location_component.html.erb
+++ b/app/components/access_panels/library_location_component.html.erb
@@ -42,7 +42,7 @@
             <span class="availability-icon-wrapper">
               <i class="availability-icon <%= item.status.availability_class %>"></i>
               <span data-available-text="<%= t('searchworks.availability.available') %>" data-unavailable-text="<%= t('searchworks.availability.unavailable') %>" class='status-text'>
-                <%= item.status.status_text unless item.current_location && item.current_location.name.present? %>
+                <%= item.status.status_text unless item.current_location&.name.present? %>
               </span>
             </span>
             <span class="current-location">

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -49,7 +49,7 @@ class BrowseController < ApplicationController
       @items = service.items(params[:before] || params[:after])
     else
       barcode = params[:barcode] || @original_doc[:preferred_barcode]
-      item = @original_doc.items.find { |c| c.barcode.starts_with?(barcode) }
+      item = @original_doc.items.find { |c| c.barcode&.starts_with?(barcode) }
 
       @items = NearbyOnShelf.around_item(
         item,

--- a/app/policies/item_request_link_policy.rb
+++ b/app/policies/item_request_link_policy.rb
@@ -39,7 +39,7 @@ class ItemRequestLinkPolicy
   end
 
   def current_location_is_always_requestable?
-    return true if current_location.end_with?('-LOAN') && current_location != "SEE-LOAN"
+    return true if current_location&.end_with?('-LOAN') && current_location != "SEE-LOAN"
 
     (Settings.requestable_current_locations[library] || Settings.requestable_current_locations.default).include?(current_location) ||
       (Settings.unavailable_current_locations[library] || Settings.unavailable_current_locations.default).include?(current_location)

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -30,7 +30,7 @@ class Holdings
         course_id: values[12],
         reserve_desk: values[13],
         loan_period: values[14]
-      }
+      }.compact_blank
       new(hash, document:)
     end
 

--- a/lib/holdings/status/deliver_from_offsite.rb
+++ b/lib/holdings/status/deliver_from_offsite.rb
@@ -16,7 +16,7 @@ class Holdings
       end
 
       def deliverable_home_location?
-        @item.home_location.try(:end_with?, '-30') ||
+        @item.home_location&.end_with?('-30') ||
           Constants::DELIVERABLE_LOCATIONS.include?(@item.home_location)
       end
     end

--- a/lib/holdings/status/unavailable.rb
+++ b/lib/holdings/status/unavailable.rb
@@ -39,7 +39,7 @@ class Holdings
       end
 
       def current_location
-        item.current_location.try(:code)
+        item.current_location&.code
       end
     end
   end


### PR DESCRIPTION
Regression from #3332; nil values used to be impossible for (most) item fields.

Fixes #3350 
