### PR TITLE
Remove out-of-order h2 and use as nav label

### DIFF
--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -1,9 +1,5 @@
 <div id="search-navbar-container" class="d-flex">
-  <h2 class="sr-only">
-    <%= t("searchworks.headers.#{article_search? ? 'articles' : 'catalog'}.search_bar") %>
-  </h2>
-
-  <nav id="search-navbar" class="navbar search-bar" role="navigation">
+  <nav id="search-navbar" class="navbar search-bar" aria-label="<%= t('searchworks.navigation.search_bar') %>">
     <div class="search-navbar-headings">
       <%= link_to (image_tag 'searchworks.svg', {:"data-svg-fallback" => "#{image_path('searchworks.png')}", :alt => 'Home'}), article_search? ? articles_path : root_path, :class => 'navbar-brand', :id => 'searchworks-logo' %>
       <%= render_search_targets_widget %>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -1,5 +1,5 @@
 <div id="search-subnavbar-container">
-  <div id="search-subnavbar" class="navbar navbar-dark navbar-expand-md">
+  <nav id="search-subnavbar" class="navbar navbar-dark navbar-expand-md" aria-label="<%= t('searchworks.navigation.search_sub_bar') %>">
     <button type="button" class="navbar-toggler pull-left" data-toggle="collapse" data-target="#search-subnavbar-collapse">
       <span class="sr-only">Toggle navigation</span>
       <span class="fa fa-bars"></span>
@@ -34,7 +34,7 @@
         </ul>
       <% end %>
     </div>
-  </div>
+  </nav>
 </div>
 <% if article_search? || current_page?(feedback_path) # For JS enabled and disabled %>
   <div id="connection-form" class="feedback-form-container collapse">

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -34,11 +34,9 @@ en:
       catalog:
         clear:
           action_confirm: Clear your catalog selections?
-    headers:
-      articles:
-        search_bar: SearchWorks articles+
-      catalog:
-        search_bar: SearchWorks catalog
+    navigation:
+      search_bar: Search bar
+      search_sub_bar: Search sub-navigation bar
     search:
       form:
         q:

--- a/spec/features/blacklight_customizations/accessibility_spec.rb
+++ b/spec/features/blacklight_customizations/accessibility_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Aria Landmarks", js: true do
   end
 
   scenario "should have SearchWorks navbar landmark" do
-    expect(page).to have_xpath("//nav[@id='search-navbar' and @role='navigation']")
+    expect(page).to have_xpath("//nav[@id='search-navbar']")
   end
 
   scenario "should have search form landmark" do


### PR DESCRIPTION
Fixes #3630

This also makes the search sub-nav into a `nav` and gives it a label; otherwise its contents are outside of any aria landmark.
