### PR TITLE
Ensure the iiif link is under the thumbnail

### DIFF
--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -52,6 +52,7 @@
 }
 
 .stacks-image {
+  display: block;
   max-height: 200px;
   max-width: 200px;
 }


### PR DESCRIPTION
Fixes a regression where the iiif logo was displayed next to the thumbnail rather than below it

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
