### PR TITLE
Handle missing full shelfkey values by sorting them last; fixes #3357

### DIFF
--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -6,6 +6,8 @@ class Holdings
   # 5 truncated call number -|- 6 shelfkey -|- 7 reverse shelfkey -|- 8 callnumber -|-
   # 9 full shelfkey -|- 10 public note -|- 11 callnumber type -|- 12 course id -|- 13 reserve desk -|- 14 loan period
   class Item
+    MAX_SHELFKEY = 0x10FFFF.chr(Encoding::UTF_8)
+
     attr_writer :current_location, :status
     attr_reader :document, :item_display
     attr_accessor :due_date
@@ -108,8 +110,8 @@ class Holdings
       end
     end
 
-    def full_shelfkey
-      item_display[:full_shelfkey]
+    def full_shelfkey(default: MAX_SHELFKEY)
+      item_display[:full_shelfkey] || default
     end
 
     def public_note

--- a/spec/lib/holdings/item_spec.rb
+++ b/spec/lib/holdings/item_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Holdings::Item do
     end
   end
 
+  describe '#full_shelfkey' do
+    it 'returns the full shelfkey' do
+      expect(item.full_shelfkey).to eq('full_shelfkey')
+    end
+
+    it 'returns a string that sorts last if there is no shelfkey in the data' do
+      expect(internet_item.full_shelfkey).to eq Holdings::Item::MAX_SHELFKEY
+    end
+  end
+
   describe '#on_order?' do
     it 'should return true for on-order items' do
       expect(Holdings::Item.from_item_display_string(' -|- -|- ON-ORDER -|- ON-ORDER -|-')).to be_on_order


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
