### PR TITLE
Support folio library codes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,7 @@ Metrics/BlockLength:
 
 Metrics/ModuleLength:
   Exclude:
+    - 'lib/constants.rb'
     - 'spec/fixtures/**/*'
 
 Metrics/ClassLength:

--- a/app/components/location_request_link_component.rb
+++ b/app/components/location_request_link_component.rb
@@ -6,14 +6,12 @@ class LocationRequestLinkComponent < ViewComponent::Base
   # @params [String] location the code for location with the holdings
   def self.for(document:, library:, location:, **kwargs)
     link_type = case library
-                when 'HOOVER'
+                when 'HOOVER', 'HV-ARCHIVE', 'HILA'
                   if document&.index_links&.finding_aid&.first&.href
                     RequestLinks::HooverArchiveRequestLinkComponent
                   else
                     RequestLinks::HooverRequestLinkComponent
                   end
-                when 'HV-ARCHIVE'
-                  RequestLinks::HooverArchiveRequestLinkComponent
                 else
                   LocationRequestLinkComponent
                 end

--- a/app/models/links/ezproxy.rb
+++ b/app/models/links/ezproxy.rb
@@ -30,7 +30,7 @@ class Links
       if apply_law_proxy_prefix?
         Settings.libraries.LAW.ezproxy_host
       elsif apply_lane_proxy_prefix?
-        Settings.libraries['LANE-MED'].ezproxy_host
+        Settings.libraries['LANE'].ezproxy_host
       elsif apply_sul_proxy_prefix?
         Settings.libraries.default.ezproxy_host
       end
@@ -42,8 +42,8 @@ class Links
     end
 
     def apply_lane_proxy_prefix?
-      libraries.include?('LANE-MED') &&
-        ezproxied_hosts['LANE-MED'].any?(link_host) &&
+      (libraries.include?('LANE') || libraries.include?('LANE-MED')) &&
+        ezproxied_hosts['LANE'].any?(link_host) &&
         lane_restricted?
     end
 
@@ -59,7 +59,7 @@ class Links
     def ezproxied_hosts
       @ezproxied_hosts ||= {
         'LAW' => Rails.root.join('config/ezproxy/law_proxy_file.txt').read.split("\n"),
-        'LANE-MED' => Rails.root.join('config/ezproxy/lane_proxy_file.txt').read.split("\n"),
+        'LANE' => Rails.root.join('config/ezproxy/lane_proxy_file.txt').read.split("\n"),
         default: Rails.root.join('config/ezproxy/sul_proxy_file.txt').read.split("\n")
       }
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,6 +128,12 @@ libraries:
     name: Green Library
   GRN-REF:
     name: Green Library
+  HILA:
+    about_url: https://www.hoover.org/library-archives
+    hours_api_url: hoover_archives/location/hv_archives
+    name: Hoover Library
+    suppress_items_list_on_results_view: true
+    suppress_location_request_link: true
   HOOVER:
     about_url: https://www.hoover.org/library-archives
     hours_api_url: hoover_archives/location/hv_archives
@@ -150,6 +156,11 @@ libraries:
     hours_api_url: green/location/reference
   JACKSON:
     name: Business Library
+  LANE:
+    about_url: https://lane.stanford.edu/index.html
+    ezproxy_host: https://login.laneproxy.stanford.edu/login?
+    hours_api_url: medical/location/medical_library
+    name: Medical Library (Lane)
   LANE-MED:
     about_url: https://lane.stanford.edu/index.html
     ezproxy_host: https://login.laneproxy.stanford.edu/login?
@@ -163,9 +174,16 @@ libraries:
     ezproxy_host: http://ezproxy.law.stanford.edu/login?
     hours_api_url: law/location/law_library
     name: Law Library (Crown)
+  MARINE-BIO:
+    about_url: https://library.stanford.edu/libraries/harold-miller-library-hopkins-marine-station
+    hours_api_url: marine_biology/location/marine_biology_library
+    name: Marine Biology Library (Miller)
   MATH-CS:
     hours_api_url: math_stats/location/math_stats_library
     name: Math & Statistics Library
+  MEDIA-CENTER:
+    hours_api_url: green/location/media_microtext
+    name: Media & Microtext Center
   MEDIA-MTXT:
     hours_api_url: green/location/media_microtext
     name: Media & Microtext Center
@@ -177,6 +195,10 @@ libraries:
     hours_api_url: music/location/music_library
     name: Music Library
   RUMSEYMAP:
