### PR TITLE
Provide missing cookie_flags to google analytics

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -6,7 +6,7 @@ gtag('js', new Date());
 
 Blacklight.onLoad(function() {
   // gtag set property and config
-  const config = {}
+  const config = { cookie_flags: 'SameSite=None;Secure' }
   // To turn off analytics debug mode, exclude the parameter altogether (cannot just set to false)
   //See https://support.google.com/analytics/answer/7201382?hl=en#zippy=%2Cgoogle-tag-websites
   if (document.head.querySelector("meta[name=analytics_debug]").getAttribute('value') === "true") {


### PR DESCRIPTION
This should prevent the warnings about misusing the samesite cookie. See https://www.tinstar.co.uk/studio-blog/some-cookies-are-misusing-the-recommended-samesite-attribute-how-to-fix/

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
<img width="1313" alt="Screenshot 2024-02-08 at 1 19 24 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/b4a98451-4bca-4269-9cd4-ab9e86e3d81e">
