### PR TITLE
strip leading a from collection search

### DIFF
--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -1,4 +1,8 @@
 module CollectionHelper
+  def self.strip_leading_a(collection_id)
+    collection_id.sub(/^a(\d+)$/, '\1')
+  end
+
   def link_to_collection_members(link_text, document, options = {})
     link_to(link_text, collection_members_path(document), options)
   end
@@ -28,7 +32,7 @@ module CollectionHelper
     if @response.documents.first&.index_parent_collections.present?
       collection = @response.documents.first.index_parent_collections.find do |coll|
         # strip leading 'a' from collection catkeys
-        coll[:id] == collection_id.sub(/^a(\d+)$/, '\1')
+        coll[:id] == CollectionHelper.strip_leading_a(collection_id)
       end
       return document_presenter(collection).heading if collection.present?
     end

--- a/app/models/concerns/collection_member.rb
+++ b/app/models/concerns/collection_member.rb
@@ -19,7 +19,7 @@ module CollectionMember
     unless @index_parent_collections
       @index_parent_collections = self[:collection_with_title].map do |collection_with_title|
         id, title = collection_with_title.split('-|-').map(&:strip)
-        SolrDocument.new(id: strip_a(id), title_display: title)
+        SolrDocument.new(id: CollectionHelper.strip_leading_a(id), title_display: title)
       end
     end
     @index_parent_collections
@@ -36,13 +36,8 @@ module CollectionMember
 
   def parent_collection_params
     self["collection"].map do |collection_id|
-      "id:#{strip_a(collection_id)}"
+      "id:#{CollectionHelper.strip_leading_a(collection_id)}"
     end.join(" OR ")
-  end
-
-  # strip leading 'a' from collection catkeys for building URLs, etc.
-  def strip_a(id)
-    id.sub(/^a(\d+)$/, '\1')
   end
 
   def blacklight_solr

--- a/app/models/concerns/digital_collection.rb
+++ b/app/models/concerns/digital_collection.rb
@@ -17,7 +17,7 @@ module DigitalCollection
     @collection_id ||= begin
       first_member = collection_members&.first || SolrDocument.new(collection: [])
       first_member[:collection].find do |col_member_col_id|
-        col_member_col_id.sub(/^a(\d+)$/, '\1') == self[:id]
+        CollectionHelper.strip_leading_a(col_member_col_id) == self[:id]
       end
     end
   end

--- a/app/models/concerns/solr_set.rb
+++ b/app/models/concerns/solr_set.rb
@@ -33,7 +33,7 @@ module SolrSet
 
   def set_solr_params
     ids = self['set'].map do |set_id|
-      "id:#{set_id}"
+      "id:#{CollectionHelper.strip_leading_a(set_id)}"
     end.join(' OR ')
     { params: { fq: ids } }
   end


### PR DESCRIPTION
closes #3854 

The code in app/models/concerns/solr_set.rb is what fixes this issue. The rest is consolidating the stripping out the a from the catkey.