### PR TITLE
Hide fake cover when Google Books cover is present

### DIFF
--- a/app/assets/javascripts/jquery.plug-google-content.js
+++ b/app/assets/javascripts/jquery.plug-google-content.js
@@ -115,9 +115,10 @@
         if(typeof imageEl.attr('src') === 'undefined') {
           imageEl.attr('src', thumbUrl)[0].hidden = false;
 
-          const cover = imageEl.parent().parent().find('span.fake-cover')[0]
-          if (cover)
-            cover.hidden = true;
+          const fakeCover = imageEl.parent().parent().find('span.fake-cover')[0]
+          if (fakeCover) {
+            fakeCover.hidden = true
+          }
         }
       }
     }

--- a/app/assets/stylesheets/modules/gallery-view.scss
+++ b/app/assets/stylesheets/modules/gallery-view.scss
@@ -105,6 +105,11 @@ span.fake-cover {
   justify-content: center;
 }
 
+/* override display for the hidden attribute */
+span.fake-cover[hidden] {
+  display: none;
+}
+
 div.fake-cover-text {
   color: $clay;
   font-variant: all-small-caps;

--- a/spec/features/blacklight_customizations/record_metadata_spec.rb
+++ b/spec/features/blacklight_customizations/record_metadata_spec.rb
@@ -6,7 +6,6 @@ feature 'Record view' do
   end
 
   scenario 'should have correct cover image attributes', js: true do
-    skip('Google Books API not working under test')
     within 'div.document' do
       expect(page).to have_css('img.cover-image', visible: true)
       expect(page).to have_css(
@@ -15,7 +14,7 @@ feature 'Record view' do
       expect(page).to have_css("img.cover-image[data-isbn='ISBN0393040801,ISBN9780393040807']", visible: true)
       expect(page).to have_css("img.cover-image[data-lccn='LCCN96049953']", visible: true)
       expect(page).to have_css("img.cover-image[data-oclc='OCLC36024029']", visible: true)
-      expect(find('img.cover-image')['src']).to match(/books\.google\.com.*id=crOdQgAACAAJ/)
+      expect(find('img.cover-image')['src']).to match(/books\.google\.com.*[?&]id=3xmDzzNiwiUC(&|$)/)
     end
   end
 

--- a/spec/features/gallery_view_spec.rb
+++ b/spec/features/gallery_view_spec.rb
@@ -15,10 +15,7 @@ feature 'Gallery View' do
       ".gallery-document a[tabindex='-1'] span.fake-cover", text: 'An object', visible: true
     )
 
-    # Google books is acting up in testing
-    # expect(page).to_not have_css(
-    #   '.gallery-document a div.fake-cover-text', text: 'Car : a drama of the American workplace', visible: true
-    # )
+    expect(page).to have_css('.gallery-document a div.fake-cover-text', text: 'Car : a drama of the American workplace', visible: :hidden)
 
     expect(page).to have_css('.gallery-document h3.index_title', text: 'An object')
     expect(page).to have_css('.gallery-document button.btn-preview', text: 'Preview')


### PR DESCRIPTION
Related to https://github.com/sul-dlss/SearchWorks/commit/e5a10ba85b9471f4fd55461eb87b8f92dc938c7e