### PR TITLE
Add line break between proxied url entries; closes #3666

### DIFF
--- a/config/ezproxy/sul_proxy_file.txt
+++ b/config/ezproxy/sul_proxy_file.txt
@@ -163,7 +163,8 @@ www.asihcopeiaonline.org
 journals.ala.org
 www.scientificamerican.com
 www.nomos-elibrary.de
-dbs.g-search.or.jpwww.mona.uwi.edu
+dbs.g-search.or.jp
+www.mona.uwi.edu
 www.ihp.sinica.edu.tw
 find.gale.com
 galenet.gale.com


### PR DESCRIPTION

In #3666 we were asked to add `www.mona.uwi.edu` to the sul proxy file. It was already present in the file, but we were missing a line break between two entries.