### PR TITLE
Remove references to unused title_uniform_display solr field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -214,7 +214,6 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_show_field "title_full_display", label: "Title"
     config.add_show_field "vern_title_full_display", label: "Title"
-    config.add_show_field "vern_title_uniform_display", label: "Uniform Title"
     config.add_show_field "title_variant_display", label: "Alternate Title"
     config.add_show_field "author_person_display", label: "Author/Creator"
     config.add_show_field "author_person_full_display", label: "Author/Creator"

--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -65,8 +65,6 @@
     <field name="vern_title_245c_display" type="string" indexed="false" stored="true" />
     <field name="title_full_display" type="string" indexed="false" stored="true" />
     <field name="vern_title_full_display" type="string" indexed="false" stored="true" />
-    <field name="title_uniform_display" type="string" indexed="false" stored="true" />
-    <field name="vern_title_uniform_display" type="string" indexed="false" stored="true" />
     <field name="title_variant_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <field name="title_sort" type="alphaSort" indexed="true" stored="true" />

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -1032,7 +1032,6 @@
         title_245c_display,           vern_title_245c_display,
         title_display,                vern_title_display,
         title_full_display,           vern_title_full_display,
-        title_uniform_display,        vern_title_uniform_display
         url_fulltext,
         url_restricted,
         url_suppl,

--- a/spec/fixtures/solr_documents/1.yml
+++ b/spec/fixtures/solr_documents/1.yml
@@ -5,7 +5,6 @@
 :title_245a_search: An object
 :author_person_display: Doe, Jane
 :author_1xx_search: Doe, Jane
-:vern_title_uniform_display: An object, aliquet sed mauris molestie, suscipit tempus
 :format: Book
 :format_main_ssim: Book
 :language: English

--- a/spec/fixtures/solr_documents/18.yml
+++ b/spec/fixtures/solr_documents/18.yml
@@ -2,7 +2,6 @@
 :hashed_id_ssi: 6f4922f45568161a8cdf4ad2299f6d23
 :pub_date: 1909
 :author_person_display: Jordan, Sheila
-:vern_title_uniform_display: Adipisicing dolor velit dolore dolore Lorem do quis sint veniam et anim aitat orediam
 :title_display: Adipisicing tempor quis ullamco enim dolore cillum velit commodo qui.
 :language: German
 :format: Image


### PR DESCRIPTION
Relates to #3467 
See https://github.com/sul-dlss/searchworks_traject_indexer/blob/cdad30e01b4e44880af5c68923464adad8a74e2e/lib/traject/config/folio_config.rb#L286

There seem to be no documents with `title_uniform_display` in our current production index, and all tests pass without it.
The indexer note says to remove the field in 2010!