### PR TITLE
Use align-items: flex-end rather than end

### DIFF
--- a/app/assets/stylesheets/modules/gallery-view.scss
+++ b/app/assets/stylesheets/modules/gallery-view.scss
@@ -4,7 +4,7 @@
   flex-wrap: wrap;
 
   .item-thumb {
-    align-items: end;
+    align-items: flex-end;
     display: flex;
     height: $sul-gallery-cover-height;
     justify-content: center;


### PR DESCRIPTION
Because flex-end has better support. This fixes an autoprefixer warning
Fixes #3838 
