### PR TITLE
Avoid drawing the connection form on pages that don't need it

### DIFF
--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -39,7 +39,9 @@
     </div>
   </div>
 </div>
-<div id="connection-form" class="feedback-form-container collapse">
-  <%= render_feedback_form('connection') if show_feedback_form? %>
-  <hr>
-</div>
+<% if article_search? || current_page?(feedback_path) # For JS enabled and disabled %>
+  <div id="connection-form" class="feedback-form-container collapse">
+    <%= render_feedback_form('connection') if show_feedback_form? %>
+    <hr>
+  </div>
+<% end %>

--- a/spec/features/connection_form_spec.rb
+++ b/spec/features/connection_form_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-feature 'Connection form (js)', js: true do
+RSpec.feature 'Connection form (js)', js: true do
   before do
     stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
     visit articles_path
@@ -31,7 +31,7 @@ feature 'Connection form (js)', js: true do
   end
 end
 
-feature 'Connection form (no js)' do
+RSpec.feature 'Connection form (no js)' do
   before do
     stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
     visit articles_path


### PR DESCRIPTION
The "Connection problem?" form is only used on the article search page, so we don't need to draw it on other pages.