### PR TITLE
Use Settings.LIVE_LOOKUP_SERVICE to select LiveLookup service class

### DIFF
--- a/app/models/concerns/solr_holdings.rb
+++ b/app/models/concerns/solr_holdings.rb
@@ -83,11 +83,11 @@ module SolrHoldings
     @folio_holdings_by_id ||= folio_holdings.index_by(&:id)
   end
 
-  # Setting this to no-op if FOLIO_LIVE_LOOKUP is enabled. This is currently
-  # used by the request app to get live information about items, but we plan
-  # to go directly to FOLIO instead.
+  # Setting this to no-op if LIVE_LOOKUP_SERVICE is set to something other than
+  # LiveLookup::Sirsi. This is currently used by the request app to get live
+  # information about items, but we plan to go directly to FOLIO instead.
   def live_data
-    @live_data ||= if Settings.FOLIO_LIVE_LOOKUP
+    @live_data ||= if Settings.LIVE_LOOKUP_SERVICE.present? && Settings.LIVE_LOOKUP_SERVICE != 'LiveLookup::Sirsi'
                      []
                    else
                      LiveLookup.new(id).records

--- a/app/models/concerns/solr_holdings.rb
+++ b/app/models/concerns/solr_holdings.rb
@@ -83,14 +83,14 @@ module SolrHoldings
     @folio_holdings_by_id ||= folio_holdings.index_by(&:id)
   end
 
-  # Setting this to no-op if LIVE_LOOKUP_SERVICE is set to something other than
+  # Setting this to no-op if live_lookup_service is set to something other than
   # LiveLookup::Sirsi. This is currently used by the request app to get live
   # information about items, but we plan to go directly to FOLIO instead.
   def live_data
-    @live_data ||= if Settings.LIVE_LOOKUP_SERVICE.present? && Settings.LIVE_LOOKUP_SERVICE != 'LiveLookup::Sirsi'
-                     []
-                   else
+    @live_data ||= if Settings.live_lookup_service == 'LiveLookup::Sirsi'
                      LiveLookup.new(id).records
+                   else
+                     []
                    end
   end
 

--- a/app/services/live_lookup.rb
+++ b/app/services/live_lookup.rb
@@ -1,5 +1,5 @@
 # LiveLookup serves as a wrapper around specific ILS implementations
-#   for requesting live information about item availability.
+# for requesting live information about item availability.
 class LiveLookup
   delegate :as_json, :to_json, to: :records
 
@@ -7,13 +7,15 @@ class LiveLookup
     @ids = [ids].flatten.compact
   end
 
-  # Uses either the Folio or Sirsi LiveLookup service
-  # depending on whether FOLIO_LIVE_LOOKUP is set.
+  # Uses the LiveLookup service specified by Settings.LIVE_LOOKUP_SERVICE,
+  # or if nothing is configured fall back to LiveLookup::Sirsi
   def records
-    if Settings.FOLIO_LIVE_LOOKUP
-      LiveLookup::Folio.new(@ids).records
-    else
-      LiveLookup::Sirsi.new(@ids).records
-    end
+    live_lookup_service.new(@ids).records
+  end
+
+  private
+
+  def live_lookup_service
+    (Settings.LIVE_LOOKUP_SERVICE || 'LiveLookup::Sirsi').constantize
   end
 end

--- a/app/services/live_lookup.rb
+++ b/app/services/live_lookup.rb
@@ -7,8 +7,7 @@ class LiveLookup
     @ids = [ids].flatten.compact
   end
 
-  # Uses the LiveLookup service specified by Settings.LIVE_LOOKUP_SERVICE,
-  # or if nothing is configured fall back to LiveLookup::Sirsi
+  # Uses the LiveLookup service specified by Settings.live_lookup_service
   def records
     live_lookup_service.new(@ids).records
   end
@@ -16,6 +15,6 @@ class LiveLookup
   private
 
   def live_lookup_service
-    (Settings.LIVE_LOOKUP_SERVICE || 'LiveLookup::Sirsi').constantize
+    Settings.live_lookup_service.constantize
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,8 @@ global_ignored_stackmap_locations:
   - SL3-LOAN
   - SLN-LOAN
 
+live_lookup_service: LiveLookup::Sirsi
+
 libraries:
   ARS:
     about_url: https://library.stanford.edu/libraries/archive-recorded-sound


### PR DESCRIPTION
Prepares us to have more than two LiveLookup services in case we need to use Solr as a backup service while Symphony is shut down. Should get merged around the same time as: https://github.com/sul-dlss/shared_configs/pull/2026
