### PR TITLE
Respect the searchworksTreatTemporaryLocationAsPermanentLocation fact…

### DIFF
--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -21,7 +21,7 @@ class Holdings
         # use the effective location's library name if we're treating it as the permanent location;
         # by the time we get here, we're already grouped by the item's library code which respects
         # the same rules
-        name ||= folio_item.effective_location&.library&.name if folio_item.effective_location&.details&.dig('searchworksTreatTemporaryLocationAsPermanentLocation')
+        name = folio_item.effective_location&.library&.name if folio_item.effective_location&.details&.dig('searchworksTreatTemporaryLocationAsPermanentLocation')
         # prefer the name from the cached folio data (for consistency across records)
         name ||= folio_item.permanent_location&.library&.name
         # fall back on the name from the document

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -8,8 +8,19 @@ describe Holdings::Library do
     end
 
     context 'with a FOLIO item' do
-      let(:items) { [instance_double(Holdings::Item, folio_item?: true, permanent_location: double(library:))] }
+      let(:items) { [instance_double(Holdings::Item, folio_item?: true, permanent_location: double(library:), effective_location: nil)] }
       let(:library) { Folio::Library.new(id: 'green', code: 'GREEN', name: 'Cecil R. Green Library') }
+
+      it "translates the library code using the FOLIO library data" do
+        expect(Holdings::Library.new("GREEN", items).name).to eq "Cecil R. Green Library"
+      end
+    end
+
+    context 'with a FOLIO item in a temporary location we treat at the permanent location for display' do
+      let(:items) { [instance_double(Holdings::Item, folio_item?: true, permanent_location: double(sal3:), effective_location:)] }
+      let(:effective_location) { instance_double(Folio::Location, details: { 'searchworksTreatTemporaryLocationAsPermanentLocation' => true }, library:) }
+      let(:library) { Folio::Library.new(id: 'green', code: 'GREEN', name: 'Cecil R. Green Library') }
+      let(:sal3) { Folio::Library.new(id: 'sal3', code: 'SAL3', name: 'SAL3') }
 
       it "translates the library code using the FOLIO library data" do
         expect(Holdings::Library.new("GREEN", items).name).to eq "Cecil R. Green Library"


### PR DESCRIPTION
… for displaying the grouped library name
Before:
![Screenshot 2023-08-16 at 16 16 50](https://github.com/sul-dlss/SearchWorks/assets/111218/81e13f52-a5ce-4c96-8b4e-bc66e257e4f6)

After:
![Screenshot 2023-08-16 at 16 16 13](https://github.com/sul-dlss/SearchWorks/assets/111218/2651cf29-82d6-46df-baf9-7429c9fb5b39)
(ignore the missing open hours; this isn't configured locally.)