### PR TITLE
Fix tests to reflect change in markup

### DIFF
--- a/spec/features/blacklight_customizations/bookmarks_path_spec.rb
+++ b/spec/features/blacklight_customizations/bookmarks_path_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Selections Path" do
     within "#documents" do
       expect(page).to have_css("h3.index_title a", count: 2)
     end
-    within ".search-widgets" do
+    within ".sort-and-per-page" do
       expect(page).to have_css("a", text: "Cite 1 - 2")
       expect(page).to have_css("button", text: "Send 1 - 2")
       expect(page).to have_no_css("button#select_all-dropdown")

--- a/spec/features/blacklight_customizations/facets_spec.rb
+++ b/spec/features/blacklight_customizations/facets_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Facets Customizations" do
     skip('Fails intermitently on Travis.') if ENV['CI']
     visit blacklight_advanced_search_engine.advanced_search_path
 
-    click_link "Resource type"
+    click_button "Resource type"
     check "Book"
 
     click_button "advanced-search-submit"

--- a/spec/features/bookmarking_items_spec.rb
+++ b/spec/features/bookmarking_items_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Bookmarking Items' do
 
       within('.modal-dialog') do
         expect(page).to have_css('h4', text: 'MLA', count: 2)
-        click_link 'By citation format'
+        click_button 'By citation format'
         expect(page).to have_css('h4', text: 'MLA', count: 1)
         expect(page).to have_css('p.citation_style_MLA', count: 2)
       end


### PR DESCRIPTION
Fixes some tests that failed locally but were excluded from CI.

[Fix wrapping for sort-and-per-page toolbar at smaller viewports · sul-dlss/SearchWorks@52a0eff (github.com)](https://github.com/sul-dlss/SearchWorks/commit/52a0eff2214017adfe77ddaa9bdd88eb944a6346) removed the `.search-widgets` class. `.sort-and-per-page` seems to be the logical choice as the next container that wraps the same elements.

[Fix multiple citations · sul-dlss/SearchWorks@9c5353c (github.com)](https://github.com/sul-dlss/SearchWorks/commit/9c5353cc7e0f22d7a14653c6e5f363573beaa71e) changes the 'By citation format' from a link to a button, the test expects a link.

I didn't confirm the exact commit, but it seems that the facet also switched from a link to a button.