### PR TITLE
Remove FOLIO codes since they will handled by Holdings::Status.folio_availability_class

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -751,14 +751,6 @@ unavailable_current_locations:
     - TECH-SER
     - TECH-SERV
     - TEMP-LL
-    - TS-CC-REPAIR
-    - TS-CC-BINDERYPREP
-    - TS-CC-BOOKJACKET
-    - TS-CC-KASEMAKE
-    - TS-COLLECTIONCARE
-    - TS-CC-SPECIALPROJECTS
-    - TS-CONSERVATION
-    - TS-PROCESSING
 
 requestable_current_locations:
   default:

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -868,15 +868,7 @@ module Constants
                       'TECH-PROC',
                       'TECH-SER',
                       'TECH-SERV',
-                      'TEMP-LL',
-                      'TS-CC-REPAIR',
-                      'TS-CC-BINDERYPREP',
-                      'TS-CC-BOOKJACKET',
-                      'TS-CC-KASEMAKE',
-                      'TS-COLLECTIONCARE',
-                      'TS-CC-SPECIALPROJECTS',
-                      'TS-CONSERVATION',
-                      'TS-PROCESSING']
+                      'TEMP-LL']
 
   FORCE_AVAILABLE_CURRENT_LOCS = [
     'ART-AT-ENG',


### PR DESCRIPTION
Part of [#1068](https://github.com/sul-dlss/searchworks_traject_indexer/issues/1068)