### PR TITLE
Add the all_search field to fixture Solr documents

### DIFF
--- a/spec/features/alternate_catalog_spec.rb
+++ b/spec/features/alternate_catalog_spec.rb
@@ -47,10 +47,10 @@ RSpec.feature 'Alterate catalog results', js: true do
     wait_for_ajax
     within '.alternate-catalog' do
       expect(page).to have_css 'h3', text: 'Your search also found results in'
-      expect(page).to have_css 'a.btn', text: 'See 30 catalog results'
+      expect(page).to have_css 'a.btn', text: 'See 31 catalog results'
       expect(page).to have_css 'a[href="/catalog?q=1%2A&f[format_main_ssim][]=Book"]', text: 'Book (10)'
       expect(page).to have_css 'a[href="/catalog?q=1%2A&f[format_main_ssim][]=Image"]', text: 'Image (7)'
-      expect(page).to have_css 'a[href="/catalog?q=1%2A&f[format_main_ssim][]=Database"]', text: 'Database (4)'
+      expect(page).to have_css 'a[href="/catalog?q=1%2A&f[format_main_ssim][]=Database"]', text: 'Database (5)'
       expect(page).to have_css 'a[href="/catalog?q=1%2A&f[format_main_ssim][]=Newspaper"]', text: 'Newspaper (4)'
       expect(page).to have_css 'a[href="/catalog?q=1%2A&f[format_main_ssim][]=Video"]', text: 'Video (4)'
 

--- a/spec/features/marc_results_metadata_spec.rb
+++ b/spec/features/marc_results_metadata_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe "MARC Metadata in search results" do
     end
 
     it 'should join the characteristics with the physical statement' do
-      within(first('.document')) do
+      # this item is the 2nd search result
+      within(all('.document')[1]) do
         expect(page).to have_css('dt', text: 'Description')
         expect(page).to have_css('dd', text: 'Video — The physical statement Sound: digital; optical; surround; stereo; Dolby. Video: NTSC. Digital: video file; DVD video; Region 1.')
       end

--- a/spec/fixtures/solr_documents/1.yml
+++ b/spec/fixtures/solr_documents/1.yml
@@ -1,6 +1,7 @@
 :id: 1
 :hashed_id_ssi: c4ca4238a0b923820dcc509a6f75849b
 :title_display: An object
+:all_search: An object
 :title_245a_search: An object
 :author_person_display: Doe, Jane
 :author_1xx_search: Doe, Jane

--- a/spec/fixtures/solr_documents/10.yml
+++ b/spec/fixtures/solr_documents/10.yml
@@ -3,6 +3,7 @@
 :pub_date: 1801
 :author_person_display: Aguirre, Trudy
 :title_display: "Car : a drama of the American workplace"
+:all_search: "Car : a drama of the American workplace"
 :language: Spanish
 :format: Book
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/11.yml
+++ b/spec/fixtures/solr_documents/11.yml
@@ -6,6 +6,7 @@
 :latest_poss_year_isi: 1837
 :author_person_display: Flores, Esperanza
 :title_display: "Amet ad & adipisicing ex mollit pariatur minim dolore."
+:all_search: "Amet ad & adipisicing ex mollit pariatur minim dolore."
 :vern_title_display: "Currently, to obtain more information from the weakness of the resultant pain."
 :language: Spanish
 :format: Newspaper

--- a/spec/fixtures/solr_documents/12.yml
+++ b/spec/fixtures/solr_documents/12.yml
@@ -4,6 +4,7 @@
 :publication_year_isi: 1999
 :author_person_display: Mckinney, Mitzi
 :title_display: Duis reprehenderit cupidatat ad cillum cupidatat esse ad dolore.
+:all_search: Duis reprehenderit cupidatat ad cillum cupidatat esse ad dolore.
 :language: German
 :format: Image
 :format_main_ssim: Image

--- a/spec/fixtures/solr_documents/13.yml
+++ b/spec/fixtures/solr_documents/13.yml
@@ -3,6 +3,7 @@
 :pub_date: 1609
 :author_person_display: Hahn, Adrian
 :title_display:  "Radio drama : a comprehensive chronicle of American network programs"
