### PR TITLE
Use FOLIO item statuses, circ rules, and location details to calculate availability and request links

### DIFF
--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -4,29 +4,30 @@ module Folio
     Institution = Struct.new(:id, :code, :name, keyword_init: true)
     Campus = Struct.new(:id, :code, :name, keyword_init: true)
     Library = Struct.new(:id, :code, :name, keyword_init: true)
-    Location = Struct.new(:id, :code, :name, keyword_init: true)
 
     # Institution for all Stanford records, including coordinate libraries/campuses
     SU = Institution.new(id: '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929', code: 'SU', name: 'Stanford University')
 
-    attr_reader :institution, :campus, :library, :location
+    attr_reader :institution, :campus, :library
 
-    delegate :id, :code, :name, to: :location
-
-    def initialize(campus:, library:, location:, institution: SU)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(id:, code:, campus:, library:, name: nil, institution: SU)
+      @id = id
+      @code = code
+      @name = name
       @institution = institution
       @campus = campus
       @library = library
-      @location = location
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def self.from_dynamic(json)
       new(institution: Institution.new(**json.fetch('institution').slice('id', 'code', 'name')),
           campus: Campus.new(**json.fetch('campus').slice('id', 'code', 'name')),
           library: Library.new(**json.fetch('library').slice('id', 'code', 'name')),
-          location: Location.new(id: json.fetch('id'),
-                                 code: json.fetch('code'),
-                                 name: json.fetch('name')))
+          id: json.fetch('id'),
+          code: json.fetch('code'),
+          name: json.fetch('name'))
     end
 
     def see_other?

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -8,7 +8,7 @@ module Folio
     # Institution for all Stanford records, including coordinate libraries/campuses
     SU = Institution.new(id: '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929', code: 'SU', name: 'Stanford University')
 
-    attr_reader :institution, :campus, :library
+    attr_reader :id, :code, :institution, :campus, :library
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(id:, code:, campus:, library:, name: nil, institution: SU)
@@ -21,6 +21,15 @@ module Folio
     end
     # rubocop:enable Metrics/ParameterLists
 
+    # Prefer the locally cached name, but fall back to the name from the document if we have to
+    def name
+      cached_location_data&.dig('name') || @name
+    end
+
+    def details
+      cached_location_data&.dig('details') || {}
+    end
+
     def self.from_dynamic(json)
       new(institution: Institution.new(**json.fetch('institution').slice('id', 'code', 'name')),
           campus: Campus.new(**json.fetch('campus').slice('id', 'code', 'name')),
@@ -32,6 +41,10 @@ module Folio
 
     def see_other?
       code.ends_with?('-SEE-OTHER')
+    end
+
+    def cached_location_data
+      Folio::Types.locations[id] || {}
     end
   end
 end

--- a/app/policies/location_request_link_policy.rb
+++ b/app/policies/location_request_link_policy.rb
@@ -82,7 +82,7 @@ class LocationRequestLinkPolicy
     !folio_disabled_status_location? &&
       (folio_mediated_pageable? ||
         folio_aeon_pageable? ||
-         Folio::CirculationRules::PolicyService.instance.item_request_policy(items.first)&.dig('requestTypes')&.include?('Page'))
+         items.first.request_policy&.dig('requestTypes')&.include?('Page'))
   end
 
   # Special cases where we don't allow requests for special collections items in certain statuses

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -772,3 +772,14 @@ disabled_current_locations:
     - ON-ORDER
     - SPEC-INPRO
     - ENDPROCESS
+
+folio_hold_recall_statuses:
+  - Checked out
+  - Awaiting pickup
+  - Awaiting delivery
+  - In transit
+  - Missing
+  - Paged
+  - On order
+  - In process
+  - Restricted

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -36,9 +36,10 @@ class Holdings
       new(hash, document:)
     end
 
-    def initialize(holding_info, document: nil)
+    def initialize(holding_info, document: nil, folio_item: nil)
       @item_display = holding_info.with_indifferent_access
       @document = document
