### PR TITLE
Remove the xs only navigation

### DIFF
--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,6 +1,6 @@
 <% ivar_to_paginate =  article_selections? ? @bookmarks : @response %>
 <!-- Markup for sm screens and larger -->
-<div class="sort-and-per-page sul-toolbar selection-list-toolbar hidden-xs">
+<div class="sort-and-per-page sul-toolbar selection-list-toolbar">
   <div id="search-results-toolbar" class="search-widgets">
     <%= render partial: "paginate_compact", object: ivar_to_paginate %>
     <% if bookmarks? %>
@@ -20,25 +20,5 @@
         <%= render partial: 'select_all_widget' %>
       <% end %>
     </span>
-  </div>
-</div>
-
-<!-- Markup for xs screens -->
-<div class="sort-and-per-page sul-toolbar visible-xs-block">
-  <%= render partial: "paginate_compact", object: ivar_to_paginate %>
-  <div id="search-results-toolbar" class="search-widgets">
-    <% if bookmarks? %>
-        <%= link_to t('blacklight.tools.cite_entries', current_range: current_entries_info(ivar_to_paginate)).html_safe, polymorphic_path(article_selections? ? :citation_articles : :citation_solr_documents, :sort=>params[:sort], :per_page=>params[:per_page], :id => @response.documents.map {|doc| doc.id}), {:id => 'citeLink', :name => 'citation', :class => 'btn btn-default', :data => {:ajax_modal => "trigger"}} %>
-        <%= render "tool_dropdown" %>
-        <%= link_to clear_bookmarks_path(type:  article_selections? ? 'article' : 'catalog'), method: :delete, class: 'btn btn-default clear-bookmarks', data: { confirm: t("searchworks.bookmarks.#{article_selections? ? 'article' : 'catalog'}.clear.action_confirm") } do %>
-          <i class="fa fa-times" aria-hidden="true"></i> Clear list
-        <% end %>
-    <% end %>
-    <%= render partial: 'view_type_group' %>
-    <%= render partial: 'sort_widget' %>
-    <%= render partial: 'shared/per_page_widget' %>
-    <% unless bookmarks? %>
-      <%= render partial: 'select_all_widget' %>
-    <% end %>
   </div>
 </div>

--- a/spec/features/access_points/databases_spec.rb
+++ b/spec/features/access_points/databases_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "Databases Access Point" do
+RSpec.feature "Databases Access Point" do
   before do
     visit databases_path
   end
@@ -37,13 +37,7 @@ feature "Databases Access Point" do
     expect(page).to have_css('h2', text: '4 catalog results')
     expect(page).to have_css('h3', text: /Selected Database \d/, count: 4)
 
-    # first is displayed only on desktop layout
-    within all('#sort-dropdown')[0] do
-      expect(page).to have_content('Sort by title')
-    end
-
-    # second is displayed only on mobile layout
-    within all('#sort-dropdown')[1] do
+    within '#sort-dropdown' do
       expect(page).to have_content('Sort by title')
     end
   end

--- a/spec/features/blacklight_customizations/sort_options_spec.rb
+++ b/spec/features/blacklight_customizations/sort_options_spec.rb
@@ -1,22 +1,12 @@
 require "spec_helper"
 
-feature "Sort options" do
+RSpec.feature "Sort options" do
   scenario "should include our custom options" do
     visit root_path
     fill_in 'q', with: ''
     click_button 'search'
 
-    # first is displayed only on desktop layout
-    within(all('#sort-dropdown')[0]) do
-      expect(page).to have_css("li a", text: 'relevance')
-      expect(page).to have_css("li a", text: 'year (new to old)')
-      expect(page).to have_css("li a", text: 'year (old to new)')
-      expect(page).to have_css("li a", text: 'author')
-      expect(page).to have_css("li a", text: 'title')
-    end
-
-    # second is displayed only on mobile layout
-    within(all('#sort-dropdown')[1]) do
+    within '#sort-dropdown' do
       expect(page).to have_css("li a", text: 'relevance')
       expect(page).to have_css("li a", text: 'year (new to old)')
       expect(page).to have_css("li a", text: 'year (old to new)')

--- a/spec/features/blacklight_customizations/view_options_spec.rb
+++ b/spec/features/blacklight_customizations/view_options_spec.rb
@@ -1,25 +1,12 @@
 require "spec_helper"
 
-feature "View options" do
+RSpec.feature "View options" do
   scenario "should include our custom options" do
     visit root_path
     fill_in 'q', with: ''
     click_button 'search'
 
-    # first is displayed only on desktop layout
-    within all('#view-type-dropdown')[0] do
-      expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'normal')
-      expect(page).to have_css("li a.view-type-list i.fa.fa-th-list")
-
-      expect(page).to have_css("li a.view-type-gallery span.view-type-label", text: 'gallery')
-      expect(page).to have_css("li a.view-type-gallery i.fa.fa-th")
-
-      expect(page).to have_css("li a.view-type-brief span.view-type-label", text: 'brief')
-      expect(page).to have_css("li a.view-type-brief i.fa.fa-align-justify")
-    end
-
-    # second is displayed only on mobile layout
-    within all('#view-type-dropdown')[1] do
+    within '#view-type-dropdown' do
       expect(page).to have_css("li a.view-type-list span.view-type-label", text: 'normal')
       expect(page).to have_css("li a.view-type-list i.fa.fa-th-list")
 


### PR DESCRIPTION
Because this has duplicate ids which is an accessability problem.  We don't expect to serve devices that can't handle small navigation.

Fixes #3509

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
