### PR TITLE
Disable noscript on feedback form recaptcha

### DIFF
--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -50,7 +50,8 @@
     <% if current_user.blank? %>
       <div class="form-group row">
         <div class="col-sm-9 offset-sm-3">
-          <%= recaptcha_tags id: "#{type}-recaptcha" %>
+          <%# Remove noscript for recaptcha. See https://github.com/sul-dlss/SearchWorks/issues/3873 %>
+          <%= recaptcha_tags id: "#{type}-recaptcha", noscript: false %>
 
           <p>(Stanford users can avoid this Captcha by logging in.)</p>
         </div>


### PR DESCRIPTION
<!-- Closes #3873 -->
<!-- 📝 CHANGELOG Fix feedback form reCAPTCHA -->

Fixes the feedback form reCAPTCHA issue in #3873.

In [SearchWorks v3.21.14](https://github.com/sul-dlss/SearchWorks/releases/tag/v3.21.14) and after, noscript tags in the form containing this reCAPTCHA sometimes do not get processed by the browser. When this happens, it breaks the reCAPTCHA auth.