+:all_search:  "Radio drama : a comprehensive chronicle of American network programs"
 :language: German
 :format: Video
 :format_main_ssim: Video

--- a/spec/fixtures/solr_documents/1343750.yml
+++ b/spec/fixtures/solr_documents/1343750.yml
@@ -1,6 +1,7 @@
 :id: 1343750
 :hashed_id_ssi: 365598133f252c8d67970a6f9c68282f
 :title_display: Stanford student work facet
+:all_search: Stanford student work facet
 :language: English
 :format: Book
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/14.yml
+++ b/spec/fixtures/solr_documents/14.yml
@@ -3,6 +3,7 @@
 :pub_date: 1617
 :author_person_display: Fleming, Salazar
 :title_display: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et anim.
+:all_search: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et anim.
 :language: Chinese
 :format: Book
 :display_type:

--- a/spec/fixtures/solr_documents/15.yml
+++ b/spec/fixtures/solr_documents/15.yml
@@ -3,6 +3,7 @@
 :pub_date: 1698
 :author_person_display: Albert, Pierce
 :title_display: Ea veniam cupidatat cupidatat aliquip nulla Lorem dolore eu.
+:all_search: Ea veniam cupidatat cupidatat aliquip nulla Lorem dolore eu.
 :language: Japanese
 :format: Image
 :display_type:

--- a/spec/fixtures/solr_documents/16.yml
+++ b/spec/fixtures/solr_documents/16.yml
@@ -3,6 +3,7 @@
 :pub_date: 1872
 :author_person_display: Holt, Janet
 :title_display: Sint aute consequat sint esse duis amet dolore fugiat Lorem.
+:all_search: Sint aute consequat sint esse duis amet dolore fugiat Lorem.
 :language: Italian
 :format: Newspaper
 :display_type:

--- a/spec/fixtures/solr_documents/19.yml
+++ b/spec/fixtures/solr_documents/19.yml
@@ -3,6 +3,7 @@
 :pub_date: 1984
 :author_person_display: Ball, Lynette
 :title_display: Ullamco laborum veniam non esse duis nisi.
+:all_search: Ullamco laborum veniam non esse duis nisi.
 :title_sort: Ullamco laborum veniam non esse duis nisi.
 :language: Russian
 :format: Database

--- a/spec/fixtures/solr_documents/2.yml
+++ b/spec/fixtures/solr_documents/2.yml
@@ -1,6 +1,7 @@
 :id: 2
 :hashed_id_ssi: c81e728d9d4c2f636f067f89cc14862c
 :title_display: Another object
+:all_search: Another object
 :author_person_display: "Doe, John"
 :format: Image
 :format_main_ssim: Image

--- a/spec/fixtures/solr_documents/20.yml
+++ b/spec/fixtures/solr_documents/20.yml
@@ -3,6 +3,7 @@
 :pub_date: 1958
 :author_person_display: Morse, Harriett
 :title_display: Enim id sint exercitation sit anim nulla id qui aliqua aute culpa anim
+:all_search: Enim id sint exercitation sit anim nulla id qui aliqua aute culpa anim
   ex.
 :title_sort: Enim id sint exercitation sit anim nulla id qui aliqua aute culpa anim
   ex.

--- a/spec/fixtures/solr_documents/21.yml
+++ b/spec/fixtures/solr_documents/21.yml
@@ -3,6 +3,7 @@
 :pub_date: 1713
 :author_person_display: Mcintosh, Clarke
 :title_display: Laborum id proident cupidatat nisi consequat dolor laborum dolore mollit
+:all_search: Laborum id proident cupidatat nisi consequat dolor laborum dolore mollit
   exercitation exercitation.
 :language: Spanish
 :format: Image

--- a/spec/fixtures/solr_documents/22.yml
+++ b/spec/fixtures/solr_documents/22.yml
@@ -3,6 +3,7 @@
 :pub_date: 1726
 :author_person_display: Vargas, Leah
 :title_display: Ea dolor non magna sunt labore duis fugiat est cupidatat laborum ex.