+      @folio_item = folio_item
     end
 
     def present?

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -161,7 +161,9 @@ class Holdings
     end
 
     def circulates?
-      folio_item_circulates? || circulating_item_types == '*' || circulating_item_types.include?(type)
+      return folio_item_circulates? if folio_item?
+
+      circulating_item_types == '*' || circulating_item_types.include?(type)
     end
 
     def as_json(*)
@@ -264,9 +266,11 @@ class Holdings
     end
 
     def folio_item_circulates?
-      return false unless folio_item?
+      loan_policy&.dig('loanable')
+    end
 
-      Folio::CirculationRules::PolicyService.instance.item_loan_policy(self)&.dig('loanable')
+    def loan_policy
+      @loan_policy ||= Folio::CirculationRules::PolicyService.instance.item_loan_policy(self)
     end
   end
 end

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -213,6 +213,12 @@ class Holdings
       folio_item.present?
     end
 
+    def request_policy
+      return unless folio_item?
+
+      @request_policy ||= Folio::CirculationRules::PolicyService.instance.item_request_policy(self)
+    end
+
     delegate :status, to: :folio_item, prefix: :folio
 
     private

--- a/lib/holdings/status.rb
+++ b/lib/holdings/status.rb
@@ -7,11 +7,15 @@ require 'holdings/status/in_process'
 
 class Holdings
   class Status
+    attr_reader :item
+
     def initialize(item)
       @item = item
     end
 
     def availability_class
+      return folio_availability_class if item.folio_item?
+
       case
       when cdl?
         'unavailable cdl'
@@ -34,6 +38,25 @@ class Holdings
 
     def status_text
       I18n.t(availability_class, scope: 'searchworks.availability')
+    end
+
+    def folio_availability_class
+      case
+      when item.folio_status == 'In process', item.folio_status == 'In process (non-requestable)', item.effective_location.details['availabilityClass'] == 'In_process'
+        'in_process'
+      when item.folio_status == 'On order', item.folio_status == 'Missing', item.folio_status == 'In transit', item.folio_status == 'Paged', item.effective_location.details['availabilityClass'] == 'Unavailable'
+        'unavailable'
+      when item.effective_location.details['availabilityClass'] == 'Offsite' && !item.circulates?
+        'noncirc_page'
+      when item.effective_location.details['availabilityClass'] == 'Offsite'
+        'deliver-from-offsite'
+      when !item.circulates?
+        'noncirc'
+      when item.effective_location.details['availabilityClass'] == 'Available'
+        'available'
+      else
+        'unknown'
+      end
     end
 
     # we can probably do something clever w/ method missing here

--- a/spec/components/item_request_link_component_spec.rb
+++ b/spec/components/item_request_link_component_spec.rb
@@ -108,4 +108,45 @@ RSpec.describe ItemRequestLinkComponent, type: :component do
       it { is_expected.not_to have_link 'Request' }
     end
   end
+
+  context 'with FOLIO items' do
+    let(:item) do
+      instance_double(Holdings::Item, document:, barcode: nil, library: nil, home_location: nil, current_location: instance_double(Holdings::Location, code: nil), folio_item?: true, folio_status:, request_policy:)
+    end
+
+    context 'checked out item from a location that allows holds' do
+      let(:folio_status) { 'Checked out' }
+      let(:request_policy) do
+        { 'requestTypes' => ['Hold', 'Recall'] }
+      end
+
+      it { is_expected.to have_link 'Request' }
+    end
+
+    context 'checked out from a location that does not allow holds' do
+      let(:folio_status) { 'Checked out' }
+      let(:request_policy) do
+        { 'requestTypes' => ['Page'] }
+      end
+
+      it { is_expected.not_to have_link 'Request' }
+    end
+
+    context 'available' do
+      let(:folio_status) { 'Available' }
+      let(:request_policy) do
+        { 'requestTypes' => ['Hold', 'Recall'] }
+      end
+
+      it { is_expected.not_to have_link 'Request' }
+    end
+
+    context 'on-order without a FOLIO item' do
+      let(:item) do
+        Holdings::Item.from_item_display_string("123 -|- GREEN -|- STACKS -|- ON-ORDER -|- STKS-MONO", document:)
+      end
+
+      it { is_expected.to have_link 'Request' }
+    end
+  end
 end

