### PR TITLE
Support FOLIO-style hrids in the 590

### DIFF
--- a/app/models/marc_fields/bound_with_note.rb
+++ b/app/models/marc_fields/bound_with_note.rb
@@ -6,9 +6,9 @@ class BoundWithNote < MarcField
   private
 
   def subfield_value(field, subfield)
-    return super unless subfield.code == 'c' && subfield.value.match?(/^(\d+)/)
+    return super unless subfield.code == 'c' && subfield.value.match?(ckey_regex)
 
-    ckey = subfield.value[/^(\d+)/]
+    ckey = subfield.value[ckey_regex]
     ckey_link = link_to(ckey, Rails.application.routes.url_helpers.solr_document_path(ckey))
 
     subfield.value.gsub(ckey, ckey_link).html_safe
@@ -16,5 +16,9 @@ class BoundWithNote < MarcField
 
   def tags
     %w(590)
+  end
+
+  def ckey_regex
+    /^((a|in|L)?\d+)/
   end
 end

--- a/app/models/marc_fields/bound_with_note_for_access_panel.rb
+++ b/app/models/marc_fields/bound_with_note_for_access_panel.rb
@@ -4,7 +4,7 @@
 class BoundWithNoteForAccessPanel < BoundWithNote
   def values
     extracted_fields.map do |field, subfields|
-      id = subfields.find { |subfield| subfield.code == 'c' }.value[/^(\d+)/]
+      id = subfields.find { |subfield| subfield.code == 'c' }.value[ckey_regex]
 
       { id:, value: display_value(field, subfields) }
     end

--- a/spec/models/marc_fields/bound_with_note_spec.rb
+++ b/spec/models/marc_fields/bound_with_note_spec.rb
@@ -14,6 +14,37 @@ RSpec.describe BoundWithNote do
       expect(subject.values).to include 'A 590 that does not have $c'
     end
 
+    context 'with a FOLIO hrid in the $c' do
+      let(:marc) do
+        <<-JSON
+          {
+            "leader": "          22        4500",
+            "fields": [
+              {
+                "590": {
+                  "ind1": " ",
+                  "ind2": " ",
+                  "subfields": [
+                    {
+                      "a": "Copy 1 bound with v. 140"
+                    },
+                    {
+                      "c": "in00001 (parent record’s ckey)"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        JSON
+      end
+
+      it 'links to the parent ID' do
+        expect(subject.values.length).to eq 1
+        expect(subject.values).to include 'Copy 1 bound with v. 140 <a href="/view/in00001">in00001</a> (parent record’s ckey)'
+      end
+    end
+
     context 'with a $c that does not start with a ckey' do
       let(:marc) { unlinked_ckey_fixture }
 


### PR DESCRIPTION
Fixes VUF-9613

Newly created bound-withs in FOLIO use FOLIO's hrids, not Symphoy catkeys (e.g. https://searchworks.stanford.edu/view/2126474). Until we can use FOLIO's native bound-with info, we should support some FOLIO hrid formats