+:all_search: Ea dolor non magna sunt labore duis fugiat est cupidatat laborum ex.
 :language: Russian
 :format: Book
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/23.yml
+++ b/spec/fixtures/solr_documents/23.yml
@@ -3,6 +3,7 @@
 :pub_date: 1632
 :author_person_display: Fischer, Goodwin
 :title_display: Proident ex duis id esse nulla quis et aute dolore.
+:all_search: Proident ex duis id esse nulla quis et aute dolore.
 :language: Chinese
 :format: Video
 :genre_ssim:

--- a/spec/fixtures/solr_documents/24.yml
+++ b/spec/fixtures/solr_documents/24.yml
@@ -3,6 +3,7 @@
 :pub_date: 1993
 :author_person_display: James, Marci
 :title_display: Ullamco do minim laboris sit velit.
+:all_search: Ullamco do minim laboris sit velit.
 :title_sort: Ullamco do minim laboris sit velit.
 :language: Spanish
 :format: Database

--- a/spec/fixtures/solr_documents/25.yml
+++ b/spec/fixtures/solr_documents/25.yml
@@ -3,6 +3,7 @@
 :pub_date: 1733
 :author_person_display: Klein, Nelson
 :title_display: Ut aliquip qui elit nostrud reprehenderit aliqua quis anim mollit nostrud
+:all_search: Ut aliquip qui elit nostrud reprehenderit aliqua quis anim mollit nostrud
   non.
 :language: Japanese
 :format: Image

--- a/spec/fixtures/solr_documents/26.yml
+++ b/spec/fixtures/solr_documents/26.yml
@@ -3,6 +3,7 @@
 :pub_date: 1967
 :author_person_display: Hebert, House
 :title_display: Sunt culpa minim est Lorem do est enim enim aute aliqua non eiusmod.
+:all_search: Sunt culpa minim est Lorem do est enim enim aute aliqua non eiusmod.
 :language: Spanish
 :format: Newspaper
 :format_main_ssim: Newspaper

--- a/spec/fixtures/solr_documents/27.yml
+++ b/spec/fixtures/solr_documents/27.yml
@@ -3,6 +3,7 @@
 :pub_date: 1776
 :author_person_display: Barber, Manuela
 :title_display: Voluptate dolore aliquip anim mollit amet cupidatat laborum cupidatat
+:all_search: Voluptate dolore aliquip anim mollit amet cupidatat laborum cupidatat
   mollit.
 :language: Italian
 :format: Book

--- a/spec/fixtures/solr_documents/28.yml
+++ b/spec/fixtures/solr_documents/28.yml
@@ -5,6 +5,7 @@
 :author_person_display: Arbirtrary, Lois
 :author_person_display: Arbitrary, Stewart
 :title_display: Some intersting papers, 1979-2010.
+:all_search: Some intersting papers, 1979-2010.
 :language: English
 :marc_json_struct: |
 <%= metadata1 %>

--- a/spec/fixtures/solr_documents/29.yml
+++ b/spec/fixtures/solr_documents/29.yml
@@ -1,6 +1,7 @@
 :id: 29
 :hashed_id_ssi: 6ea9ab1baa0efb9e19094440c317e21b
 :title_display: Image Collection1
+:all_search: Image Collection1
 :summary_display:
   - "A collection of fixture images from the SearchWorks development index."
 :display_type:

--- a/spec/fixtures/solr_documents/3.yml
+++ b/spec/fixtures/solr_documents/3.yml
@@ -4,6 +4,7 @@
 :pub_year_tisim: 1727
 :author_person_display: Moss, Pollard
 :title_display: Officia consequat aliqua esse ipsum.
+:all_search: Officia consequat aliqua esse ipsum.
 :language: Russian
 :marc_json_struct: |
 <%= metadata1 %>

--- a/spec/fixtures/solr_documents/31.yml
+++ b/spec/fixtures/solr_documents/31.yml
@@ -1,6 +1,7 @@
 :id: 31
 :hashed_id_ssi: c16a5320fa475530d9583c34fd356ef5
 :title_display: File Collection1
+:all_search: File Collection1
 :collection_type: Digital Collection
 :summary_display:
   - "A collection of fixture files from the SearchWorks development index."

