### PR TITLE
Set recaptcha noscript to false for the email modal

### DIFF
--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -48,6 +48,8 @@
   <% if current_user.blank? %>
     <div class="form-group row">
       <div class="col-sm-10 offset-sm-2">
+        <%# Remove noscript for recaptcha when used in a modal. %>
+        <%# Otherwise the modal builder will insert unprocessed noscript tags, resulting in an empty g-recaptcha-response. %>
         <%= recaptcha_tags id: 'connection-form-recaptcha', noscript: false %>
 
         <p>(Stanford users can avoid this Captcha by logging in.)</p>

--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -48,7 +48,7 @@
   <% if current_user.blank? %>
     <div class="form-group row">
       <div class="col-sm-10 offset-sm-2">
-        <%= recaptcha_tags id: 'connection-form-recaptcha' %>
+        <%= recaptcha_tags id: 'connection-form-recaptcha', noscript: false %>
 
         <p>(Stanford users can avoid this Captcha by logging in.)</p>
       </div>


### PR DESCRIPTION
<!-- Closes #3808 -->

Fixes #3808. 

Related to #3762. The new DOMParser parsing/modal content handling appears to leave the noscript elements unprocessed by the browser. This breaks recaptcha.

Seems most straightforward to disable noscript on recaptcha for the email modal.

I thought about amending the new code from #3762 in application.js with something like the following:
```js
// If contents contains noscript elements, they are unprocessed at this point.
// Hack to reprocess those elements.  
frag.querySelectorAll('noscript').forEach(noscript => noscript.innerHTML = noscript.innerHTML);
```

This works for all browsers I've tested on, but I'm unclear if this kind of hack would work everywhere.