### PR TITLE
Fix collection membership display

### DIFF
--- a/app/controllers/collection_members_controller.rb
+++ b/app/controllers/collection_members_controller.rb
@@ -1,10 +1,10 @@
 class CollectionMembersController < ApplicationController
   def show
-    @document = SolrDocument.find(show_param)
+    @document = SolrDocument.find(collection_id)
     respond_to do |format|
       format.json {
         render(
-          json: @document.collection_members.with_type(params.permit(:type)[:type]),
+          json: @document.collection_members.with_type(collection_params[:type]),
           layout: false
         )
       }
@@ -13,7 +13,11 @@ class CollectionMembersController < ApplicationController
 
   private
 
-  def show_param
-    params.require(:id)
+  def collection_params
+    params.permit(:id, :type, :format)
+  end
+
+  def collection_id
+    collection_params.require(:id)
   end
 end

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -1,10 +1,10 @@
 module CollectionHelper
   def link_to_collection_members(link_text, document, options = {})
-    link_to(link_text, search_catalog_path(f: { collection: [document[:id]] }), options)
+    link_to(link_text, collection_members_path(document), options)
   end
 
   def collection_members_path(document, options = {})
-    search_catalog_path(f: { collection: [document[:id]] })
+    search_catalog_path(f: { collection: [document.prefixed_id] })
   end
 
   def collection_members_enumeration(document)

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -27,7 +27,8 @@ module CollectionHelper
   def collection_breadcrumb_value(collection_id)
     if @response.documents.first&.index_parent_collections.present?
       collection = @response.documents.first.index_parent_collections.find do |coll|
-        coll[:id] == collection_id
+        # strip leading 'a' from collection catkeys
+        coll[:id] == collection_id.sub(/^a(\d+)$/, '\1')
       end
       return document_presenter(collection).heading if collection.present?
     end

--- a/app/models/concerns/collection_member.rb
+++ b/app/models/concerns/collection_member.rb
@@ -19,7 +19,7 @@ module CollectionMember
     unless @index_parent_collections
       @index_parent_collections = self[:collection_with_title].map do |collection_with_title|
         id, title = collection_with_title.split('-|-').map(&:strip)
-        SolrDocument.new(id:, title_display: title)
+        SolrDocument.new(id: strip_a(id), title_display: title)
       end
     end
     @index_parent_collections
@@ -36,8 +36,13 @@ module CollectionMember
 
   def parent_collection_params
     self["collection"].map do |collection_id|
-      "id:#{collection_id}"
+      "id:#{strip_a(collection_id)}"
     end.join(" OR ")
+  end
+
+  # strip leading 'a' from collection catkeys for building URLs, etc.
+  def strip_a(id)
+    id.sub(/^a(\d+)$/, '\1')
   end
 
   def blacklight_solr

--- a/app/models/concerns/digital_collection.rb
+++ b/app/models/concerns/digital_collection.rb
@@ -68,7 +68,7 @@ module DigitalCollection
     def response
       @response ||= blacklight_solr.select(
         params: {
-          fq: "collection:\"#{@document[:id]}\"",
+          fq: collection_member_params,
           rows: 20
         }
       )['response']
@@ -95,6 +95,14 @@ module DigitalCollection
 
     def blacklight_solr
       Blacklight.default_index.connection
+    end
+
+    # @return [String] a Solr query string
+    # search for items with collection set to both prefixed and non-prefixed ids
+    def collection_member_params
+      [document[:id], document.prefixed_id].uniq.map do |collection_id|
+        "collection:\"#{collection_id}\""
+      end.join(" OR ")
     end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -129,4 +129,10 @@ class SolrDocument
       @organization_and_arrangement ||= OrganizationAndArrangement.new(self)
     end
   end
+
+  # @return [String] the document id, prefixed with an 'a' if it's a numeric catkey
+  # after FOLIO migration, all ILS-derived ids should be prefixed with 'a'
+  def prefixed_id
+    self[:id].to_s.sub(/^(\d+)$/, 'a\1')
+  end
 end

--- a/spec/helpers/collection_helper_spec.rb
+++ b/spec/helpers/collection_helper_spec.rb
@@ -7,8 +7,8 @@ describe CollectionHelper do
     it "should link to the given text" do
       expect(link_to_collection_members("LinkText", document)).to match /<a href.*>LinkText<\/a>/
     end
-    it "should link document id" do
-      expect(link_to_collection_members("LinkText", document)).to match /<a href=\".*collection.*=1234\".*/
+    it "should link the collection id with prefix" do
+      expect(link_to_collection_members("LinkText", document)).to match /<a href=\".*collection.*=a1234\".*/
     end
   end
 
@@ -23,8 +23,8 @@ describe CollectionHelper do
   describe "#collection_members_path" do
     let(:document) { SolrDocument.new(id: '1234') }
 