--- a/spec/fixtures/solr_documents/32.yml
+++ b/spec/fixtures/solr_documents/32.yml
@@ -1,6 +1,7 @@
 :id: 32
 :hashed_id_ssi: 6364d3f0f495b6ab9dcf8d3b5c6e0b01
 :title_display: File Item1
+:all_search: File Item1
 :author_person_full_display: Dr. Katz
 :display_type:
   - file

--- a/spec/fixtures/solr_documents/33.yml
+++ b/spec/fixtures/solr_documents/33.yml
@@ -1,6 +1,7 @@
 :id: 33
 :hashed_id_ssi: 182be0c5cdcd5072bb1864cdee4d3d6e
 :title_display: File Item2
+:all_search: File Item2
 :author_person_full_display: Mr. Stedman
 :display_type:
   - file

--- a/spec/fixtures/solr_documents/34.yml
+++ b/spec/fixtures/solr_documents/34.yml
@@ -1,6 +1,7 @@
 :id: 34
 :hashed_id_ssi: e369853df766fa44e1ed0ff613f563bd
 :title_display: Merged Image Collection1
+:all_search: Merged Image Collection1
 :author_person_full_display: Bob, Uncle
 :collection_type: Digital Collection
 :display_type:

--- a/spec/fixtures/solr_documents/35.yml
+++ b/spec/fixtures/solr_documents/35.yml
@@ -1,6 +1,7 @@
 :id: 35
 :hashed_id_ssi: 1c383cd30b7c298ab50293adfecb7b18
 :title_display: Image Item3
+:all_search: Image Item3
 :author_person_full_display: Mr. Stedman
 :display_type:
   - image

--- a/spec/fixtures/solr_documents/36.yml
+++ b/spec/fixtures/solr_documents/36.yml
@@ -1,6 +1,7 @@
 :id: 36
 :hashed_id_ssi: 19ca14e7ea6328a42e0eb13d585e4c22
 :title_display: Image Item4
+:all_search: Image Item4
 :author_person_full_display: Tony Balogna
 :display_type:
   - image

--- a/spec/fixtures/solr_documents/37.yml
+++ b/spec/fixtures/solr_documents/37.yml
@@ -1,6 +1,7 @@
 :id: 37
 :hashed_id_ssi: a5bfc9e07964f8dddeb95fc584cd965d
 :title_display: Merged Image1
+:all_search: Merged Image1
 :author_person_full_display: Eric Carbonara
 :display_type:
   - image

--- a/spec/fixtures/solr_documents/38.yml
+++ b/spec/fixtures/solr_documents/38.yml
@@ -1,6 +1,7 @@
 :id: 38
 :hashed_id_ssi: a5771bce93e200c36f7cd9dfd0e5deaa
 :title_display: Merged File Collection1
+:all_search: Merged File Collection1
 :collection_type: Digital Collection
 :summary_display:
   - "A collection of fixture files from the SearchWorks development index."

--- a/spec/fixtures/solr_documents/39.yml
+++ b/spec/fixtures/solr_documents/39.yml
@@ -1,6 +1,7 @@
 :id: 39
 :hashed_id_ssi: d67d8ab4f4c10bf22aa353e27879133c
 :title_display: File Item3
+:all_search: File Item3
 :author_person_full_display: Dr. Who
 :display_type:
   - file

--- a/spec/fixtures/solr_documents/4.yml
+++ b/spec/fixtures/solr_documents/4.yml
@@ -3,8 +3,8 @@
 :pub_date: 1607
 :pub_year_tisim: 1607
 :author_person_display: Cortez, Essie
-:title_display: Lorem aute dolor proident ullamco adipisicing cupidatat consectetur
-  id irure dolor proident minim.
+:title_display: Lorem aute dolor proident ullamco adipisicing cupidatat consectetur id irure dolor proident minim.
+:all_search: Lorem aute dolor proident ullamco adipisicing cupidatat consectetur id irure dolor proident minim.
 :language: French
 :format: Video
 :format_main_ssim: Video

--- a/spec/fixtures/solr_documents/40.yml
+++ b/spec/fixtures/solr_documents/40.yml
@@ -1,6 +1,7 @@
 :id: 40
 :hashed_id_ssi: d645920e395fedad7bbbed0eca3fe2e0
 :title_display: File Item4 - Deathstar Bluprints
