### PR TITLE
update render_real_time_availability_request_link? to not render

### DIFF
--- a/app/components/access_panels/location_item_component.rb
+++ b/app/components/access_panels/location_item_component.rb
@@ -41,6 +41,9 @@ module AccessPanels
       # we're not rendering item-level request links (because e.g. there's already alocation level request link)
       return false unless render_item_level_request_link?
 
+      # don't render unless item is requestable
+      return false unless item.requestable?
+
       # non-circulating items don't need real time availability
       return false unless item.circulates?
 

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -164,6 +164,10 @@ class Holdings
       @request_link ||= ItemRequestLinkComponent.new(item: self)
     end
 
+    def requestable?
+      @requestable ||= ItemRequestLinkPolicy.new(item: self).show?
+    end
+
     # create sorting key for spine
     # shelfkey asc, then by sorting title asc, then by pub date desc
     # note: pub_date must be inverted for descending sort


### PR DESCRIPTION
 request link when item not lendable


Not sure about this. My gut reaction is that `return false if item.request_link.render?` should be `return false if !item.request_link.render?` due to the conditions of render but I am not familiar enough with edge cases to be sure. Please advise if this is the right route, my gut was or if there is a better route I did not think of.