### PR TITLE
Remove unused display_type field from solr schema and fixtures

### DIFF
--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -241,9 +241,6 @@
     <field name="collection_with_title" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- collection_search: allow searching within collections for aggr. colls -->
     <field name="collection_search" type="string_punct_stop" indexed="true" stored="true" multiValued="true" omitNorms="true" />
-    <!-- display_type: used by UI code, e.g. 'file' or 'image' -->
-    <!-- display_type can be removed after all DOR objects and MARC records are reindexed in Feb/March 2016 -->
-    <field name="display_type" type="string" indexed="true" stored="true" multiValued="true" omitNorms="true" />
     <!--  used to determine when something is a digital collection -->
     <field name="collection_type" type="string" indexed="true" stored="true" multiValued="true" />
     <!-- file_id:  ids of files (including images) in the digital stacks -->

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -96,9 +96,6 @@
           <str name="facet.field">db_az_subject</str>
             <str name="f.db_az_subject.facet.sort">index</str>
             <str name="f.db_az_subject.facet.method">enum</str>
-          <!-- display_type can be removed after all DOR objects and MARC records are reindexed in Feb/March 2016 -->
-          <str name="facet.field">display_type</str>
-            <str name="f.display_type.facet.method">enum</str>
           <str name="facet.field">era_facet</str>
           <str name="facet.field">format_main_ssim</str>
             <str name="f.format_main_ssim.facet.method">enum</str>
@@ -141,9 +138,6 @@
           <str name="facet.field">db_az_subject</str>
             <str name="f.db_az_subject.facet.sort">index</str>
             <str name="f.db_az_subject.facet.method">enum</str>
-          <!-- display_type can be removed after all DOR objects and MARC records are reindexed in Feb/March 2016 -->
-          <str name="facet.field">display_type</str>
-            <str name="f.display_type.facet.method">enum</str>
           <str name="facet.field">era_facet</str>
             <str name="f.era_facet.facet.method">uif</str>
           <str name="facet.field">format_main_ssim</str>

--- a/spec/fixtures/solr_documents/1.yml
+++ b/spec/fixtures/solr_documents/1.yml
@@ -11,8 +11,6 @@
 :language: English
 :marc_json_struct: |
 <%= simple_856 %>
-:display_type:
-  - sirsi
 :pub_date: 2014
 :callnum_search: G70.212 .A426 2011:test
 :pub_year_tisim: 2014

--- a/spec/fixtures/solr_documents/10.yml
+++ b/spec/fixtures/solr_documents/10.yml
@@ -13,8 +13,6 @@
 <%= metadata1 %>
 :genre_ssim:
   - Thesis/Dissertation
-:display_type:
-  - sirsi
 :item_display_struct:
   - barcode: "123"
     library: CHEMCHMENG

--- a/spec/fixtures/solr_documents/11.yml
+++ b/spec/fixtures/solr_documents/11.yml
@@ -10,8 +10,6 @@
 :vern_title_display: "Currently, to obtain more information from the weakness of the resultant pain."
 :language: Spanish
 :format: Newspaper
-:display_type:
-  - sirsi
 :marc_json_struct: |
 <%= simple_856 %>
 :format_main_ssim: Newspaper

--- a/spec/fixtures/solr_documents/14.yml
+++ b/spec/fixtures/solr_documents/14.yml
@@ -6,8 +6,6 @@
 :all_search: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et anim.
 :language: Chinese
 :format: Book
-:display_type:
-  - sirsi
 :marc_json_struct: |
 <%= metadata1 %>
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/15.yml
+++ b/spec/fixtures/solr_documents/15.yml
@@ -6,8 +6,6 @@
 :all_search: Ea veniam cupidatat cupidatat aliquip nulla Lorem dolore eu.
 :language: Japanese
 :format: Image
-:display_type:
-  - sirsi
 :author_corp_display:
   - Scientific Council for Africa South of the Sahara.
 :marc_json_struct: |

