### PR TITLE
Restore Course reserve title in access panel

### DIFF
--- a/app/components/access_panels/course_reserves_component.html.erb
+++ b/app/components/access_panels/course_reserves_component.html.erb
@@ -1,5 +1,7 @@
 <%= render @layout.new(classes: 'panel-course-reserve') do |c| %>
-  <% c.title('Course reserve') %>
+  <% c.title do %>
+    Course reserve
+  <% end %>
   <% c.body do %>
     <%= render course_reserves_list %>
   <% end %>


### PR DESCRIPTION
Currently in prod
<img width="514" alt="Screenshot 2023-09-21 at 12 23 25" src="https://github.com/sul-dlss/SearchWorks/assets/1328900/b3a0bc3f-314f-4d5f-92f2-6f34b822e166">


Fix
<img width="448" alt="Screenshot 2023-09-21 at 12 23 09" src="https://github.com/sul-dlss/SearchWorks/assets/1328900/f17725ce-cf09-40bf-90df-ab155ccc210e">
