### PR TITLE
Avoid using the CSS class hide

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -2,7 +2,7 @@
   /*
     jQuery plugin to render Google book covers for image elements
 
-      Usage: $(selector).renderGoogleBookCovers();
+      Usage: $(selector).plugGoogleBookContent();
 
     This plugin :
       - collects all 'img.cover-image' elements and batches them
@@ -113,13 +113,11 @@
 
         // Only set the thumb src if it's not already set
         if(typeof imageEl.attr('src') === 'undefined') {
-          imageEl
-            .attr('src', thumbUrl)
-            .removeClass('hide')
-            .addClass('show');
+          imageEl.attr('src', thumbUrl)[0].hidden = false;
 
-          imageEl.parent().parent().find('span.fake-cover')
-            .addClass('hide');
+          const cover = imageEl.parent().parent().find('span.fake-cover')[0]
+          if (cover)
+            cover.hidden = true;
         }
       }
     }
@@ -170,7 +168,7 @@
       var $accessPanel = $googleBooks.parents(selectorPanel);
 
       if ($accessPanel.length > 0) {
-        $accessPanel.removeClass('hide').addClass('show');
+        $accessPanel[0].hidden = false;
         $googleBooks.show();
       }
     }
@@ -179,8 +177,8 @@
       $resultsOnlineSection = $googleBooks.parents('[data-behavior="results-online-section"]');
 
       if ($resultsOnlineSection.length > 0) {
-        $resultsOnlineSection.removeClass('hide').addClass('show');
-        $googleBooks.removeClass('hide').addClass('show');
+        $resultsOnlineSection[0].hidden = false;
+        $googleBooks[0].hidden = false;
         // Re-run responsive truncation on the list in case the google link takes us over the two-line threshold
         $googleBooks
           .parents("[data-behavior='truncate-results-metadata-links']")

--- a/app/components/access_panels/online_component.html.erb
+++ b/app/components/access_panels/online_component.html.erb
@@ -1,4 +1,4 @@
-<%= render @layout.new(classes: ['panel-online', ('hide' unless links.any?)]) do |c| %>
+<%= render @layout.new(classes: ['panel-online'], hidden: !links.any?) do |c| %>
   <% c.header do %>
     <h2>Online</h2>
   <% end if links.any? %>

--- a/app/components/access_panels/online_component.rb
+++ b/app/components/access_panels/online_component.rb
@@ -1,4 +1,5 @@
 module AccessPanels
+  # Displays online links and provides a place for plugGoogleBookContent() to add book cover previews
   class OnlineComponent < AccessPanels::Base
     def links
       @document.preferred_online_links

--- a/app/components/access_panels/related_component.html.erb
+++ b/app/components/access_panels/related_component.html.erb
@@ -1,8 +1,4 @@
-<%
-  visible = oclc.present? ?  'show' : 'hide'
-%>
-
-<%= render @layout.new(classes: ['panel-related', ('hide' unless oclc.present?)].compact) do |c| %>
+<%= render @layout.new(classes: ['panel-related'], hidden: !oclc.present?) do |c| %>
   <% c.title do %>
     More options
   <% end %>

--- a/app/components/access_panels/related_component.rb
+++ b/app/components/access_panels/related_component.rb
@@ -1,4 +1,5 @@
 module AccessPanels
+  # Displays related items and provides a place for plugGoogleBookContent() to add book cover previews
   class RelatedComponent < AccessPanels::Base
     def oclc
       document[:oclc]

--- a/app/views/catalog/_index_online_section.html.erb
+++ b/app/views/catalog/_index_online_section.html.erb
@@ -1,5 +1,5 @@
 <% display_panel = document.preferred_online_links.present? %>
-<dl data-behavior="results-online-section" class="dl-horizontal results-online-section results-metadata-section col-md-8 <%= 'hide' unless display_panel %>">
+<dl data-behavior="results-online-section" class="dl-horizontal results-online-section results-metadata-section col-md-8" <%= 'hidden' unless display_panel %>>
   <% if document.druid %>
     <dt class="also-online-label">Also online at</dt>
   <% else %>
@@ -15,7 +15,7 @@
 
       <% if document.index_links.managed_purls.none? %>
         <% book_ids  = get_book_ids(document) %>
-        <li class="hide google-books <%= (book_ids['isbn'] + book_ids['oclc'] + book_ids['lccn']).join(' ') %>">
+        <li hidden class="google-books <%= (book_ids['isbn'] + book_ids['oclc'] + book_ids['lccn']).join(' ') %>">
           <a href="" class="full-view">Google Books (Full view)</a>
         </li>
       <% end %>

--- a/app/views/catalog/thumbnails/_item_thumbnail.html.erb
+++ b/app/views/catalog/thumbnails/_item_thumbnail.html.erb
@@ -2,7 +2,7 @@
 <% if thumbnail_src.present? %>
   <%= image_tag(thumbnail_src, class: 'stacks-image', alt: '') %>
 <% else %>
-  <img class="cover-image center-block <%= css_class %> hide" alt="" data-isbn="<%= isbn %>" data-oclc="<%= oclc %>" data-lccn="<%= lccn %>">
+  <img class="cover-image center-block <%= css_class %>" hidden alt="" data-isbn="<%= isbn %>" data-oclc="<%= oclc %>" data-lccn="<%= lccn %>">
 
   <% if document_index_view_type == :gallery %>
     <%= link_to document, tabindex: '-1', aria: { hidden: true } do %>

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AccessPanels::OnlineComponent, type: :component do
+RSpec.describe AccessPanels::OnlineComponent, type: :component do
   include ModsFixtures
   include Marc856Fixtures
 
@@ -210,7 +210,7 @@ describe AccessPanels::OnlineComponent, type: :component do
         render_inline(described_class.new(document:))
 
         expect(page).to have_css('.panel-online', visible: false)
-        expect(page).to have_css('.panel-online .google-books.OCLCabc123')
+        expect(page).to have_css('.panel-online .google-books.OCLCabc123', visible: false)
       end
     end
 

--- a/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "catalog/_index_online_section" do
+RSpec.describe "catalog/_index_online_section" do
   include Marc856Fixtures
 
   describe "Accordion section - Online" do
@@ -23,8 +23,9 @@ describe "catalog/_index_online_section" do
 
       it 'should include the online dl' do
         expect(rendered).to have_css('dt', text: 'Online')
-        expect(rendered).to have_css('dd li', count: 5) # 4 links and a Google Books link
-        expect(rendered).to have_css('dd li a', text: 'Google Books (Full view)')
+        expect(rendered).to have_css('dd li', count: 4)
+        expect(rendered).to have_css('dd li', count: 5, visible: false) # 4 links and a Google Books link
+        expect(rendered).to have_css('dd li a', text: 'Google Books (Full view)', visible: false)
       end
     end
 

--- a/spec/views/catalog/thumbnails/_item_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/thumbnails/_item_thumbnail.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "catalog/thumbnails/_item_thumbnail" do
+RSpec.describe "catalog/thumbnails/_item_thumbnail" do
   before do
     allow(view).to receive_messages(css_class: '', oclc: '', isbn: '', lccn: '', document:, blacklight_config: CatalogController.blacklight_config)
   end
@@ -9,15 +9,16 @@ describe "catalog/thumbnails/_item_thumbnail" do
     let(:document) { SolrDocument.new(id: '1234', title_display: 'Title') }
 
     describe "fake covers" do
-      it "should be included on the gallery view" do
+      it "is included on the gallery view" do
         allow(view).to receive(:document_index_view_type).and_return(:gallery)
         render
         expect(rendered).to have_css('.fake-cover', text: "Title")
       end
-      it "should not be included on other views" do
+
+      it "is not included on other views" do
         allow(view).to receive(:document_index_view_type).and_return(:list)
         render
-        expect(rendered).to have_css('img.cover-image')
+        expect(rendered).to have_css('img.cover-image', visible: false)
         expect(rendered).not_to have_css('.fake-cover')
       end
     end


### PR DESCRIPTION
It is not present in Bootstrap v4, so this helps us prepare for that transition

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
