### PR TITLE
Remove condition preventing bound-with children from displaying live availability

### DIFF
--- a/app/components/access_panels/location_item_component.html.erb
+++ b/app/components/access_panels/location_item_component.html.erb
@@ -10,7 +10,7 @@
     </td>
   <% end %>
   <% if render_item_details? %>
-    <td class="item-availability" data-live-lookup-id="<%= item.live_lookup_instance_id %>" data-status-target=".availability-icon" data-item-id="<%= item.live_lookup_item_id if item.live_status? %>" <%= "data-request-url='#{helpers.request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if render_real_time_availability_request_link? %>>
+    <td class="item-availability" data-live-lookup-id="<%= item.live_lookup_instance_id %>" data-status-target=".availability-icon" data-item-id="<%= item.live_lookup_item_id %>" <%= "data-request-url='#{helpers.request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if render_real_time_availability_request_link? %>>
       <span class="availability-icon-wrapper">
         <i class="availability-icon <%= item.status.availability_class %>"></i>
         <span data-available-text="<%= t('searchworks.availability.available') %>" data-unavailable-text="<%= t('searchworks.availability.unavailable') %>" class='status-text'>

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -154,10 +154,6 @@ class Holdings
       bound_with_parent.present?
     end
 
-    def live_status?
-      folio_item?
-    end
-
     def circulates?
       folio_item? && folio_item_circulates?
     end


### PR DESCRIPTION
The original purpose of this condition was to prevent live lookup for medical library material ([code ref](https://github.com/sul-dlss/SearchWorks/blame/a1fe2cc37c990f769ccceb8def0fae697d8f8f47/lib/holdings/item.rb#L134)). This is no longer relevant because their material is now in FOLIO with everything else. The condition was preventing bound-with children from displaying live availability.

Before:
<img width="378" alt="Screenshot 2023-10-27 at 9 34 45 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/476a817a-1c5f-42b3-9734-82225a9a85ff">

After:
<img width="392" alt="Screenshot 2023-10-27 at 9 34 17 AM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/3ac079c7-80b7-4524-a1b6-5fa6eaa70edb">

Fixes: https://jirasul.stanford.edu/jira/browse/SW-4240
