### PR TITLE
Removing deprecated summary view code

### DIFF
--- a/app/views/catalog/_summary_data.html.erb
+++ b/app/views/catalog/_summary_data.html.erb
@@ -42,15 +42,5 @@
   <% end %>
 
 <% elsif document.mods_abstract.present? %>
-    <%= document.mods_abstract.join('<br/>').html_safe %>
-
-<% elsif document[:summary_display].present? %>
-  <div>
-    <%= document[:summary_display].join('<br/>').html_safe %>
-  </div>
-<%# TODO: Remove this elsif block after new mods index is in place %>
-<% elsif document.respond_to?(:mods) && document.mods.present? %>
-  <% if document.mods.abstract.present? %>
-    <%= document.mods.abstract.map(&:values).join('<br/>').html_safe %>
-  <% end %>
+  <%= document.mods_abstract.join('<br/>').html_safe %>
 <% end %>

--- a/spec/components/search_result/item/mods/metadata_component_spec.rb
+++ b/spec/components/search_result/item/mods/metadata_component_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SearchResult::Item::Mods::MetadataComponent, type: :component do
       modsxml: mods_everything,
       physical: ["The Physical Extent"],
       imprint_display: ["Imprint Statement"],
+      summary_display: ['Nunc venenatis et odio ac elementum. Nulla ornare faucibus laoreet'],
       author_struct: [
         { 'link' => 'J. Smith', 'search' => '"J. Smith"', 'post_text' => '(Author)' },
         { 'link' => 'B. Smith', 'search' => '"B. Smith"', 'post_text' => '(Producer)' }

--- a/spec/fixtures/solr_documents/mf774fs2413.yml
+++ b/spec/fixtures/solr_documents/mf774fs2413.yml
@@ -15,6 +15,8 @@
 :beginning_year_isi: 2000
 :imprint_display: 1990
 :druid: mf774fs2413
+summary_display:
+  - Nunc venenatis et odio ac elementum. Nulla ornare faucibus laoreet
 :file_id:
   - "mf774fs2413%2FW784_000001_300.jp2"
   - "mf774fs2413%wFW784_000002_300.jp2"


### PR DESCRIPTION
The index is populated with summary_display now: https://searchworks.stanford.edu/view/mw886tk2640.json It was added in https://github.com/sul-dlss/searchworks_traject_indexer/pull/224/files

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
