### PR TITLE
Make Folio::Item.permanent_location a readable attribute

### DIFF
--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -1,6 +1,6 @@
 module Folio
   class Item
-    attr_reader :id, :status, :barcode, :material_type, :effective_location
+    attr_reader :id, :status, :barcode, :material_type, :effective_location, :permanent_location
 
     MaterialType = Struct.new(:id, :name, keyword_init: true)
     LoanType = Struct.new(:id, :name, keyword_init: true)


### PR DESCRIPTION
Fixes:


```
[c0bf13c4-fe82-48d5-af43-011785419e76] ActionView::Template::Error (undefined method `permanent_location' for #<Folio::Item:0x00007fed9c799988 @id="cad93aec-5da8-5fdc-b0c5-83389e8bf660", @barcode="36105036611262", @status="Available", @material_type=#<struct Folio::Item::MaterialType id="1a54b431-2e4f-452d-9cae-9cee66c9a892", name="book">, @permanent_loan_type=#<struct Folio::Item::LoanType id="2b94c631-fca9-4892-a730-03ee529ffe27", name="Can circulate">, @effective_location=#<Folio::Location:0x00007fed9c79a1d0 @id="1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2", @code="SAL3-STACKS", @name="Off-campus storage", @institution=#<struct Folio::Location::Institution id="8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929", code="SU", name="Stanford University">, @campus=#<struct Folio::Location::Campus id="c365047a-51f2-45ce-8601-e421ca3615c5", code="SUL", name="Stanford Libraries">, @library=#<struct Folio::Location::Library id="ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9", code="SAL3", name="Stanford Auxiliary Library 3">>, @permanent_location=#<Folio::Location:0x00007fed9c7999d8 @id="1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2", @code="SAL3-STACKS", @name="Off-campus storage", @institution=#<struct Folio::Location::Institution id="8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929", code="SU", name="Stanford University">, @campus=#<struct Folio::Location::Campus id="c365047a-51f2-45ce-8601-e421ca3615c5", code="SUL", name="Stanford Libraries">, @library=#<struct Folio::Location::Library id="ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9", code="SAL3", name="Stanford Auxiliary Library 3">>, @temporary_loan_type=nil>):
```

Introduced in https://github.com/sul-dlss/SearchWorks/pull/3383