### PR TITLE
Remove handling for prev and next in filmstrip

### DIFF
--- a/app/javascript/jquery.preview-filmstrip.js
+++ b/app/javascript/jquery.preview-filmstrip.js
@@ -90,10 +90,6 @@ import PreviewContent from './preview-content'
         $item.find($triggerFocus).on('click', $.proxy(function(e) {
           showPreview();
         }, this));
-
-        $filmstrip.find('.prev, .next').on('click', $.proxy(function() {
-          closePreview();
-        }, this));
       }
 
 


### PR DESCRIPTION
We don't have .prev or .next nodes anywhere

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