--- a/spec/fixtures/solr_documents/16.yml
+++ b/spec/fixtures/solr_documents/16.yml
@@ -6,8 +6,6 @@
 :all_search: Sint aute consequat sint esse duis amet dolore fugiat Lorem.
 :language: Italian
 :format: Newspaper
-:display_type:
-  - sirsi
 :author_meeting_display:
   - Most Excellent Meeting
 :marc_json_struct: |

--- a/spec/fixtures/solr_documents/18.yml
+++ b/spec/fixtures/solr_documents/18.yml
@@ -7,8 +7,6 @@
 :language: German
 :format: Image
 :format_main_ssim: Image
-:display_type:
-  - sirsi
 :marc_json_struct: |
 <%= uniform_title_fixture %>
 :imprint_display: 1933

--- a/spec/fixtures/solr_documents/20.yml
+++ b/spec/fixtures/solr_documents/20.yml
@@ -15,8 +15,6 @@
 :db_az_subject: Biology
 :summary_display:
   - A summary of the database, this needs to be long so that we can test whether or not it gets truncated
-:display_type:
-  - sirsi
 :access_facet: Online
 :building_facet: Law (Crown)
 :marc_json_struct: |

--- a/spec/fixtures/solr_documents/24.yml
+++ b/spec/fixtures/solr_documents/24.yml
@@ -10,8 +10,6 @@
 :marc_json_struct: |
 <%= stanford_only_856 %>
 :format_main_ssim: Database
-:display_type:
-  - sirsi
 :db_az_subject: Biology
 :access_facet: Online
 :building_facet: Hoover Library

--- a/spec/fixtures/solr_documents/28.yml
+++ b/spec/fixtures/solr_documents/28.yml
@@ -11,7 +11,5 @@
 <%= metadata1 %>
 :format: Book
 :format_main_ssim: Book
-:display_type:
-  - sirsi
 :access_facet: Online
 :building_facet: Green

--- a/spec/fixtures/solr_documents/29.yml
+++ b/spec/fixtures/solr_documents/29.yml
@@ -4,8 +4,6 @@
 :all_search: Image Collection1
 :summary_display:
   - "A collection of fixture images from the SearchWorks development index."
-:display_type:
-  - image
 :format: Image
 :format_main_ssim: Image
 :collection_type: Digital Collection

--- a/spec/fixtures/solr_documents/31.yml
+++ b/spec/fixtures/solr_documents/31.yml
@@ -5,8 +5,6 @@
 :collection_type: Digital Collection
 :summary_display:
   - "A collection of fixture files from the SearchWorks development index."
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :modsxml: <%= mods_everything %>

--- a/spec/fixtures/solr_documents/32.yml
+++ b/spec/fixtures/solr_documents/32.yml
@@ -3,8 +3,6 @@
 :title_display: File Item1
 :all_search: File Item1
 :author_person_full_display: Dr. Katz
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :collection:

--- a/spec/fixtures/solr_documents/33.yml
+++ b/spec/fixtures/solr_documents/33.yml
@@ -3,8 +3,6 @@
 :title_display: File Item2
 :all_search: File Item2
 :author_person_full_display: Mr. Stedman
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :collection:

--- a/spec/fixtures/solr_documents/34.yml
+++ b/spec/fixtures/solr_documents/34.yml
@@ -4,9 +4,6 @@
 :all_search: Merged Image Collection1
 :author_person_full_display: Bob, Uncle
 :collection_type: Digital Collection
-:display_type:
-  - image
-  - sirsi
 :format: Image
 :format_main_ssim: Image
 :marc_json_struct: |

--- a/spec/fixtures/solr_documents/35.yml
+++ b/spec/fixtures/solr_documents/35.yml
@@ -3,8 +3,6 @@
 :title_display: Image Item3
 :all_search: Image Item3
 :author_person_full_display: Mr. Stedman
-:display_type:
-  - image
 :format: Image
 :format_main_ssim: Image
 :collection:

