### PR TITLE
Allow Jenkins to deploy specific branch

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@ set :repo_url, 'https://github.com/sul-dlss/SearchWorks.git'
 
 # Default branch is :master so we need to update to main
 if ENV['DEPLOY']
-  set :branch, 'main'
+  set :branch, ENV.fetch('BRANCH', 'main')
 else
   ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 end


### PR DESCRIPTION
Jenkins tries to set the BRANCH variable, so we need to make the deploy configuration to respect it.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