+:all_search: File Item4 - Deathstar Bluprints
 :author_person_full_display: Skywalker, Luke
 :display_type:
   - file

--- a/spec/fixtures/solr_documents/41.yml
+++ b/spec/fixtures/solr_documents/41.yml
@@ -1,6 +1,7 @@
 :id: 41
 :hashed_id_ssi: 3416a75f4cea9109507cacd8e2f2aefc
 :title_display: File Item5 - Blaster User Manual - The Good Parts
+:all_search: File Item5 - Blaster User Manual - The Good Parts
 :author_person_full_display: Chewy
 :display_type:
   - file

--- a/spec/fixtures/solr_documents/42.yml
+++ b/spec/fixtures/solr_documents/42.yml
@@ -1,6 +1,7 @@
 :id: 42
 :hashed_id_ssi: a1d0c6e83f027327d8461063f4ac58a6
 :title_display: File Item4 - selfie.vine
+:all_search: File Item4 - selfie.vine
 :author_person_full_display: Solo, Han
 :display_type:
   - file

--- a/spec/fixtures/solr_documents/43.yml
+++ b/spec/fixtures/solr_documents/43.yml
@@ -1,6 +1,7 @@
 :id: 43
 :hashed_id_ssi: 17e62166fc8586dfa4d1bc0e1742c08b
 :title_display: Best Album Every Written
+:all_search: Best Album Every Written
 :author_person_full_display: McDonald, Ronald
 :display_type:
   - sirsi

--- a/spec/fixtures/solr_documents/44.yml
+++ b/spec/fixtures/solr_documents/44.yml
@@ -2,6 +2,7 @@
 :hashed_id_ssi: f7177163c833dff4b38fc8d2872f1ec6
 :pub_date: 1907
 :title_display: The Guanches of Tenerife
+:all_search: The Guanches of Tenerife
 :title_245a_display: The Guanches of Tenerife
 :language: English
 :format: Book

--- a/spec/fixtures/solr_documents/45.yml
+++ b/spec/fixtures/solr_documents/45.yml
@@ -1,6 +1,7 @@
 :id: 45
 :hashed_id_ssi: 6c8349cc7260ae62e3b1396831a8398f
 :title_display: The Item With a Bookplate
+:all_search: The Item With a Bookplate
 :language: English
 :format: Book
 :display_type:

--- a/spec/fixtures/solr_documents/46.yml
+++ b/spec/fixtures/solr_documents/46.yml
@@ -1,6 +1,7 @@
 :id: 46
 :hashed_id_ssi: d9d4f495e875a2e075a1a4a6e1b9770f
 :title_display: A new item to the catalog
+:all_search: A new item to the catalog
 :date_cataloged: "<%= Time.new.utc.iso8601 %>"
 :format: Book
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/47.yml
+++ b/spec/fixtures/solr_documents/47.yml
@@ -1,6 +1,7 @@
 :id: 47
 :hashed_id_ssi: 67c6a1e7ce56d3d6fa748ab6d9af3fd7
 :title_display: A Collection of Virtual Objects
+:all_search: A Collection of Virtual Objects
 :format_main_ssim: "Archive/Manuscript"
 :modsxml: <%= mods_everything %>
 :collection_type: Digital Collection

--- a/spec/fixtures/solr_documents/48.yml
+++ b/spec/fixtures/solr_documents/48.yml
@@ -1,6 +1,7 @@
 :id: 48
 :hashed_id_ssi: 642e92efb79421734881b53e1e1b18b6
 :title_display: A Virtual Object
+:all_search: A Virtual Object
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= metadata2 %>

--- a/spec/fixtures/solr_documents/488729.yml
+++ b/spec/fixtures/solr_documents/488729.yml
@@ -2,6 +2,7 @@
 :hashed_id_ssi: 6ecb0941aab220fb97d920d6082840ba
 :pub_date: 2012
 :title_display: Selected Database 1
+:all_search: Selected Database 1
 :title_sort: Selected Database 1
 :title_245a_display: Selected Database 1
 :language: English

