### PR TITLE
Set base branch to main for jenkins pull requests

### DIFF
--- a/Jenkinsfile-Folio-Update
+++ b/Jenkinsfile-Folio-Update
@@ -33,7 +33,7 @@ pipeline {
           git add config/folio
           git commit -m "Update FOLIO types" &&
           git push git@github.com:sul-dlss/SearchWorks.git folio-policies-update &&
-          hub pull-request -f -m "Update FOLIO types"
+          hub pull-request -f -m "Update FOLIO types" --base main
           echo 'Done!'
           '''
         }

--- a/Jenkinsfile-Lane-Update
+++ b/Jenkinsfile-Lane-Update
@@ -25,7 +25,7 @@ pipeline {
           git add config/ezproxy/lane_proxy_file.txt
           git commit -m "Update Lane Library EZProxy config" &&
           git push git@github.com:sul-dlss/SearchWorks.git lane-ezproxy-update &&
-          hub pull-request -f -m "Update Lane Library EZProxy config"
+          hub pull-request -f -m "Update Lane Library EZProxy config" --base main
           echo 'Done!'
           '''
         }


### PR DESCRIPTION
This fixes pull requests when jenkins attempts to update folio data & the lane proxy list. These have been failing since the base branch was switched from master to main.
