### PR TITLE
Restore a .hidden class (used by the preview toggler on brief view)

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -34,3 +34,7 @@ dd {
 label {
   font-weight: normal;
 }
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
This fixes a regression from bootstrap 3 (and fixes #3876; the gap appearing at all was a result of this)

![Screenshot 2024-02-06 at 11 36 20](https://github.com/sul-dlss/SearchWorks/assets/111218/9abf3297-32c5-4462-90fe-ff67536d5d6c)