--- a/spec/fixtures/solr_documents/49.yml
+++ b/spec/fixtures/solr_documents/49.yml
@@ -1,6 +1,7 @@
 :id: 49
 :hashed_id_ssi: f457c545a9ded88f18ecee47145a72c0
 :title_display: Another Virtual Object
+:all_search: Another Virtual Object
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= contributed_works_fixture %>

--- a/spec/fixtures/solr_documents/5.yml
+++ b/spec/fixtures/solr_documents/5.yml
@@ -3,6 +3,7 @@
 :pub_date: 1799
 :author_person_display: Dotson, Patti
 :title_display: Pariatur labore incididunt aliquip fugiat ea incididunt deserunt sit
+:all_search: Pariatur labore incididunt aliquip fugiat ea incididunt deserunt sit
   dolor enim nisi aliquip laborum enim.
 :title_sort: Pariatur labore incididunt aliquip fugiat ea incididunt deserunt sit
   dolor enim nisi aliquip laborum enim.

--- a/spec/fixtures/solr_documents/50.yml
+++ b/spec/fixtures/solr_documents/50.yml
@@ -1,6 +1,7 @@
 :id: 50
 :hashed_id_ssi: c0c7c76d30bd3dcaefc96f40275bdc0a
 :title_display: An item in a virtual object
+:all_search: An item in a virtual object
 :format_main_ssim: Map
 :modsxml: <%= mods_everything %>
 :display_type:

--- a/spec/fixtures/solr_documents/51.yml
+++ b/spec/fixtures/solr_documents/51.yml
@@ -1,6 +1,7 @@
 :id: 51
 :hashed_id_ssi: 2838023a778dfaecdc212708f721b788
 :title_display: Another item in a virtual object
+:all_search: Another item in a virtual object
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= metadata1 %>

--- a/spec/fixtures/solr_documents/52.yml
+++ b/spec/fixtures/solr_documents/52.yml
@@ -1,6 +1,7 @@
 :id: 52
 :hashed_id_ssi: 9a1158154dfa42caddbd0694a4e9bdc8
 :title_display: An item in a another virtual object
+:all_search: An item in a another virtual object
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= metadata1 %>

--- a/spec/fixtures/solr_documents/53.yml
+++ b/spec/fixtures/solr_documents/53.yml
@@ -1,6 +1,7 @@
 :id: 53
 :hashed_id_ssi: d82c8d1619ad8176d665453cfb2e55f0
 :title_display: Another item in a another virtual object
+:all_search: Another item in a another virtual object
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= marc_382_instrumentation %>

--- a/spec/fixtures/solr_documents/55.yml
+++ b/spec/fixtures/solr_documents/55.yml
@@ -1,6 +1,7 @@
 :id: 55
 :hashed_id_ssi: b53b3a3d6ab90ce0268229151c9bde11
 :title_display: Collection in process
+:all_search: Collection in process
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= marc_382_instrumentation %>

--- a/spec/fixtures/solr_documents/56.yml
+++ b/spec/fixtures/solr_documents/56.yml
@@ -1,6 +1,7 @@
 :id: 56
 :hashed_id_ssi: 9f61408e3afb633e50cdf1b20de6f466
 :title_display: Hoover Item
+:all_search: Hoover Item
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= hoover_request_fixture %>

--- a/spec/fixtures/solr_documents/5608954.yml
+++ b/spec/fixtures/solr_documents/5608954.yml
@@ -2,6 +2,7 @@
 :hashed_id_ssi: 4f8ddbf8e4eb008327504e30c2bc17b7
 :pub_date: 2012
 :title_display: Selected Database 2
+:all_search: Selected Database 2
 :title_sort: Selected Database 2
 :title_245a_display: Selected Database 2
 :language: English

--- a/spec/fixtures/solr_documents/57.yml
+++ b/spec/fixtures/solr_documents/57.yml
@@ -1,6 +1,7 @@
 :id: 57
 :hashed_id_ssi: 72b32a1f754ba1c09b3695e0cb6cde7f
 :title_display: SFX Catalog Item
+:all_search: SFX Catalog Item
 :format_main_ssim: Journal/Periodical
 :marc_json_struct: |
 <%= metadata1 %>