+    about_url: https://library.stanford.edu/libraries/david-rumsey-map-center
+    hours_api_url: Rumsey/location/visitor-access
+    name: David Rumsey Map Center
+  RUMSEY-MAP:
     about_url: https://library.stanford.edu/libraries/david-rumsey-map-center
     hours_api_url: Rumsey/location/visitor-access
     name: David Rumsey Map Center

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1027,6 +1027,10 @@ module Constants
       heading: 'Access',
       text: 'The Education Library is closed for construction. Request items for pickup at another library.'
     },
+    'HILA' => {
+      heading: 'Access',
+      text: 'Items must be requested in advance and viewed on-site.'
+    },
     'HOOVER' => {
       heading: 'Access',
       text: 'Items must be requested in advance and viewed on-site.'
@@ -1034,6 +1038,10 @@ module Constants
     'HV-ARCHIVE' => {
       heading: 'Access',
       text: 'Items must be requested in advance and viewed on-site.'
+    },
+    'RUMSEY-MAP' => {
+      heading: 'On-site access',
+      text: 'Researchers can request to view these materials in the David Rumsey Map Center.'
     },
     'RUMSEYMAP' => {
       heading: 'On-site access',

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -141,9 +141,7 @@ class Holdings
     end
 
     def live_status?
-      return true if folio_item?
-
-      library != 'LANE-MED'
+      folio_item?
     end
 
     def circulates?

--- a/lib/holdings/status/noncirc_page.rb
+++ b/lib/holdings/status/noncirc_page.rb
@@ -1,7 +1,7 @@
 class Holdings
   class Status
     class NoncircPage
-      LIBRARIES = ['HV-ARCHIVE', 'RUMSEYMAP', 'SPEC-COLL'].freeze
+      LIBRARIES = ['HV-ARCHIVE', 'RUMSEYMAP', 'RUMSEY-MAP', 'SPEC-COLL'].freeze
 
       def initialize(item)
         @item = item

--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -432,23 +432,5 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
         expect(page).to have_css '.status-text', text: 'In-library use'
       end
     end
-
-    context 'without a finding aid' do
-      before do
-        document = SolrDocument.new(
-          id: '123',
-          item_display_struct: [
-            { barcode: '123', library: 'HV-ARCHIVE', home_location: 'STACKS', callnumber: 'ABC' }
-          ]
-        )
-        render_inline(described_class.new(document:))
-      end
-
-      it 'renders not available text' do
-        expect(page).to have_css '.panel-body .pull-right', text: 'Not available to request'
-        expect(page).to have_css '.availability-icon.in_process'
-        expect(page).to have_css '.status-text', text: 'In process'
-      end
-    end
   end
 end

--- a/spec/components/location_request_link_component_spec.rb
+++ b/spec/components/location_request_link_component_spec.rb
@@ -121,17 +121,6 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
     it { expect(page).to have_link 'Request via Finding Aid', href: 'http://oac.cdlib.org/ark:/abc123' }
   end
 
-  context 'for Hoover Archive items without finding aids' do
-    let(:document) do
-      SolrDocument.new
-    end
-    let(:library) { 'HV-ARCHIVE' }
-    let(:location) { 'STACKS' }
-    let(:items) { [] }
-
-    it { expect(page).to have_content 'Not available to request' }
-  end
-
   context 'for Hoover Library items' do
     let(:document) { SolrDocument.new(marc_json_struct: metadata1) }
     let(:library) { 'HOOVER' }

--- a/spec/lib/holdings/item_spec.rb
+++ b/spec/lib/holdings/item_spec.rb
@@ -145,16 +145,6 @@ RSpec.describe Holdings::Item do
     end
   end
 
-  describe '#live_status?' do
-    it 'should identify material not in LANE-MED for live lookup' do
-      expect(Holdings::Item.new({ barcode: 'barcode', library: 'GREEN', home_location: 'STACKS' })).to be_live_status
-    end
-
-    it 'should identify material in LANE-MED to not do a live lookup' do
-      expect(Holdings::Item.new({ barcode: 'barcode', library: 'LANE-MED', home_location: 'STACKS' })).not_to be_live_status
-    end
-  end
-
   describe 'treat_current_location_as_home_location?' do
     it "should return true if an item's current location is in the list of locations" do
       Constants::CURRENT_HOME_LOCS.each do |current_location|


### PR DESCRIPTION
This PR adds FOLIO library codes in places we're using Symphony codes. This should allow us to change the indexer to populate the `item_display` `library` field with the FOLIO code instead.

This also removes tests for the Symphony library code `HV-ARCHIVE` which does not exist in the FOLIO data (because it is mapped to `HOOVER` instead)