### PR TITLE
Make configured Lane Library name the same as the FOLIO name

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -160,12 +160,12 @@ libraries:
     about_url: https://lane.stanford.edu/index.html
     ezproxy_host: https://login.laneproxy.stanford.edu/login?
     hours_api_url: medical/location/medical_library
-    name: Medical Library (Lane)
+    name: Lane Medical Library
   LANE-MED:
     about_url: https://lane.stanford.edu/index.html
     ezproxy_host: https://login.laneproxy.stanford.edu/login?
     hours_api_url: medical/location/medical_library
-    name: Medical Library (Lane)
+    name: Lane Medical Library
   LATHROP:
     hours_api_url: lathrop/location/tech-lounge
     name: Lathrop Library


### PR DESCRIPTION
Fixes https://jirasul.stanford.edu/jira/browse/SW-4238
