### PR TITLE
Remove item-level on-site locations

### DIFF
--- a/app/components/item_request_link_component.rb
+++ b/app/components/item_request_link_component.rb
@@ -1,34 +1,4 @@
 class ItemRequestLinkComponent < ViewComponent::Base
-  LEGACY_ONSITE_LOCATIONS = %w(PAGE-AR PAGE-AS PAGE-EA PAGE-ED PAGE-EN PAGE-ES PAGE-GR
-                               PAGE-HA PAGE-HP PAGE-HV PAGE-LW PAGE-MA PAGE-MD PAGE-MU PAGE-RM PAGE-SP).freeze
-
-  FOLIO_ONSITE_LOCATIONS = %w(
-    SAL3-PAGE-AR
-    ART-PAGE-AR
-    SAL3-PAGE-AS
-    SAL3-PAGE-EA
-    EAL-PAGE-EA
-    SAL-PAGE-EA
-    SAL3-PAGE-ED
-    EDU-PAGE-ED
-    SAL3-PAGE-EN
-    ENG-PAGE-EN
-    SAL3-PAGE-ES
-    EAR-PAGE-ES
-    SAL-PAGE-GR
-    SAL3-PAGE-GR
-    GRE-PAGE-GR
-    MAR-PAGE-MA
-    SAL3-PAGE-MA
-    SAL3-PAGE-MD
-    MEDIA-PAGE-MD
-    SAL3-PAGE-MU
-    MUS-PAGE-MU
-    SAL3-PAGE-RM
-    RUM-PAGE-RM
-    SAL3-PAGE-SP
-  ).freeze
-
   attr_reader :item, :classes
 
   delegate :document, :library, :home_location, :barcode, to: :item
@@ -70,17 +40,6 @@ class ItemRequestLinkComponent < ViewComponent::Base
   end
 
   def link_text
-    locale_key = if on_site_location?
-                   'request_on_site' # e.g. "Request on-site access"
-                 else
-                   'default'
-                 end
-
-    t(locale_key, default: :default, scope: 'searchworks.request_link')
-  end
-
-  def on_site_location?
-    (item.folio_item? && FOLIO_ONSITE_LOCATIONS.include?(item.effective_location.location.code)) ||
-      LEGACY_ONSITE_LOCATIONS.include?(home_location)
+    t('searchworks.request_link.default')
   end
 end

--- a/spec/components/item_request_link_component_spec.rb
+++ b/spec/components/item_request_link_component_spec.rb
@@ -108,44 +108,4 @@ RSpec.describe ItemRequestLinkComponent, type: :component do
       it { is_expected.not_to have_link 'Request' }
     end
   end
-
-  context 'with a Folio item' do
-    let(:policy) { instance_double(ItemRequestLinkPolicy, show?: true) }
-    let(:item) do
-      instance_double(Holdings::Item, document:, library:, effective_location:, home_location: location, barcode: 13_333_333_333_333, folio_item?: true)
-    end
-
-    before do
-      allow(ItemRequestLinkPolicy).to receive(:new).and_return(policy)
-    end
-
-    context 'with an onsite page location' do
-      let(:effective_location) do
-        Folio::Location.from_dynamic(
-          {
-            'id' => 'f155b1bc-7d19-402a-8412-431988b12cc3',
-            'code' => 'SAL3-PAGE-AS',
-            'name' => 'Off-campus storage',
-            'institution' => {
-              'id' => '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929',
-              'code' => 'SU',
-              'name' => 'Stanford University'
-            },
-            'campus' => {
-              'id' => 'c365047a-51f2-45ce-8601-e421ca3615c5',
-              'code' => 'SUL',
-              'name' => 'Stanford Libraries'
-            },
-            'library' => {
-              'id' => 'f6b5519e-88d9-413e-924d-9ed96255f72e',
-              'code' => 'SAL3',
-              'name' => 'Stanford Auxiliary Library 3'
-            }
-          }
-        )
-      end
-
-      it { is_expected.to have_link 'Request on-site access' }
-    end
-  end
 end


### PR DESCRIPTION
I don't see how this can happen in practice. If the item is in one of these locations, it has a location-level request link. 
