### PR TITLE
fix css to truncate locations and display locations inline

### DIFF
--- a/app/assets/stylesheets/modules/accordion-sections.scss
+++ b/app/assets/stylesheets/modules/accordion-sections.scss
@@ -5,6 +5,15 @@
   .accordion-section {
     padding-left: 0;
 
+    .snippet-wrapper {
+      display: inline-flex;
+      align-items: center;
+      width: 100%;
+      button.header {
+        min-width: 147px;
+      }
+    }
+
     .header {
       @extend .btn;
       color: $white;

--- a/app/views/catalog/_accordion_section_course_reserves.html.erb
+++ b/app/views/catalog/_accordion_section_course_reserves.html.erb
@@ -9,12 +9,14 @@
     snippet = document.course_reserves.courses.map(&:id).join(', ')
   %>
   <div class="accordion-section course-reserves">
-    <button class="header" data-accordion-section-target=".<%= id %>-course-reserves" aria-expanded="false">
-      <span class="section-label">Course reserve</span>
-    </button>
-    <span class="snippet <%= id %>-course-reserves-snippet">
-      <%= snippet %>
-    </span>
+    <div class="snippet-wrapper">
+      <button class="header" data-accordion-section-target=".<%= id %>-course-reserves" aria-expanded="false">
+        <span class="section-label">Course reserve</span>
+      </button>
+      <span class="snippet <%= id %>-course-reserves-snippet">
+        <%= snippet %>
+      </span>
+    </div>
     <div class="details <%= id %>-course-reserves" aria-expanded="false">
       <%= render AccessPanels::CourseReservesListComponent.new(document: document) %>
     </div>

--- a/app/views/catalog/_accordion_section_library.html.erb
+++ b/app/views/catalog/_accordion_section_library.html.erb
@@ -8,12 +8,14 @@
     snippet = document.holdings.libraries.select(&:present?).map(&:name).join(', ')
   %>
   <div class="accordion-section location">
-    <button class="header" data-accordion-section-target=".<%= id %>-location" aria-expanded="false">
-      <span class="section-label">Check availability</span>
-    </button>
-    <span class="snippet <%= id %>-location-snippet">
-      <%= snippet %>
-    </span>
+    <div class="snippet-wrapper">
+      <button class="header" data-accordion-section-target=".<%= id %>-location" aria-expanded="false">
+        <span class="section-label">Check availability</span>
+      </button>
+      <span class="snippet <%= id %>-location-snippet">
+        <%= snippet %>
+      </span>
+    </div>
     <div class="details <%= id %>-location" aria-expanded="false">
       <%= render :partial => "catalog/index_location", :locals => { :document => document } %>
     </div>


### PR DESCRIPTION
closes #3791 

<img width="520" alt="Screenshot 2024-01-24 at 3 54 11 PM" src="https://github.com/sul-dlss/SearchWorks/assets/19173991/f1294c30-4de5-4f3b-89bb-481f5dc63d3e">