-    it "should link document id" do
-      expect(collection_members_path(document)).to match /.*collection.*=1234.*/
+    it "should link the collection id with prefix" do
+      expect(collection_members_path(document)).to match /.*collection.*=a1234.*/
     end
   end
 
@@ -67,21 +67,21 @@ describe CollectionHelper do
         OpenStruct.new(heading: 'Title2')
       )
       document_list = [
-        SolrDocument.new(collection: ['12345', '54321'], collection_with_title: ['12345 -|- Title1', '54321 -|- Title2'])
+        SolrDocument.new(collection: ['a12345', 'a54321'], collection_with_title: ['a12345 -|- Title1', 'a54321 -|- Title2'])
       ]
       assign(:response, OpenStruct.new(documents: document_list))
-      expect(helper.send(:collection_breadcrumb_value, '54321')).to eq 'Title2'
+      expect(helper.send(:collection_breadcrumb_value, 'a54321')).to eq 'Title2'
     end
-    it "should return the ID if there is no @document_list" do
+    it "should return the ID with the prefix if there is no @document_list" do
       assign(:response, OpenStruct.new(documents: []))
-      expect(helper.send(:collection_breadcrumb_value, '54321')).to eq '54321'
+      expect(helper.send(:collection_breadcrumb_value, 'a54321')).to eq 'a54321'
     end
-    it "should return the ID if there are no matching collections" do
+    it "should return the ID with the prefix if there are no matching collections" do
       document_list = [
         SolrDocument.new(collection: ['12345', '54321'], collection_with_title: ['12345 -|- Title1', '54321 -|- Title2'])
       ]
       assign(:response, OpenStruct.new(documents: document_list))
-      expect(helper.send(:collection_breadcrumb_value, '11111')).to eq '11111'
+      expect(helper.send(:collection_breadcrumb_value, 'a11111')).to eq 'a11111'
     end
   end
 end

--- a/spec/models/concerns/collection_member_spec.rb
+++ b/spec/models/concerns/collection_member_spec.rb
@@ -23,6 +23,7 @@ describe CollectionMember do
 
   describe "#parent_collections" do
     let(:multi_collection) { SolrDocument.new(collection: ['12345', '54321']) }
+    let(:catkey_prefix) { SolrDocument.new(collection: ['a12345']) }
     let(:stub_solr) { double('solr') }
     let(:stub_params) { { params: { fq: "id:12345" } } }
     let(:stub_response) { {
@@ -47,6 +48,9 @@ describe CollectionMember do
     end
     it "#parent_collection_params should return all IDs joined w/ OR" do
       expect(multi_collection.send(:parent_collection_params)).to eq "id:12345 OR id:54321"
+    end
+    it 'should strip leading "a" from collection ids' do
+      expect(catkey_prefix.send(:parent_collection_params)).to eq "id:12345"
     end
     it "should return nil for non collection members" do
       expect(non_member.parent_collections).to be_nil

--- a/spec/models/concerns/digital_collection_spec.rb
+++ b/spec/models/concerns/digital_collection_spec.rb
@@ -17,9 +17,9 @@ describe DigitalCollection do
     let(:collection_members) { DigitalCollection::CollectionMembers.new(collection) }
     let(:collection_members_with_rows) { DigitalCollection::CollectionMembers.new(collection, rows: 17) }
     let(:stub_solr) { double('solr') }
-    let(:stub_params) { { params: { fq: "collection:\"1234\"", rows: 20 } } }
-    let(:rows_params) { { params: { fq: "collection:\"1234\"", rows: 17 } } }
-    let(:small_rows_params) { { params: { fq: "collection:\"1234\"", rows: 3 } } }
+    let(:stub_params) { { params: { fq: "collection:\"1234\" OR collection:\"a1234\"", rows: 20 } } }
+    let(:rows_params) { { params: { fq: "collection:\"1234\" OR collection:\"a1234\"", rows: 17 } } }
+    let(:small_rows_params) { { params: { fq: "collection:\"1234\" OR collection:\"a1234\"", rows: 3 } } }
     let(:stub_response) { {
       'response' => {
         'numFound' => 2,

--- a/spec/views/collection_members/_file_collection_members.html.erb_spec.rb
+++ b/spec/views/collection_members/_file_collection_members.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "collection_members/_file_collection_members" do
-  let(:document) { SolrDocument.new() }
+  let(:document) { SolrDocument.new(id: 12345) }
   let(:collection_members) { [
     SolrDocument.new(id: 1, pub_date: "2010", author_person_full_display: "Mr. Bean"),
     SolrDocument.new(id: 2, pub_date: "2011")


### PR DESCRIPTION
- Strip leading 'a' from catkeys when finding parent collections
- Make digital collection preview search use a-prefixed catkeys
- Permit some params for CollectionMembersController to silence warnings

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