--- a/spec/fixtures/solr_documents/5749286.yml
+++ b/spec/fixtures/solr_documents/5749286.yml
@@ -2,6 +2,7 @@
 :hashed_id_ssi: a8a7eb2adcecd94918e78a7eb9a496ac
 :pub_date: 2012
 :title_display: Selected Database 3
+:all_search: Selected Database 3
 :title_sort: Selected Database 3
 :title_245a_display: Selected Database 3
 :language: English

--- a/spec/fixtures/solr_documents/58.yml
+++ b/spec/fixtures/solr_documents/58.yml
@@ -1,6 +1,7 @@
 :id: 58
 :hashed_id_ssi: 66f041e16a60928b05a7e228a89c3799
 :title_display: The Item in Curriculum Collection
+:all_search: The Item in Curriculum Collection
 :language: English
 :format: Book
 :display_type:

--- a/spec/fixtures/solr_documents/6.yml
+++ b/spec/fixtures/solr_documents/6.yml
@@ -3,6 +3,7 @@
 :pub_date: 1786
 :author_person_display: Saunders, Herman
 :title_display: Deserunt ex officia occaecat incididunt esse veniam amet nulla labore.
+:all_search: Deserunt ex officia occaecat incididunt esse veniam amet nulla labore.
 :language: French
 :format: Image
 :format_main_ssim: Image

--- a/spec/fixtures/solr_documents/7.yml
+++ b/spec/fixtures/solr_documents/7.yml
@@ -3,6 +3,7 @@
 :pub_date: 1729
 :author_person_display: Bartlett, Richards
 :title_display: Cupidatat fugiat quis duis id.
+:all_search: Cupidatat fugiat quis duis id.
 :language: Russian
 :format: Book
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/7626894.yml
+++ b/spec/fixtures/solr_documents/7626894.yml
@@ -2,6 +2,7 @@
 :hashed_id_ssi: a930d114300464f04cae1768a1fc3556
 :pub_date: 2012
 :title_display: Selected Database 4
+:all_search: Selected Database 4
 :title_sort: Selected Database 4
 :title_245a_display: Selected Database 4
 :language: English

--- a/spec/fixtures/solr_documents/8.yml
+++ b/spec/fixtures/solr_documents/8.yml
@@ -3,6 +3,7 @@
 :pub_date: 1654
 :author_person_display: Hays, Sellers
 :title_display: Officia sunt mollit in reprehenderit anim qui aute enim velit.
+:all_search: Officia sunt mollit in reprehenderit anim qui aute enim velit.
 :language: Spanish
 :format: Newspaper
 :format_main_ssim: Newspaper

--- a/spec/fixtures/solr_documents/8923346.yml
+++ b/spec/fixtures/solr_documents/8923346.yml
@@ -1,6 +1,7 @@
 :id: 8923346
 :hashed_id_ssi: edbe0f562943f5c0fc0ed005e6026d27
 :title_display: Many PURLs for One CKey
+:all_search: Many PURLs for One CKey
 :language: English
 :format: Book
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/9.yml
+++ b/spec/fixtures/solr_documents/9.yml
@@ -3,6 +3,7 @@
 :pub_date: 1842
 :author_person_display: Wood, Beatrice
 :title_display: Incididunt fugiat cillum tempor excepteur.
+:all_search: Incididunt fugiat cillum tempor excepteur.
 :language: English
 :format: Video
 :format_main_ssim: Video

--- a/spec/fixtures/solr_documents/mf774fs2413.yml
+++ b/spec/fixtures/solr_documents/mf774fs2413.yml
@@ -1,6 +1,7 @@
 :id: mf774fs2413
 :hashed_id_ssi: 35765816d35553b532e04080792f2b33
 :title_display: Image Item1
+:all_search: Image Item1
 :display_type:
   - image
 :format: Image


### PR DESCRIPTION
Without this, searching locally for a word contained in a fixture title returns no results. Here I copied `:title_display` into `:all_search` for each document which is simplified but functional. In production `all_search` is populated with text from the title and other data since it is piped through the traject indexer.

This is worth fixing because multiple new people spinning up the local dev app have gotten stuck on this (me included!) thinking they'd done something wrong when the searchbar doesn't work. It's also useful in general for local work. 