### PR TITLE
Re-enable force_ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,8 +49,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # TODO: Set force_ssl to true once ops completes https://github.com/sul-dlss/operations-tasks/issues/3587
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
Now that [ops task #3587](https://github.com/sul-dlss/operations-tasks/issues/3587) is complete to check app health via https we can enable force_ssl.

Closes #3759 
