### PR TITLE
Extract a record toolbar component

### DIFF
--- a/app/components/record_toolbar_component.html.erb
+++ b/app/components/record_toolbar_component.html.erb
@@ -1,6 +1,6 @@
 <div class="record-toolbar sul-toolbar navbar navbar-expand-md navbar-dark px-3 my-4" role="navigation">
   <div>
-    <%= link_back_to_catalog :class => 'btn btn-sul-toolbar back-to-results', :label => t('blacklight.back_to_search').html_safe %>
+    <%= helpers.link_back_to_catalog class: 'btn btn-sul-toolbar back-to-results', label: t('blacklight.back_to_search').html_safe %>
     <%= render ToolbarSearchContextInfoComponent.new(search_context: @search_context, search_session: nil) %>
   </div>
   <button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".toolbar-collapse">
@@ -9,9 +9,9 @@
   </button>
   <div class="navbar-collapse collapse toolbar-collapse">
     <ul class="nav navbar-nav ml-auto">
-      <% if @document.citable? %>
+      <% if citable? %>
         <li>
-          <%= link_to t('blacklight.tools.cite_html'), (@document.eds? ? citation_article_path(@document) : citation_solr_document_path(@document)), {:id => 'citeLink', :data => {blacklight_modal: "trigger"}, :class => 'btn btn-sul-toolbar'} %>
+          <%= link_to t('blacklight.tools.cite_html'), cite_path, id: 'citeLink', data: { blacklight_modal: "trigger" }, class: 'btn btn-sul-toolbar' %>
         </li>
       <% end %>
       <li class="dropdown">
@@ -23,7 +23,7 @@
         </div>
       </li>
       <li>
-        <%= render(:partial => 'bookmark_control', :locals => {:document=> @document}) %>
+        <%= render 'bookmark_control', document: document %>
       </li>
     </ul>
   </div>

--- a/app/components/record_toolbar_component.rb
+++ b/app/components/record_toolbar_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RecordToolbarComponent < ViewComponent::Base
+  def initialize(presenter:, search_context:)
+    @presenter = presenter
+    @search_context = search_context
+    super()
+  end
+
+  delegate :document, to: :@presenter
+  delegate :citable?, to: :document
+
+  def cite_path
+    document.eds? ? citation_article_path(document) : citation_solr_document_path(document)
+  end
+end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,7 +1,9 @@
+<% @page_title = t 'blacklight.search.show.title_html', document_title: document_presenter(@document).html_title, application_name: "#{I18n.t('blacklight.application_name')} articles" %>
+
 <div class="row">
   <div id="content" class="col-md-12 show-document">
-    <%= render "shared/record/record_toolbar" %>
-    <% @page_title = t 'blacklight.search.show.title_html', document_title: document_presenter(@document).html_title, application_name: "#{I18n.t('blacklight.application_name')} articles" %>
+    <%= render RecordToolbarComponent.new(presenter: document_presenter(@document), search_context: @search_context) %>
+
     <% # content_for(:head) { render_link_rel_alternates } Commented out for now %>
 
     <div id="document" class="document article-search-show <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,9 +1,9 @@
-    <%= render "shared/record/record_toolbar" %>
 
     <% @page_title = t 'blacklight.search.show.title_html', :document_title => document_presenter(@document).html_title, :application_name => "#{I18n.t('blacklight.application_name')} catalog" -%>
     <% content_for(:head) { render_link_rel_alternates } -%>
     <%# this should be in a partial -%>
 
+    <%= render RecordToolbarComponent.new(presenter: document_presenter(@document), search_context: @search_context) %>
     <div id="document" class="document <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">
       <div id="doc_<%= @document.id.to_s.parameterize %>">
         <% # bookmark/folder functions -%>


### PR DESCRIPTION
This helps us align with the patterns used by blacklight, so that upgrades are less challenging.