### PR TITLE
Address BS4 style regression on the zero results page; fixes #3670

### DIFF
--- a/app/assets/stylesheets/modules/zero-results.scss
+++ b/app/assets/stylesheets/modules/zero-results.scss
@@ -43,3 +43,9 @@
   }
 
 }
+
+.zero-results-more-options {
+  .media {
+    flex-direction: column;
+  }
+}

--- a/app/assets/stylesheets/modules/zero-results.scss
+++ b/app/assets/stylesheets/modules/zero-results.scss
@@ -7,8 +7,6 @@
 }
 
 .zero-results {
-  padding-left: 10px;
-
   // don't display the "Catalog start" button in this context
   #appliedParams a.btn-reset {
     display: none;

--- a/app/views/shared/_search_assistance_block.html.erb
+++ b/app/views/shared/_search_assistance_block.html.erb
@@ -1,7 +1,7 @@
-<div class="card">
+<div class="card mb-3">
   <div class="card-body">
     <h3>More options</h3>
-    <ul class="media-list">
+    <ul class="list-unstyled zero-results-more-options">
       <li class='media'>
         <%= link_to 'Interlibrary loan', 'https://sulils.stanford.edu/', class: 'media-heading stanford-only' %>
         <p>For Stanford affiliates. We can get just about anything.</p>

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card mb-3">
   <div class="card-body zero-results">
     <h3><%= t 'blacklight.search.zero_results.modify_your_search', search_type: search_type_name %></h3>
     <dl>


### PR DESCRIPTION
After:
<img width="834" alt="Screenshot 2023-11-07 at 07 43 13" src="https://github.com/sul-dlss/SearchWorks/assets/111218/258b1e83-e2a4-4137-b28a-883ddfa0e743">