--- a/spec/fixtures/solr_documents/36.yml
+++ b/spec/fixtures/solr_documents/36.yml
@@ -3,8 +3,6 @@
 :title_display: Image Item4
 :all_search: Image Item4
 :author_person_full_display: Tony Balogna
-:display_type:
-  - image
 :format: Image
 :format_main_ssim: Image
 :collection:

--- a/spec/fixtures/solr_documents/37.yml
+++ b/spec/fixtures/solr_documents/37.yml
@@ -3,9 +3,6 @@
 :title_display: Merged Image1
 :all_search: Merged Image1
 :author_person_full_display: Eric Carbonara
-:display_type:
-  - image
-  - sirsi
 :format: Image
 :format_main_ssim: Image
 :collection:

--- a/spec/fixtures/solr_documents/38.yml
+++ b/spec/fixtures/solr_documents/38.yml
@@ -5,9 +5,6 @@
 :collection_type: Digital Collection
 :summary_display:
   - "A collection of fixture files from the SearchWorks development index."
-:display_type:
-  - file
-  - sirsi
 :format: File
 :format_main_ssim: Dataset
 :marc_json_struct: |

--- a/spec/fixtures/solr_documents/39.yml
+++ b/spec/fixtures/solr_documents/39.yml
@@ -3,8 +3,6 @@
 :title_display: File Item3
 :all_search: File Item3
 :author_person_full_display: Dr. Who
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :collection:

--- a/spec/fixtures/solr_documents/4.yml
+++ b/spec/fixtures/solr_documents/4.yml
@@ -8,8 +8,6 @@
 :language: French
 :format: Video
 :format_main_ssim: Video
-:display_type:
-  - sirsi
 :physical: The physical statement
 :marc_json_struct: |
 <%= marc_characteristics_fixture %>

--- a/spec/fixtures/solr_documents/40.yml
+++ b/spec/fixtures/solr_documents/40.yml
@@ -3,8 +3,6 @@
 :title_display: File Item4 - Deathstar Bluprints
 :all_search: File Item4 - Deathstar Bluprints
 :author_person_full_display: Skywalker, Luke
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :collection:

--- a/spec/fixtures/solr_documents/41.yml
+++ b/spec/fixtures/solr_documents/41.yml
@@ -3,8 +3,6 @@
 :title_display: File Item5 - Blaster User Manual - The Good Parts
 :all_search: File Item5 - Blaster User Manual - The Good Parts
 :author_person_full_display: Chewy
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :collection:

--- a/spec/fixtures/solr_documents/42.yml
+++ b/spec/fixtures/solr_documents/42.yml
@@ -3,8 +3,6 @@
 :title_display: File Item4 - selfie.vine
 :all_search: File Item4 - selfie.vine
 :author_person_full_display: Solo, Han
-:display_type:
-  - file
 :format: File
 :format_main_ssim: Dataset
 :collection:

--- a/spec/fixtures/solr_documents/43.yml
+++ b/spec/fixtures/solr_documents/43.yml
@@ -3,8 +3,6 @@
 :title_display: Best Album Every Written
 :all_search: Best Album Every Written
 :author_person_full_display: McDonald, Ronald
-:display_type:
-  - sirsi
 :format: music
 :format_main_ssim: Music recording
 :marc_json_struct: |

--- a/spec/fixtures/solr_documents/44.yml
+++ b/spec/fixtures/solr_documents/44.yml
@@ -6,8 +6,6 @@
 :title_245a_display: The Guanches of Tenerife
 :language: English
 :format: Book
-:display_type:
-  - sirsi
 :format_main_ssim: Book
 :access_facet: At the Library
 :building_facet: Green

--- a/spec/fixtures/solr_documents/45.yml
+++ b/spec/fixtures/solr_documents/45.yml
@@ -4,8 +4,6 @@
 :all_search: The Item With a Bookplate
 :language: English
 :format: Book
