### PR TITLE
Remove null schema.org json+ld properties

### DIFF
--- a/app/models/concerns/schema_dot_org.rb
+++ b/app/models/concerns/schema_dot_org.rb
@@ -29,7 +29,7 @@ module SchemaDotOrg
               name: self[:author_meeting_display]
             }
           end)
-      }
+      }.compact
     end
   end
 

--- a/spec/models/concerns/schema_dot_org_spec.rb
+++ b/spec/models/concerns/schema_dot_org_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SchemaDotOrg do
 
     it 'fabricates schema.org data' do
       expect(document).to be_schema_dot_org
-      expect(document.as_schema_dot_org).to include '@type': 'Thing'
+      expect(document.as_schema_dot_org).to eq(:@context => "http://schema.org", :@type => "Thing")
     end
   end
 


### PR DESCRIPTION
Safari tries to parse these, and expects Author to be a type of Object. Then the parsing fails and it logs a Honeybadger message about it.

See https://app.honeybadger.io/projects/50022/faults/100897149
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
