### PR TITLE
adding context to honeybadger notification

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ActiveRecord::Base
   # with the stanford:library-resources-eligible status.
   def stanford_affiliated?
     Honeybadger.notify("User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
-                                        "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
+                       "Affiliated by suAffiliation: #{affiliations}")
     # Will rely primarily on eduPersonAffiliation so return true if this works
     return true if person_affiliated?
 
@@ -47,7 +47,7 @@ class User < ActiveRecord::Base
     # because this shows us a mismatch between the two attributes when there shouldn't be a difference.
     if su_affiliated?
       Honeybadger.notify("User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
-                                        "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
+                         "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
       true
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,10 @@ class User < ActiveRecord::Base
   # Note also that currently 'member' for eduPersonAffiliation has a one to one correspondence
   # with the stanford:library-resources-eligible status.
   def stanford_affiliated?
+    Honeybadger.notify(error_message: "User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
+                                        "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
     # Will rely primarily on eduPersonAffiliation so return true if this works
-    # return true if person_affiliated?
+    return true if person_affiliated?
 
     # If not true, we still want to check against suAffiliation.
     # We also want to send a notification in case it is covered by suAffiliation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,6 @@ class User < ActiveRecord::Base
   # Note also that currently 'member' for eduPersonAffiliation has a one to one correspondence
   # with the stanford:library-resources-eligible status.
   def stanford_affiliated?
-    Honeybadger.notify("User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
-                       "Affiliated by suAffiliation: #{affiliations}")
     # Will rely primarily on eduPersonAffiliation so return true if this works
     return true if person_affiliated?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ActiveRecord::Base
   # with the stanford:library-resources-eligible status.
   def stanford_affiliated?
     # Will rely primarily on eduPersonAffiliation so return true if this works
-    return true if person_affiliated?
+    # return true if person_affiliated?
 
     # If not true, we still want to check against suAffiliation.
     # We also want to send a notification in case it is covered by suAffiliation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ActiveRecord::Base
   # Note also that currently 'member' for eduPersonAffiliation has a one to one correspondence
   # with the stanford:library-resources-eligible status.
   def stanford_affiliated?
-    Honeybadger.notify(error_message: "User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
+    Honeybadger.notify("User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
                                         "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
     # Will rely primarily on eduPersonAffiliation so return true if this works
     return true if person_affiliated?
@@ -46,7 +46,7 @@ class User < ActiveRecord::Base
     # We also want to send a notification in case it is covered by suAffiliation
     # because this shows us a mismatch between the two attributes when there shouldn't be a difference.
     if su_affiliated?
-      Honeybadger.notify(error_message: "User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
+      Honeybadger.notify("User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
                                         "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
       true
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,8 +44,8 @@ class User < ActiveRecord::Base
     # We also want to send a notification in case it is covered by suAffiliation
     # because this shows us a mismatch between the two attributes when there shouldn't be a difference.
     if su_affiliated?
-      Honeybadger.notify("User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
-                         "Affiliated by suAffiliation: #{affiliations}")
+      Honeybadger.notify(error_message: "User affiliations and privileges: Not affiliated by eduPersonAffiliation: #{person_affiliations}; " \
+                                        "Affiliated by suAffiliation: #{affiliations}", context: to_honeybadger_context)
       true
     end
   end


### PR DESCRIPTION
Patch to add context to honeybadger, to help address https://github.com/sul-dlss/SearchWorks/issues/3867 .

We want to be able to track sunet ids that correspond to the error so we can generate examples to pass on to SAML etc.