--- a/spec/components/location_request_link_component_spec.rb
+++ b/spec/components/location_request_link_component_spec.rb
@@ -235,12 +235,17 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
     let(:library) { 'SAL3' }
     let(:location) { 'STACKS' }
 
-    let(:material_type) { Folio::Item::MaterialType.new(id: '1a54b431-2e4f-452d-9cae-9cee66c9a892', name: 'book') }
-    let(:loan_type) { Folio::Item::LoanType.new(id: '2b94c631-fca9-4892-a730-03ee529ffe27', name: 'Can circulate') }
-    let(:items) { [instance_double(Holdings::Item, folio_item?: true, effective_location:, material_type:, loan_type:, folio_status:)] }
+    let(:items) { [instance_double(Holdings::Item, folio_item?: true, request_policy:, effective_location:, folio_status:)] }
     let(:folio_status) { 'Available' }
+    let(:request_policy) { {} }
 
     context 'in a pageable location' do
+      let(:request_policy) do
+        {
+          'requestTypes' => ['Page']
+        }
+      end
+
       let(:effective_location) do
         Folio::Location.from_dynamic(
           {

--- a/spec/lib/holdings/status_spec.rb
+++ b/spec/lib/holdings/status_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe Holdings::Status do
           library: 'SAL3',
           home_location: 'STACKS',
           current_location: instance_double(Holdings::Location, code: 'LOST-ASSUM'),
-          type: 'STACKS'
+          type: 'STACKS',
+          folio_item?: false
         )
       end
 

--- a/spec/models/folio/location_spec.rb
+++ b/spec/models/folio/location_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Folio::Location do
     {
       'id' => '1af90de1-a5c0-4c46-bab1-2847d041f997',
       'code' => 'GRE-BENDER',
-      'name' => 'Green Library Bender Room',
+      'name' => 'Green Bender Room',
       'institution' => {
         'id' => '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929',
         'code' => 'SU',
@@ -28,7 +28,7 @@ RSpec.describe Folio::Location do
 
   describe '#new' do
     context 'with no institution' do
-      subject { described_class.new(campus: 'foo', library: 'bar', location: 'baz') }
+      subject { described_class.new(id: 'uuid', code: 'baz', campus: 'foo', library: 'bar') }
 
       it 'uses the default institution' do
         expect(subject.institution.name).to eq 'Stanford University'
@@ -52,7 +52,7 @@ RSpec.describe Folio::Location do
     end
 
     it 'stores the location info' do
-      expect(subject.name).to eq 'Green Library Bender Room'
+      expect(subject.name).to eq 'Green Bender Room'
     end
   end
 end

--- a/spec/services/folio/circulation_rules/policy_service_spec.rb
+++ b/spec/services/folio/circulation_rules/policy_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Folio::CirculationRules::PolicyService do
         allow(item).to receive_messages(material_type: Folio::Item::MaterialType.new(id: 'multimedia', name: 'Multimedia'), loan_type: Folio::Item::LoanType.new(id: '7hour', name: '7-hour reserve'), effective_location: Folio::Location.new(
           campus: Folio::Location::Campus.new(id: 'sul', code: 'SUL', name: 'Stanford University Libraries'),
           library: Folio::Location::Library.new(id: 'media-center', code: 'MEDIA-CENTER', name: 'Media & Microtext Center'),
-          location: Folio::Location::Location.new(id: 'media-cage', code: 'MEDIA-CAGE', name: 'Media Cage')
+          id: 'media-cage', code: 'MEDIA-CAGE', name: 'Media Cage'
         ))
       end
 
@@ -63,7 +63,7 @@ RSpec.describe Folio::CirculationRules::PolicyService do
         allow(item).to receive_messages(material_type: Folio::Item::MaterialType.new(id: 'microform', name: 'Microform'), loan_type: Folio::Item::LoanType.new(id: '12hour', name: '12-hour reserve'), effective_location: Folio::Location.new(
           campus: Folio::Location::Campus.new(id: 'sul', code: 'SUL', name: 'Stanford University Libraries'),
           library: Folio::Location::Library.new(id: 'media-center', code: 'MEDIA-CENTER', name: 'Media & Microtext Center'),
-          location: Folio::Location::Location.new(id: 'media-stacks', code: 'MEDIA-STACKS', name: 'Media Stacks')
+          id: 'media-stacks', code: 'MEDIA-STACKS', name: 'Media Stacks'
         ))
       end
 
@@ -77,7 +77,7 @@ RSpec.describe Folio::CirculationRules::PolicyService do
         allow(item).to receive_messages(material_type: Folio::Item::MaterialType.new(id: 'book', name: 'Books'), loan_type: Folio::Item::LoanType.new(id: '7day', name: '7-day loan'), effective_location: Folio::Location.new(
           campus: Folio::Location::Campus.new(id: 'sul', code: 'SUL', name: 'Stanford University Libraries'),
           library: Folio::Location::Library.new(id: 'green', code: 'GREEN', name: 'Cecil R. Green Library'),
-          location: Folio::Location::Location.new(id: 'green-stacks', code: 'GRE-STACKS', name: 'Green Stacks')
+          id: 'green-stacks', code: 'GRE-STACKS', name: 'Green Stacks'
         ))
       end
 
@@ -91,7 +91,7 @@ RSpec.describe Folio::CirculationRules::PolicyService do
         allow(item).to receive_messages(material_type: Folio::Item::MaterialType.new(id: 'multimedia', name: 'Multimedia'), loan_type: Folio::Item::LoanType.new(id: 'rr', name: 'Reading room use only'), effective_location: Folio::Location.new(
           campus: Folio::Location::Campus.new(id: 'sul', code: 'SUL', name: 'Stanford University Libraries'),
           library: Folio::Location::Library.new(id: 'ars', code: 'ARS', name: 'Archive of Recorded Sound'),
-          location: Folio::Location::Location.new(id: 'reference', code: 'REFERENCE', name: 'Reference')
+          id: 'reference', code: 'REFERENCE', name: 'Reference'
         ))
       end
 
@@ -160,7 +160,7 @@ RSpec.describe Folio::CirculationRules::PolicyService do
       allow(item).to receive_messages(material_type: Folio::Item::MaterialType.new(id: 'book', name: 'Books'), loan_type: Folio::Item::LoanType.new(id: 'can-circ', name: 'Can circulate'), effective_location: Folio::Location.new(
         campus: Folio::Location::Campus.new(id: 'sul', code: 'SUL', name: 'Stanford University Libraries'),
         library: Folio::Location::Library.new(id: 'green', code: 'GREEN', name: 'Cecil R. Green Library'),
-        location: Folio::Location::Location.new(id: 'green-stacks', code: 'GRE-STACKS', name: 'Green Stacks')
+        id: 'green-stacks', code: 'GRE-STACKS', name: 'Green Stacks'
       ))
     end
 


### PR DESCRIPTION
Part of #3129 

We can use information from FOLIO's item statuses, location details and circulation rules to determine the (non-real-time) availability information previously determined by Symphony location codes.

- `cdl` => unsupported at FOLIO launch
- `in_process` (currently just Hoover archives without finding aids) => anything with the FOLIO item status of "In process" or in a location that implies in-process. It's unclear why the Symphony definition is quite so limited and marked as explicitly unavailable instead
- `unavailable` (derived from a huge list of current locations) => derived from folio item statuses or the implied status of the item's location
- `noncirc_page` (derived from a list of locations) => locations marked as offsite and a non-circulating item loan policy
- `noncirc` (derived from Symphony locations or item types) => non-circulating item loan policy
- `deliver-from-offsite` (derived from a list of libraries + locations) => locations marked as offsite
- `available` (derived from a list of locations) => likely unused in Symphony because the item status isn't confused with the current location, but left as a possibility
- `unknown`: in both cases, the item status display is determined by a real-time availability lookup