### PR TITLE
Don't cut off descenders with line-height

### DIFF
--- a/app/assets/stylesheets/modules/access-panel-library-locations.scss
+++ b/app/assets/stylesheets/modules/access-panel-library-locations.scss
@@ -22,6 +22,8 @@
     h3 {
       color: $sul-access-header-color;
       display: inline-block;
+    }
+    .small {
       line-height: 1em;
     }
   }
@@ -33,7 +35,6 @@
   .library-location-heading-text {
     padding-top: 4px;
     padding-left: 60px;
-
   }
 
   .location {


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/SearchWorks/issues/3609
Now the h3 inherits a line-height of 1.2em instead of 1


before
<img width="395" alt="Screen Shot 2023-10-18 at 12 55 30 PM" src="https://github.com/sul-dlss/SearchWorks/assets/1328900/806dcb7f-6d06-4d9a-a561-849cf1500443">
fix
<img width="393" alt="Screen Shot 2023-10-18 at 12 55 21 PM" src="https://github.com/sul-dlss/SearchWorks/assets/1328900/2e7225db-68d0-4575-a7cd-eaf277473685">

(this is a fake example but wanted to check the dotted underline)
before
<img width="377" alt="Screen Shot 2023-10-18 at 12 57 09 PM" src="https://github.com/sul-dlss/SearchWorks/assets/1328900/360c3ccb-5f18-4849-841a-8fea991c5d69">
fix
<img width="381" alt="Screen Shot 2023-10-18 at 12 56 34 PM" src="https://github.com/sul-dlss/SearchWorks/assets/1328900/b4cf46a1-e9b7-458b-8c8f-394cacfcf866">
