### PR TITLE
Workaround for a record with a missing format

### DIFF
--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -6,7 +6,7 @@
       <% component.with_footer do %>
         <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
           <!-- COinS, for Zotero among others. -->
-          <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(@document.document_formats) %>"></span>
+          <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(@document.document_formats.first) %>"></span>
         <% end %>
       <%  end %>
     <% end %>


### PR DESCRIPTION
There are currently ~11.5k of these http://sul-solr-prod-a.stanford.edu/solr/#/searchworks-prod/query?q=-format_main_ssim:*&q.op=OR&indent=true

Shelly says this occurs when
> it is not source=MARC and is currently uncataloged.

This is probably an upstream bug: https://github.com/projectblacklight/blacklight-marc/issues/114

fixes #3866
<!-- 📝 CHANGELOG update? -->
