### PR TITLE
Make item.on_reserve? more lenient

### DIFF
--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -120,7 +120,7 @@ class Holdings
     end
 
     def on_reserve?
-      reserve_desk.present? && loan_period.present?
+      course_id.present?
     end
 
     def treat_current_location_as_home_location?


### PR DESCRIPTION
Closes #3322

Items occasionally will be placed on reserve for a course that
does not have a reserve desk assigned (yet), so this handles
a case where we erroneously don't treat them as on reserve.

Otherwise, all of the data driving this is already coming from
FOLIO via the indexer.
