### PR TITLE
Stop testing on ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1', '3.2']
+        ruby: ['3.2']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
All deploys now use 3.2

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
