### PR TITLE
Encode html &#13 as \r for display

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -34,4 +34,11 @@ module RecordHelper
       end
     end.join('').html_safe
   end
+
+  ##
+  # Expose format_mods_html from mods_display to properly encode content as needed
+  # RecordHelper behavior
+  def format_record_html(...)
+    format_mods_html(...)
+  end
 end

--- a/app/views/catalog/mastheads/_collection.html.erb
+++ b/app/views/catalog/mastheads/_collection.html.erb
@@ -7,7 +7,7 @@
         <% if @parent[:summary_display] %>
           <div class="collection-summary">
             <div data-behavior='truncate'>
-              <%= @parent[:summary_display].join(', ') %>
+              <%= format_record_html(@parent[:summary_display].join(', ')) %>
             </div>
           </div>
         <% end %>

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -20,4 +20,22 @@ RSpec.describe RecordHelper do
       end
     end
   end
+
+  describe 'record html' do
+    context 'when the record has line feeds in the string' do
+      let(:html) { "some text\r\nsome other text" }
+
+      it 'returns the string without changing the encoding' do
+        expect(helper.format_record_html(html)).to eq "some text\r\nsome other text"
+      end
+    end
+
+    context 'when the record has encoded line feeds in the string' do
+      let(:html) { "some text&#13\nsome other text" }
+
+      it 'returns the string with proper encoding' do
+        expect(helper.format_record_html(html)).to eq "some text\r\nsome other text"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #3671 

This may not be the best or only place to fix this display issue. In both H2 and Argo we've made sure that when `\r\n` is included they are represented properly and do not use the `&#13` html encoding by reverting it back to `\r`. This seems to still be converted to `&#13` when reading the solr document for display in searchworks. 

Happy for any suggestions on how else to approach this.