### PR TITLE
Add the barcode to the item tr tag for debugging

### DIFF
--- a/app/components/access_panels/library_location_component.html.erb
+++ b/app/components/access_panels/library_location_component.html.erb
@@ -28,7 +28,7 @@
   </thead>
   <tbody data-long-list data-list-type="location">
     <% location.items.each do |item| %>
-      <tr class="availability-item">
+      <%= tag.tr class: 'availability-item', data: { barcode: item.barcode } do %>
         <td class="callnumber">
           <%= item.callnumber %>
         </td>
@@ -62,7 +62,7 @@
         <% else %>
           <td></td>
         <% end %>
-      </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>


### PR DESCRIPTION
It's hard to debug item display problems when we don't include a unique identifier for the item 🤷‍♂️ 

![Screenshot 2023-08-17 at 09 51 04](https://github.com/sul-dlss/SearchWorks/assets/111218/ff96fa74-d589-482d-b2be-d3e7c17a46e6)