-:display_type:
-  - sirsi
 :marc_json_struct: |
 <%= metadata1 %>
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/48.yml
+++ b/spec/fixtures/solr_documents/48.yml
@@ -5,8 +5,6 @@
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= metadata2 %>
-:display_type:
-  - image
 :file_id:
   - cg767mn6478%2F2542A.jp2
 :druid: hj097bm8879

--- a/spec/fixtures/solr_documents/49.yml
+++ b/spec/fixtures/solr_documents/49.yml
@@ -5,8 +5,6 @@
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= contributed_works_fixture %>
-:display_type:
-  - image
 :file_id:
   - jw923xn5254%2F2542B.jp2
 :druid: hj097bm8879

--- a/spec/fixtures/solr_documents/50.yml
+++ b/spec/fixtures/solr_documents/50.yml
@@ -4,8 +4,6 @@
 :all_search: An item in a virtual object
 :format_main_ssim: Map
 :modsxml: <%= mods_everything %>
-:display_type:
-  - image
 :file_id:
   - wn461xh4882%2F2542001.jp2
 :druid: wn461xh4882

--- a/spec/fixtures/solr_documents/51.yml
+++ b/spec/fixtures/solr_documents/51.yml
@@ -5,8 +5,6 @@
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= metadata1 %>
-:display_type:
-  - image
 :file_id:
   - fh193nf4583%2F2542002.jp2
 :druid: fh193nf4583

--- a/spec/fixtures/solr_documents/52.yml
+++ b/spec/fixtures/solr_documents/52.yml
@@ -5,8 +5,6 @@
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= metadata1 %>
-:display_type:
-  - image
 :file_id:
   - zm141bz6672%2F2542003.jp2
 :druid: zm141bz6672

--- a/spec/fixtures/solr_documents/53.yml
+++ b/spec/fixtures/solr_documents/53.yml
@@ -5,8 +5,6 @@
 :format_main_ssim: Map
 :marc_json_struct: |
 <%= marc_382_instrumentation %>
-:display_type:
-  - image
 :file_id:
   - ty335fg4673%2F2542004.jp2
 :druid: ty335fg4673

--- a/spec/fixtures/solr_documents/58.yml
+++ b/spec/fixtures/solr_documents/58.yml
@@ -4,8 +4,6 @@
 :all_search: The Item in Curriculum Collection
 :language: English
 :format: Book
-:display_type:
-  - sirsi
 :marc_json_struct: |
 <%= metadata1 %>
 :format_main_ssim: Book

--- a/spec/fixtures/solr_documents/8923346.yml
+++ b/spec/fixtures/solr_documents/8923346.yml
@@ -8,9 +8,6 @@
 :access_facet: At the Library
 :marc_json_struct: |
 <%= many_managed_purl_856 %>
-:display_type:
-  - sirsi
-  - image
 marc_links_struct:
   - '{ "managed_purl": true, "href": "https://purl.stanford.edu/ct493wg6431", "druid": "ct493wg6431" }'
   - '{ "managed_purl": true, "href": "https://purl.stanford.edu/zg338xh5248", "druid": "zg338xh5248" }'

--- a/spec/fixtures/solr_documents/mf774fs2413.yml
+++ b/spec/fixtures/solr_documents/mf774fs2413.yml
@@ -2,8 +2,6 @@
 :hashed_id_ssi: 35765816d35553b532e04080792f2b33
 :title_display: Image Item1
 :all_search: Image Item1
-:display_type:
-  - image
 :format: Image
 :format_main_ssim: Image
 :collection:


### PR DESCRIPTION
Contributes to #3467 

There seem to be no documents with `display_type` in our current production index.
The note says to remove the field in 2016.
Our `catalog_controller` sets the display type field to `format_main_ssim`: https://github.com/sul-dlss/SearchWorks/blob/2515718e3fc72ea232a2e8f95940f5ea89dc2121/app/controllers/catalog_controller.rb#L100