### PR TITLE
Use the permanent location to determine location-specific behavior

### DIFF
--- a/app/models/concerns/solr_holdings.rb
+++ b/app/models/concerns/solr_holdings.rb
@@ -71,10 +71,17 @@ module SolrHoldings
   end
 
   def folio_items
-    @folio_items ||= Array(holdings_json['items']).map { |item| Folio::Item.from_dynamic(item) }
+    @folio_items ||= Array(holdings_json['items']).map do |item|
+      holdings_record = folio_holdings_by_id[item['holdingsRecordId']]
+      Folio::Item.from_dynamic(item, holdings_record:)
+    end
   end
 
   private
+
+  def folio_holdings_by_id
+    @folio_holdings_by_id ||= folio_holdings.index_by(&:id)
+  end
 
   # Setting this to no-op if FOLIO_LIVE_LOOKUP is enabled. This is currently
   # used by the request app to get live information about items, but we plan

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -6,18 +6,19 @@ module Folio
     LoanType = Struct.new(:id, :name, keyword_init: true)
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(id:, status:, barcode:, material_type:, permanent_loan_type:, effective_location:, temporary_loan_type: nil)
+    def initialize(id:, status:, barcode:, material_type:, permanent_loan_type:, effective_location:, permanent_location: nil, temporary_loan_type: nil)
       @id = id
       @barcode = barcode
       @status = status
       @material_type = material_type
       @permanent_loan_type = permanent_loan_type
       @effective_location = effective_location
+      @permanent_location = permanent_location || effective_location
       @temporary_loan_type = temporary_loan_type
     end
     # rubocop:enable Metrics/ParameterLists
 
-    def self.from_dynamic(json)
+    def self.from_dynamic(json, holdings_record: nil)
       new(id: json.fetch('id'),
           status: json.fetch('status'),
           barcode: json['barcode'],
@@ -33,7 +34,8 @@ module Folio
             id: json.fetch('temporaryLoanTypeId'),
             name: json.fetch('temporaryLoanType')
           ),
-          effective_location: Folio::Location.from_dynamic(json.dig('location', 'effectiveLocation')))
+          effective_location: Folio::Location.from_dynamic(json.dig('location', 'effectiveLocation')),
+          permanent_location: Folio::Location.from_dynamic(json.dig('location', 'permanentLocation')) || holdings_record&.effective_location)
     end
 
     def loan_type

--- a/app/policies/location_request_link_policy.rb
+++ b/app/policies/location_request_link_policy.rb
@@ -93,23 +93,19 @@ class LocationRequestLinkPolicy
   end
 
   def folio_mediated_pageable?
-    return false unless folio_items? && folio_locations.any?
+    return false unless folio_items? && folio_permanent_locations.any?
 
-    folio_locations.all? { |location| location.dig('details', 'pageMediationGroupKey') }
+    folio_permanent_locations.all? { |location| location.dig('details', 'pageMediationGroupKey') }
   end
 
   def folio_aeon_pageable?
-    return false unless folio_items? && folio_locations.any?
+    return false unless folio_items? && folio_permanent_locations.any?
 
-    folio_locations.all? { |location| location.dig('details', 'pageAeonSite') }
+    folio_permanent_locations.all? { |location| location.dig('details', 'pageAeonSite') }
   end
 
   # there probably is only one FOLIO location.
-  def folio_locations
-    @folio_locations ||= begin
-      location_uuids = items.filter_map(&:effective_location).map(&:id).uniq
-
-      Folio::Types.locations.values.select { |l| location_uuids.include?(l['id']) }
-    end
+  def folio_permanent_locations
+    @folio_permanent_locations ||= items.filter_map(&:permanent_location).uniq(&:id).map(&:cached_location_data)
   end
 end

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -12,7 +12,7 @@ class Holdings
     attr_reader :document, :item_display
     attr_accessor :due_date
 
-    delegate :loan_type, :material_type, :effective_location, to: :folio_item, allow_nil: true
+    delegate :loan_type, :material_type, :effective_location, :permanent_location, to: :folio_item, allow_nil: true
 
     def self.from_item_display_string(item_display, document: nil)
       values = item_display.split('-|-').map(&:strip)

--- a/spec/components/location_request_link_component_spec.rb
+++ b/spec/components/location_request_link_component_spec.rb
@@ -235,9 +235,10 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
     let(:library) { 'SAL3' }
     let(:location) { 'STACKS' }
 
-    let(:items) { [instance_double(Holdings::Item, folio_item?: true, request_policy:, effective_location:, folio_status:)] }
+    let(:items) { [instance_double(Holdings::Item, folio_item?: true, request_policy:, effective_location:, permanent_location:, folio_status:)] }
     let(:folio_status) { 'Available' }
     let(:request_policy) { {} }
+    let(:permanent_location) { effective_location }
 
     context 'in a pageable location' do
       let(:request_policy) do
@@ -333,6 +334,62 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
             }
           }
         )
+      end
+
+      it { expect(page).to have_link 'Request', href: 'https://host.example.com/requests/new?item_id=12345&origin=SPEC-COLL&origin_location=MANUSCRIPT' }
+    end
+
+    context 'in an Aeon permanent location, but with a temporary location somewhere else' do
+      let(:library) { 'SPEC-COLL' }
+      let(:location) { 'MANUSCRIPT' }
+
+      let(:permanent_location) do
+        Folio::Location.from_dynamic(
+          {
+            "id" => "891ca554-5109-419a-bd01-d647944a40ea",
+            "name" => "Spec Manuscript",
+            "code" => "SPEC-MANUSCRIPT",
+            'institution' => {
+              'id' => '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929',
+              'code' => 'SU',
+              'name' => 'Stanford University'
+            },
+            'campus' => {
+              'id' => 'c365047a-51f2-45ce-8601-e421ca3615c5',
+              'code' => 'SUL',
+              'name' => 'Stanford Libraries'
+            },
+            'library' => {
+              "id" => "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+              "name" => "Special Collections",
+              "code" => "SPEC-COLL"
+            }
+          }
+        )
+      end
+
+      let(:effective_location) do
+        Folio::Location.from_dynamic({
+                                       "id" => "51d37aaa-dcb5-46ee-a9f1-9310f1737b55",
+                                       "name" => "SUL TS CC Repair",
+                                       "code" => "SUL-TS-CC-REPAIR",
+                                       "discoveryDisplayName" => "Out for repair",
+                                       'institution' => {
+                                         'id' => '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929',
+                                         'code' => 'SU',
+                                         'name' => 'Stanford University'
+                                       },
+                                       'campus' => {
+                                         'id' => 'c365047a-51f2-45ce-8601-e421ca3615c5',
+                                         'code' => 'SUL',
+                                         'name' => 'Stanford Libraries'
+                                       },
+                                       'library' => {
+                                         "id" => "c1a86906-ced0-46cb-8f5b-8cef542bdd00",
+                                         "name" => "SUL",
+                                         "code" => "SUL"
+                                       }
+                                     })
       end
 
       it { expect(page).to have_link 'Request', href: 'https://host.example.com/requests/new?item_id=12345&origin=SPEC-COLL&origin_location=MANUSCRIPT' }


### PR DESCRIPTION
e.g. for Aeon + mediation groups, we should look at the its permanent location (falling back on the holdings effective location) to determine whether to use Aeon or mediation behavior. This is especially true for items e.g. in-process, out for repair, etc which shouldn't lose their Aeon-ness just because they are temporarily somewhere else.

Part of #3129 

