### PR TITLE
Comment out config.force_ssl = true

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,8 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # TODO: Set force_ssl to true once ops completes https://github.com/sul-dlss/operations-tasks/issues/3587
+  # config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
Do not force SSL until ops completes https://github.com/sul-dlss/operations-tasks/issues/3587

Tested on sw-stage with no apparent bad effects.

Issue to revert this change once the ops task is complete: https://github.com/sul-dlss/SearchWorks/issues/3759