### PR TITLE
Decouple CourseInfo from the serialization format

### DIFF
--- a/app/controllers/course_reserves_controller.rb
+++ b/app/controllers/course_reserves_controller.rb
@@ -1,7 +1,6 @@
 class CourseReservesController < ApplicationController
   include Blacklight::SearchContext
   include Blacklight::Configurable
-  include CourseReserves
   copy_blacklight_config_from(CatalogController)
 
   def index
@@ -13,7 +12,7 @@ class CourseReservesController < ApplicationController
     response = blacklight_config.repository.search(p)
     course_reserves = []
     response.aggregations.values.first.items.each do |item|
-      course_reserves << CourseInfo.new(item.value)
+      course_reserves << CourseReserves.from_crez_info(item.value)
     end
     @course_reserves = course_reserves
   end

--- a/app/helpers/course_reserve_access_point_helper.rb
+++ b/app/helpers/course_reserve_access_point_helper.rb
@@ -5,14 +5,14 @@ module CourseReserveAccessPointHelper
       # and return it's course reserve info that matches facet params.
       @course_info = @response.docs.map do |document|
         document[:crez_course_info].map do |course|
-          CourseReserves::CourseInfo.new(course)
+          CourseReserves.from_crez_info(course)
         end.find do |course|
           course.id == params[:f][:course][0] && course.instructor == params[:f][:instructor][0]
         end
       end.compact.first
     else
       # If no docs match the search params, return some course info though it will be missing course name
-      @course_info = CourseReserves::CourseInfo.new("#{params[:f][:course][0]}-|--|-#{params[:f][:instructor][0]}")
+      @course_info = CourseReserves::CourseInfo.new(id: params[:f][:course][0], name: '', instructor: params[:f][:instructor][0])
     end
   end
 end

--- a/app/models/concerns/course_reserves.rb
+++ b/app/models/concerns/course_reserves.rb
@@ -5,11 +5,15 @@ module CourseReserves
     end
   end
 
+  def self.from_crez_info(course)
+    CourseInfo.new(*course.split('-|-').map { |c| c.strip })
+  end
+
   private
 
   class Processor
     def initialize(document)
-      @courses = document[:crez_course_info].map { |course| CourseInfo.new(course) } unless document[:crez_course_info].nil?
+      @courses = Array(document[:crez_course_info]).map { |course| CourseReserves.from_crez_info(course) }
     end
 
     def present?
@@ -19,21 +23,5 @@ module CourseReserves
     attr_reader :courses
   end
 
-  class CourseInfo
-    def initialize(course)
-      @course = course.split('-|-').map { |c| c.strip }
-    end
-
-    def id
-      @course[0]
-    end
-
-    def name
-      @course[1]
-    end
-
-    def instructor
-      @course[2]
-    end
-  end
+  CourseInfo = Data.define(:id, :name, :instructor)
 end

--- a/spec/models/concerns/course_reserves_spec.rb
+++ b/spec/models/concerns/course_reserves_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CourseReserves do
 
   describe CourseReserves::CourseInfo do
     let(:doc) { "CAT-401-01-01 -|- Emergency Kittenz -|- McDonald, Ronald" }
-    let(:course_info) { CourseReserves::CourseInfo.new(doc) }
+    let(:course_info) { CourseReserves.from_crez_info(doc) }
 
     it "should initialize a new reservation" do
       expect(course_info).to be_an CourseReserves::CourseInfo

--- a/spec/views/course_reserves/index.html.erb_spec.rb
+++ b/spec/views/course_reserves/index.html.erb_spec.rb
@@ -1,19 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'course_reserves/index' do
-  let(:course_1) { 'CAT-401-01-01 -|- Emergency Kittenz -|- McDonald, Ronald' }
-  let(:course_2) { 'DOG-902-10-01 -|- Of Dogs and Men -|- Dog, Crime' }
-  let(:course_reserves) { [
-    CourseReserves::CourseInfo.new(course_1),
-    CourseReserves::CourseInfo.new(course_2)
-  ] }
-
   before do
-    assign(:course_reserves, course_reserves)
+    @course_reserves = [
+      CourseReserves::CourseInfo.new(id: 'CAT-401-01-01', name: 'Emergency Kittenz', instructor: 'McDonald, Ronald'),
+      CourseReserves::CourseInfo.new(id: 'DOG-902-10-01', name: 'Of Dogs and Men', instructor: 'Dog, Crime')
+    ]
     render
   end
 
-  it 'should render a table with course info' do
+  it 'renders a table with course info' do
     expect(rendered).to have_css('table')
     expect(rendered).to have_css('th', text: 'Course ID')
     expect(rendered).to have_css('th', text: 'Description')


### PR DESCRIPTION
This will allow us to switch to the courses_json_struct field

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
