### PR TITLE
Use preferred item for browse nearby if instance has no preferred barcode

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -48,8 +48,12 @@ class BrowseController < ApplicationController
 
       @items = service.items(params[:before] || params[:after])
     else
-      barcode = params[:barcode] || @original_doc[:preferred_barcode]
-      item = @original_doc.items.find { |c| c.barcode&.starts_with?(barcode) }
+
+      item = if params[:barcode]
+               @original_doc.items.find { |c| c.barcode&.starts_with?(params[:barcode]) }
+             else
+               @original_doc.preferred_item
+             end
 
       @items = NearbyOnShelf.around_item(
         item,

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe BrowseController do
+  describe 'GET #index' do
+    # rubocop:disable RSpec/IndexedLet
+    let(:item1) { Holdings::Item.from_item_display_string('123456 -|-') }
+    let(:item2) { Holdings::Item.from_item_display_string('109876 -|-') }
+    # rubocop:enable RSpec/IndexedLet
+    let(:original_doc) { instance_double(SolrDocument, items: [item1, item2], preferred_item: item2) }
+
+    before do
+      allow(controller).to receive_messages(search_service: double('search_service', fetch: [response, original_doc]), params: { start: 'xyz' }, fetch_original_document: original_doc)
+    end
+
+    context 'when params[:barcode] is present' do
+      before do
+        allow(controller).to receive(:params).and_return(barcode: '123456', start: 'xyz')
+      end
+
+      it 'calls NearbyOnShelf.around_item with the correct item' do
+        expect(NearbyOnShelf).to receive(:around_item) do |item, _search_service|
+          expect(item).to eq(item1)
+        end
+
+        get :index
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when params[:barcode] is not present' do
+      it 'calls NearbyOnShelf.around_item with the correct item' do
+        expect(NearbyOnShelf).to receive(:around_item) do |item, _search_service|
+          expect(item).to eq(item2)
+        end
+
+        get :index
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3405 