### PR TITLE
Additively put a style on links in the LibraryComponent

### DIFF
--- a/app/assets/stylesheets/modules/access-panel-library-locations.scss
+++ b/app/assets/stylesheets/modules/access-panel-library-locations.scss
@@ -1,16 +1,28 @@
-.panel-library-location {
-  .library-location-heading {
+.panel-library-location { // A kind of .access-panel
+  a { // SAL3 is not wrapped with an anchor tag. See link_to_library_about_page
+    .library-location-heading {
+      &:hover {
+        background-color: $warm-grey;
+      }
+      h3 {
+        border-bottom: 1px dotted $white;
+        max-width: 95%; // so the border won't extend past the text
+
+        &:hover,
+        &:active {
+          border-bottom: 1px solid $white;
+        }  
+      }
+    }
+  }
+  .library-location-heading { // A kind of .access-panel-heading
     @include panel-heading($sul-access-location-bg, $sul-access-header-color);
     height: 50px;
     padding-bottom: 6px;
     h3 {
       color: $sul-access-header-color;
+      display: inline-block;
       line-height: 1em;
-    }
-    a {
-      color: #fff;
-      text-decoration: underline;
-      height: 50px;
     }
   }
 
@@ -23,9 +35,7 @@
     padding-left: 60px;
 
   }
-  .library-location-heading:hover {
-    background-color: $warm-grey;
-  }
+
   .location {
     .items {
       li {

--- a/app/assets/stylesheets/modules/access-panel.scss
+++ b/app/assets/stylesheets/modules/access-panel.scss
@@ -7,23 +7,6 @@
   font-weight: 400;
 }
 
-.access-panel-heading {
-  &.library-location-heading h3 {
-    border-bottom: 1px dotted $white;
-    display: inline-block;
-    max-width: 95%; // so the border won't extend past the text
-
-    &:hover,
-    &:active {
-      border-bottom: 1px solid $white;
-    }
-
-    &.no-link {
-      border-bottom: 0;
-    }
-  }
-}
-
 .access-panel {
   .panel-body {
     h4 {

--- a/app/components/access_panels/library_component.html.erb
+++ b/app/components/access_panels/library_component.html.erb
@@ -3,7 +3,7 @@
     <div class="library-location-heading access-panel-heading">
       <%= thumb_for_library %>
       <div class="library-location-heading-text">
-        <h3 class="<%= "no-link" unless library.about_url %>"><%= library.name %></h3>
+        <h3><%= library.name %></h3>
         <div class="small location-hours-today">
           <% unless library.holding_library? %>
             (no holding library)

--- a/spec/components/access_panels/library_component_spec.rb
+++ b/spec/components/access_panels/library_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AccessPanels::LibraryComponent, type: :component do
     it "returns a placeholder panel" do
       render_inline(component)
 
-      expect(page).to have_selector('h3.no-link', text: 'Stanford Libraries')
+      expect(page).to have_selector('h3', text: 'Stanford Libraries')
     end
   end
 end


### PR DESCRIPTION
Rather than adding special styles to remove them.  I think this is easier to understand as there are fewer unnecessary conditionals in the code

Fixes #3567 
<!-- 📝 CHANGELOG update? -->
