### PR TITLE
Update librarian view to have items

### DIFF
--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -53,7 +53,9 @@ $pagination-active-bg: $sul-pagination-active-bg;
 $pagination-active-border: $sul-pagination-active-bg;
 
 // Tables
-$table-accent-bg: $light-sandstone; // background for .table-striped
+$table-cell-padding: 0.5rem;
+$table-accent-bg: $secondary; // background for .table-striped (This becomes $table-striped-color in BS 5)
+$table-caption-color: $blackish;
 
 // Tooltip
 $tooltip-bg: $sul-tooltip-bg;

--- a/app/assets/stylesheets/modules/librarian-view.scss
+++ b/app/assets/stylesheets/modules/librarian-view.scss
@@ -1,8 +1,20 @@
-#marc_view .field {
-  word-break: break-all;
+.last-updated { 
+  margin-left: auto;
+  align-self: center;
+}
+.last-updated + .blacklight-modal-close {
+  margin-left: 0;
 }
 
-#folio-json-view summary {
-  @extend .h4;
-  @extend .my-3;
+#marc_view {
+  .field {
+    word-break: break-all;
+  }
+
+  .item-details {
+    caption {
+      caption-side: top;
+      background-color: $secondary;
+    }
+  }
 }

--- a/app/components/librarian/item_details/table_component.html.erb
+++ b/app/components/librarian/item_details/table_component.html.erb
@@ -1,0 +1,24 @@
+<details class="item-details mb-3">
+    <summary class="h3">Item details</summary>
+    <% locations.each do |location| %>
+      <table class="table">
+          <caption class="px-3 h4 mb-0"><strong>Permanent Location</strong> <%= location.label %></caption>
+          <thead>
+              <tr>
+                  <th>Effective Call Number</th>
+                  <th>Barcode</th>
+                  <th>Effective Location</th>
+              </tr>
+          </thead>
+          <tbody>
+            <% location.items.each do |item| %>
+                <tr>
+                  <td class="pl-5"><%= item.call_number %></td>
+                  <td><%= item.barcode %></td>
+                  <td><%= item.location %></td>
+              </tr>
+            <% end %>
+          </tbody>
+      </table>
+    <% end %>
+</details>

--- a/app/components/librarian/item_details/table_component.rb
+++ b/app/components/librarian/item_details/table_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Librarian
+  module ItemDetails
+    class TableComponent < ViewComponent::Base
+      Location = Data.define(:items, :permanent_location_code, :label)
+      Item = Data.define(:call_number, :barcode, :location)
+
+      def initialize(document:)
+        @document = document
+        super()
+      end
+
+      attr_reader :document
+
+      delegate :folio_items, to: :document
+
+      def folio_items_by_location
+        folio_items.group_by { |item| item.permanent_location.code }
+      end
+
+      def locations
+        folio_items_by_location.map do |permanent_location_code, items_in_location|
+          label = items_in_location.first.permanent_location&.name
+          Location.new(items: display_items(items_in_location, permanent_location_code), permanent_location_code:, label:)
+        end
+      end
+
+      def display_items(items_in_location, permanent_location_code)
+        items_in_location.map do |item|
+          Item.new(call_number: item.constructed_call_number || 'No call number',
+                   barcode: item.barcode || 'No barcode',
+                   location: item.effective_location&.code == permanent_location_code ? nil : item.effective_location&.name)
+        end
+      end
+
+      def render?
+        folio_items.present?
+      end
+    end
+  end
+end

--- a/app/models/concerns/solr_holdings.rb
+++ b/app/models/concerns/solr_holdings.rb
@@ -53,13 +53,13 @@ module SolrHoldings
     end
   end
 
+  def holdings_json
+    @holdings_json ||= first(:holdings_json_struct).presence || {}
+  end
+
   private
 
   def folio_holdings_by_id
     @folio_holdings_by_id ||= folio_holdings.index_by(&:id)
-  end
-
-  def holdings_json
-    @holdings_json ||= self[:holdings_json_struct].present? ? first(:holdings_json_struct) : {}
   end
 end

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -1,12 +1,18 @@
 module Folio
   class Item
-    attr_reader :id, :status, :barcode, :material_type, :effective_location, :permanent_location
+    attr_reader :id, :status, :barcode, :call_number, :material_type, :effective_location,
+                :permanent_location, :volume, :enumeration, :chronology
 
     MaterialType = Struct.new(:id, :name, keyword_init: true)
     LoanType = Struct.new(:id, :name, keyword_init: true)
+    CallNumber = Data.define(:type_id, :type_name, :call_number) do
+      def self.from_dynamic(json)
+        new(type_id: json['typeId'], type_name: json['typeName'], call_number: json['callNumber'])
+      end
+    end
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(id:, status:, barcode:, material_type:, permanent_loan_type:, effective_location:, permanent_location: nil, temporary_loan_type: nil)
+    def initialize(id:, status:, barcode:, material_type:, permanent_loan_type:, effective_location:, call_number:, volume:, enumeration:, chronology:, permanent_location: nil, temporary_loan_type: nil)
       @id = id
       @barcode = barcode
       @status = status
@@ -15,6 +21,10 @@ module Folio
       @effective_location = effective_location
       @permanent_location = permanent_location || effective_location
       @temporary_loan_type = temporary_loan_type
+      @call_number = call_number
+      @volume = volume
+      @enumeration = enumeration
+      @chronology = chronology
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -34,8 +44,16 @@ module Folio
             id: json.fetch('temporaryLoanTypeId'),
             name: json.fetch('temporaryLoanType')
           ),
+          volume: json['volume'], # only present for serials
+          enumeration: json['enumeration'], # only present for serials
+          chronology: json['chronology'], # only present for serials
+          call_number: CallNumber.from_dynamic(json['callNumber']),
           effective_location: Folio::Location.from_dynamic(json.dig('location', 'effectiveLocation')),
           permanent_location: (Folio::Location.from_dynamic(json.dig('location', 'permanentLocation')) if json.dig('location', 'permanentLocation')) || holdings_record&.effective_location)
+    end
+
+    def constructed_call_number
+      [call_number.call_number, volume, enumeration, chronology].compact.join(' ').presence
     end
 
     def location_provided_availability

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -22,6 +22,7 @@ module Folio
     # rubocop:enable Metrics/ParameterLists
 
     # Prefer the locally cached name, but fall back to the name from the document if we have to
+    # The name in the document is the "discoveryDisplayName", which may differ from "name"
     def name
       cached_location_data&.dig('name') || @name
     end

--- a/app/views/catalog/_folio_json_view.html.erb
+++ b/app/views/catalog/_folio_json_view.html.erb
@@ -1,20 +1,18 @@
 <% if @document.first(:folio_json_struct) %>
-    <div id="folio-json-view">
-        <details>
-            <summary>Holdings JSON</summary>
-            <pre class="card p-2 bg-secondary"><%= JSON.pretty_generate(@document.first(:holdings_json_struct)) %></pre>
-        </details>
-        <details>
-            <summary>FOLIO JSON</summary>
-            <pre class="card p-2 bg-secondary"><%= JSON.pretty_generate(JSON.parse(@document.first(:folio_json_struct))) %></pre>
-        </details>
-        <% if @document.preferred_item&.folio_item? %>
-        <details>
-            <summary>Circulation rules</summary>
-            <pre class="card p-2 bg-secondary"><%= Folio::CirculationRules::PolicyService.instance.item_rule(@document.preferred_item).to_debug_s %></pre>
+    <details class="mb-3">
+        <summary class="h3">Holdings JSON</summary>
+        <pre class="card p-2 bg-secondary"><%= JSON.pretty_generate(@document.first(:holdings_json_struct)) %></pre>
+    </details>
+    <details class="mb-3">
+        <summary class="h3">FOLIO JSON</summary>
+        <pre class="card p-2 bg-secondary"><%= JSON.pretty_generate(JSON.parse(@document.first(:folio_json_struct))) %></pre>
+    </details>
+    <% if @document.preferred_item&.folio_item? %>
+    <details class="mb-3">
+        <summary class="h3">Circulation rules</summary>
+        <pre class="card p-2 bg-secondary"><%= Folio::CirculationRules::PolicyService.instance.item_rule(@document.preferred_item).to_debug_s %></pre>
 
-            <pre class="card p-2 bg-secondary"><%= @document.items.select(&:folio_item?).group_by { |item| [item.loan_type, item.material_type, item.effective_location.code, item.folio_status] }.map { |_g, items| [solr_document_url(@document), @document.id, items.first.effective_location.code, items.map(&:barcode).join('|'), items.first.folio_status].to_csv(row_sep: nil) + "," + Folio::CirculationRules::PolicyService.instance.item_rule(items.first).to_csv(include_line_metadata: true) }.join %></pre>
-        </details>
-        <% end %>
-    </div>
+        <pre class="card p-2 bg-secondary"><%= @document.items.select(&:folio_item?).group_by { |item| [item.loan_type, item.material_type, item.effective_location.code, item.folio_status] }.map { |_g, items| [solr_document_url(@document), @document.id, items.first.effective_location.code, items.map(&:barcode).join('|'), items.first.folio_status].to_csv(row_sep: nil) + "," + Folio::CirculationRules::PolicyService.instance.item_rule(items.first).to_csv(include_line_metadata: true) }.join %></pre>
+    </details>
+    <% end %>
 <% end %>

--- a/app/views/catalog/_marc_view.html.erb
+++ b/app/views/catalog/_marc_view.html.erb
@@ -1,34 +1,37 @@
 <div id="marc_view">
-  <% fields = @document.to_marc.find_all{|f| ('000'..'999') === f.tag }  %>
-  <div class="field"><%= t('blacklight.search.librarian_view.leader', :leader => @document.to_marc.leader) %></div>
-  <%- fields.each do |field| -%>
-  <%- unless field.tag.to_s == "940" -%>
-    <div class="field">
-      <div class="tag_ind">
-        <span class="tag">
-          <%= h(field.tag) %>
-        </span>
-      <%- if field.is_a?(MARC::ControlField) -%>
-        <span class="control_field_values">
-          <%= h(field.value) %>
-        </span>
-      <%- else -%>
-        <div class="ind1">
-          <%= !field.indicator1.blank? ? field.indicator1 : "&nbsp;&nbsp;".html_safe -%>
+  <details class="mb-3">
+    <summary class="h3">Metadata</summary>
+    <% fields = @document.to_marc.find_all{|f| ('000'..'999') === f.tag }  %>
+    <div class="field"><%= t('blacklight.search.librarian_view.leader', :leader => @document.to_marc.leader) %></div>
+    <%- fields.each do |field| -%>
+      <%- unless field.tag.to_s == "940" -%>
+        <div class="field">
+          <div class="tag_ind">
+            <span class="tag">
+              <%= h(field.tag) %>
+            </span>
+          <%- if field.is_a?(MARC::ControlField) -%>
+            <span class="control_field_values">
+              <%= h(field.value) %>
+            </span>
+          <%- else -%>
+            <div class="ind1">
+              <%= !field.indicator1.blank? ? field.indicator1 : "&nbsp;&nbsp;".html_safe -%>
+            </div>
+            <div class="ind2">
+              <%= !field.indicator2.blank? ? field.indicator2 : "&nbsp;&nbsp;".html_safe -%>
+            </div>
+          </div>
+          <div class="subfields">
+            <%- field.each do |sub| -%>
+            <span class="sub_code"><%= h(sub.code) %>|</span> <%= h(sub.value) %>
+          <%- end -%>
+          <%- end -%>
+          </div>
         </div>
-        <div class="ind2">
-          <%= !field.indicator2.blank? ? field.indicator2 : "&nbsp;&nbsp;".html_safe -%>
-        </div>
-      </div>
-      <div class="subfields">
-        <%- field.each do |sub| -%>
-        <span class="sub_code"><%= h(sub.code) %>|</span> <%= h(sub.value) %>
-      <%- end -%>
-      <%- end -%>
-      </div>
-    </div>
-  <%- end-%>
-  <%- end -%>
-
+      <%- end-%>
+    <%- end -%>
+  </details>
+  <%= render Librarian::ItemDetails::TableComponent.new(document: @document) %>
   <%= render "folio_json_view" %>
 </div>

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,11 +1,12 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
   <% component.with_header do %>
     <h3 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h3>
+
+    <% if @document[:last_updated] %>
+      <span class="last-updated">Last updated in SearchWorks on <%= l @document[:last_updated].to_time.in_time_zone, format: :long %></span>
+    <% end %>
   <% end %>
 
-  <% if @document[:last_updated] %>
-    <p>Last updated in SearchWorks on <%= l @document[:last_updated].to_time.in_time_zone, format: :long %></p>
-  <% end %>
   <% if @document.respond_to?(:to_marc) %>
     <%= render "marc_view" %>
   <% elsif @document.mods? %>

--- a/spec/components/librarian/item_details/table_component_spec.rb
+++ b/spec/components/librarian/item_details/table_component_spec.rb
@@ -1,0 +1,1410 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Librarian::ItemDetails::TableComponent, type: :component do
+  let(:component) { described_class.new(document:) }
+
+  let(:document) { SolrDocument.new(item_display_struct:, holdings_json_struct:) }
+  let(:item_display_struct) do
+    [
+      {
+        "id" => "502863a5-b53c-58cf-9305-03846673ef14",
+        "barcode" => "36105223688552",
+        "library" => "EARTH-SCI",
+        "home_location" => "EAR-STACKS",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "EAR-STACKS",
+        "status" => "Available",
+        "effective_location_id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "9773449d-90d7-5108-b73d-c532e69de8cd",
+        "barcode" => "36105226059181",
+        "library" => "EARTH-SCI",
+        "home_location" => "EAR-STACKS",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "EAR-STACKS",
+        "status" => "Available",
+        "effective_location_id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "99c01199-b248-58a7-a452-d7219c2cb817",
+        "barcode" => "36105225598411",
+        "library" => "RUMSEY-MAP",
+        "home_location" => "RUM-W7-STK-REF",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "RUM-W7-STK-REF",
+        "status" => "Available",
+        "effective_location_id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "ad35d1a4-067e-522d-99e4-5be7b1358668",
+        "barcode" => "36105218665789",
+        "library" => "GREEN",
+        "home_location" => "GRE-STACKS",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "GRE-STACKS",
+        "status" => "Available",
+        "effective_location_id" => "4573e824-9273-4f13-972f-cff7bf504217",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "lopped_callnumber" => "E179 .F84 1990",
+        "shelfkey" => "lc e   0179.000000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}zzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179 .F84 1990",
+        "full_shelfkey" => "lc e   0179.000000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "be2de21c-e500-5334-862a-e22fcc9d2776",
+        "barcode" => "36105226157456",
+        "library" => "RUMSEY-MAP",
+        "home_location" => "RUM-W7-STK-REF",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "RUM-W7-STK-REF",
+        "status" => "Available",
+        "effective_location_id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "db5de9be-8e47-540a-b9ce-1f0940e21169",
+        "barcode" => "36105226146277",
+        "library" => "EARTH-SCI",
+        "home_location" => "EAR-STACKS",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "EAR-STACKS",
+        "status" => "Available",
+        "effective_location_id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "dda764bf-b634-5253-a1b8-00abdc7cd60a",
+        "barcode" => "36105225598403",
+        "library" => "RUMSEY-MAP",
+        "home_location" => "RUM-W7-STK-REF",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "RUM-W7-STK-REF",
+        "status" => "Available",
+        "effective_location_id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "df0d7b8b-23f8-50a5-97d0-d6ed95173eac",
+        "barcode" => "36105225598080",
+        "library" => "RUMSEY-MAP",
+        "home_location" => "RUM-W7-STK-REF",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "RUM-W7-STK-REF",
+        "status" => "Available",
+        "effective_location_id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+        "lopped_callnumber" => "E179.5 .F84 1990",
+        "shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}uzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179.5 .F84 1990",
+        "full_shelfkey" => "lc e   0179.500000 f0.840000 001990",
+        "scheme" => "LC"
+      },
+      {
+        "id" => "e4cdaaa5-9ed2-57b3-aede-ba9f69aa9f23",
+        "barcode" => "36105005105536",
+        "library" => "GREEN",
+        "home_location" => "GRE-STACKS",
+        "current_location" => nil,
+        "type" => "book",
+        "note" => nil,
+        "instance_id" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+        "instance_hrid" => "a2800276",
+        "temporary_location_code" => nil,
+        "permanent_location_code" => "GRE-STACKS",
+        "status" => "Available",
+        "effective_location_id" => "4573e824-9273-4f13-972f-cff7bf504217",
+        "material_type_id" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "loan_type_id" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "lopped_callnumber" => "E179 .F84 1990",
+        "shelfkey" => "lc e   0179.000000 f0.840000 001990",
+        "reverse_shelfkey" => "en~l~~~zysq}zzzzzz~kz}rvzzzz~zzyqqz~~~~~~~~~~~~~~~",
+        "callnumber" => "E179 .F84 1990",
+        "full_shelfkey" => "lc e   0179.000000 f0.840000 001990",
+        "scheme" => "LC"
+      }
+    ]
+  end
+
+  subject(:page) { render_inline(component) }
+
+  context "when the record has items in three locations" do
+    let(:holdings_json_struct) do
+      [
+        {
+          "holdings" => [
+            {
+              "id" => "37144f55-afba-5af8-b9d4-0d3a412cd45c",
+              "hrid" => "ah2800276_3",
+              "notes" => [],
+              "_version" => 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:14:38.544Z",
+                "updatedDate" => "2023-08-21T04:14:38.544Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "sourceId" => "f32d531e-df79-46b3-8932-cdd35f7a2264",
+              "boundWith" => nil,
+              "formerIds" => [],
+              "illPolicy" => nil,
+              "callNumber" => "E179.5 .F84 1990",
+              "instanceId" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+              "holdingsType" => {
+                "id" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+                "name" => "Book",
+                "source" => "local"
+              },
+              "holdingsItems" => [],
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "holdingsTypeId" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+              "callNumberTypeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+              "electronicAccess" => [],
+              "bareHoldingsItems" => [],
+              discoverySuppress: false,
+              "holdingsStatements" => [],
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              "permanentLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              suppressFromDiscovery: false,
+              "holdingsStatementsForIndexes" => [],
+              "holdingsStatementsForSupplements" => [],
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                },
+                "permanentLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              }
+            },
+            {
+              "id" => "8e909bd9-aa6e-50e0-9b32-d8d213d16d89",
+              "hrid" => "ah2800276_1",
+              "notes" => [],
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:14:38.544Z",
+                "updatedDate" => "2023-08-21T04:14:38.544Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "sourceId" => "f32d531e-df79-46b3-8932-cdd35f7a2264",
+              "boundWith" => nil,
+              "formerIds" => [],
+              "illPolicy" => nil,
+              "callNumber" => "E179 .F84 1990",
+              "instanceId" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+              "holdingsType" => {
+                "id" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+                "name" => "Book",
+                "source" => "local"
+              },
+              "holdingsItems" => [],
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "holdingsTypeId" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+              "callNumberTypeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+              "electronicAccess" => [],
+              "bareHoldingsItems" => [],
+              discoverySuppress: false,
+              "holdingsStatements" => [],
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "4573e824-9273-4f13-972f-cff7bf504217",
+              "permanentLocationId" => "4573e824-9273-4f13-972f-cff7bf504217",
+              suppressFromDiscovery: false,
+              "holdingsStatementsForIndexes" => [],
+              "holdingsStatementsForSupplements" => [],
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "4573e824-9273-4f13-972f-cff7bf504217",
+                  "code" => "GRE-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "stackmapBaseUrl" => "https://stanford.stackmap.com/json/"
+                  },
+                  "library" => {
+                    "id" => "f6b5519e-88d9-413e-924d-9ed96255f72e",
+                    "code" => "GREEN",
+                    "name" => "Green Library"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                },
+                "permanentLocation" => {
+                  "id" => "4573e824-9273-4f13-972f-cff7bf504217",
+                  "code" => "GRE-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "stackmapBaseUrl" => "https://stanford.stackmap.com/json/"
+                  },
+                  "library" => {
+                    "id" => "f6b5519e-88d9-413e-924d-9ed96255f72e",
+                    "code" => "GREEN",
+                    "name" => "Green Library"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              }
+            },
+            {
+              "id" => "c51c74d4-8a6f-52f2-a1c7-006fd0af7734",
+              "hrid" => "ah2800276_2",
+              "notes" => [],
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:14:38.544Z",
+                "updatedDate" => "2023-08-21T04:14:38.544Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "sourceId" => "f32d531e-df79-46b3-8932-cdd35f7a2264",
+              "boundWith" => nil,
+              "formerIds" => [],
+              "illPolicy" => nil,
+              "callNumber" => "E179.5 .F84 1990",
+              "instanceId" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+              "holdingsType" => {
+                "id" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+                "name" => "Book",
+                "source" => "local"
+              },
+              "holdingsItems" => [],
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "holdingsTypeId" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+              "callNumberTypeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+              "electronicAccess" => [],
+              "bareHoldingsItems" => [],
+              discoverySuppress: false,
+              "holdingsStatements" => [],
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+              "permanentLocationId" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+              suppressFromDiscovery: false,
+              "holdingsStatementsForIndexes" => [],
+              "holdingsStatementsForSupplements" => [],
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+                  "code" => "EAR-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {},
+                  "library" => {
+                    "id" => "96630997-201d-49b3-b8d5-e4ba43a6cde8",
+                    "code" => "EARTH-SCI",
+                    "name" => "Earth Sciences Library (Branner)"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                },
+                "permanentLocation" => {
+                  "id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+                  "code" => "EAR-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {},
+                  "library" => {
+                    "id" => "96630997-201d-49b3-b8d5-e4ba43a6cde8",
+                    "code" => "EARTH-SCI",
+                    "name" => "Earth Sciences Library (Branner)"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              }
+            }
+          ],
+          "items" => [
+            {
+              "id" => "502863a5-b53c-58cf-9305-03846673ef14",
+              "hrid" => "ai2800276_2_5",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105223688552",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "4",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "c51c74d4-8a6f-52f2-a1c7-006fd0af7734",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Can circulate",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+              "permanentLoanTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 14",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+                  "code" => "EAR-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {},
+                  "library" => {
+                    "id" => "96630997-201d-49b3-b8d5-e4ba43a6cde8",
+                    "code" => "EARTH-SCI",
+                    "name" => "Earth Sciences Library (Branner)"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "9773449d-90d7-5108-b73d-c532e69de8cd",
+              "hrid" => "ai2800276_2_1",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105226059181",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "1",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "c51c74d4-8a6f-52f2-a1c7-006fd0af7734",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Can circulate",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+              "permanentLoanTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 11",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+                  "code" => "EAR-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {},
+                  "library" => {
+                    "id" => "96630997-201d-49b3-b8d5-e4ba43a6cde8",
+                    "code" => "EARTH-SCI",
+                    "name" => "Earth Sciences Library (Branner)"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "99c01199-b248-58a7-a452-d7219c2cb817",
+              "hrid" => "ai2800276_3_7",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105225598411",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "4",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "37144f55-afba-5af8-b9d4-0d3a412cd45c",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Non-circulating",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              "permanentLoanTypeId" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 14",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "ad35d1a4-067e-522d-99e4-5be7b1358668",
+              "hrid" => "ai2800276_1_3",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105218665789",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179 .F84 1990"
+              },
+              "copyNumber" => "2",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "8e909bd9-aa6e-50e0-9b32-d8d213d16d89",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Can circulate",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "4573e824-9273-4f13-972f-cff7bf504217",
+              "permanentLoanTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179 F84 41990 12",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "4573e824-9273-4f13-972f-cff7bf504217",
+                  "code" => "GRE-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "stackmapBaseUrl" => "https://stanford.stackmap.com/json/"
+                  },
+                  "library" => {
+                    "id" => "f6b5519e-88d9-413e-924d-9ed96255f72e",
+                    "code" => "GREEN",
+                    "name" => "Green Library"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "be2de21c-e500-5334-862a-e22fcc9d2776",
+              "hrid" => "ai2800276_3_5",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105226157456",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "3",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "37144f55-afba-5af8-b9d4-0d3a412cd45c",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Non-circulating",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              "permanentLoanTypeId" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 13",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "db5de9be-8e47-540a-b9ce-1f0940e21169",
+              "hrid" => "ai2800276_2_3",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105226146277",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "2",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "c51c74d4-8a6f-52f2-a1c7-006fd0af7734",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Can circulate",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+              "permanentLoanTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 12",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "13c2ee3e-5d88-453e-bb64-890e2936bebf",
+                  "code" => "EAR-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {},
+                  "library" => {
+                    "id" => "96630997-201d-49b3-b8d5-e4ba43a6cde8",
+                    "code" => "EARTH-SCI",
+                    "name" => "Earth Sciences Library (Branner)"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "dda764bf-b634-5253-a1b8-00abdc7cd60a",
+              "hrid" => "ai2800276_3_1",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105225598403",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "1",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "37144f55-afba-5af8-b9d4-0d3a412cd45c",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Non-circulating",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              "permanentLoanTypeId" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 11",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "df0d7b8b-23f8-50a5-97d0-d6ed95173eac",
+              "hrid" => "ai2800276_3_3",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105225598080",
+              "request" => nil,
+              _version: 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-08-21T04:16:06.255Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "copyNumber" => "2",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "37144f55-afba-5af8-b9d4-0d3a412cd45c",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Non-circulating",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              "permanentLoanTypeId" => "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179.5 F84 41990 12",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179.5 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            },
+            {
+              "id" => "e4cdaaa5-9ed2-57b3-aede-ba9f69aa9f23",
+              "hrid" => "ai2800276_1_1",
+              "notes" => [],
+              "status" => "Available",
+              "barcode" => "36105005105536",
+              "request" => nil,
+              _version: 2,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:16:06.255Z",
+                "updatedDate" => "2023-09-29T20:49:04.124Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "formerIds" => [],
+              "callNumber" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "typeName" => "Library of Congress classification",
+                "callNumber" => "E179 .F84 1990"
+              },
+              "copyNumber" => "1",
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "numberOfPieces" => "1",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "8e909bd9-aa6e-50e0-9b32-d8d213d16d89",
+              discoverySuppress: false,
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Can circulate",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "4573e824-9273-4f13-972f-cff7bf504217",
+              "permanentLoanTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+              suppressFromDiscovery: false,
+              "effectiveShelvingOrder" => "E 3179 F84 41990 11",
+              "effectiveCallNumberComponents" => {
+                "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "callNumber" => "E179 .F84 1990"
+              },
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "4573e824-9273-4f13-972f-cff7bf504217",
+                  "code" => "GRE-STACKS",
+                  "name" => "Stacks",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "stackmapBaseUrl" => "https://stanford.stackmap.com/json/"
+                  },
+                  "library" => {
+                    "id" => "f6b5519e-88d9-413e-924d-9ed96255f72e",
+                    "code" => "GREEN",
+                    "name" => "Green Library"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              },
+              "courses" => []
+            }
+          ]
+        }
+      ]
+    end
+
+    it 'has three tables' do
+      # within('table:first-of-type do # https://github.com/ViewComponent/view_component/issues/1910
+      expect(page).to have_content '36105218665789'
+      expect(page).to have_content '36105005105536'
+      # end
+      # within('table:nth-of-type(2)') do # https://github.com/ViewComponent/view_component/issues/1910
+      expect(page).to have_content '36105225598411'
+      expect(page).to have_content '36105225598403'
+      expect(page).to have_content '36105225598080'
+      expect(page).to have_content '36105226157456'
+      # end
+
+      # within('table:nth-of-type(3)') do # https://github.com/ViewComponent/view_component/issues/1910
+      expect(page).to have_content '36105223688552'
+      expect(page).to have_content '36105226146277'
+      expect(page).to have_content '36105226059181'
+      # end
+    end
+  end
+
+  context "when the record has no items" do
+    let(:holdings_json_struct) do
+      [
+        {
+          "holdings" => [
+            {
+              "id" => "37144f55-afba-5af8-b9d4-0d3a412cd45c",
+              "hrid" => "ah2800276_3",
+              "notes" => [],
+              "_version" => 1,
+              "metadata" => {
+                "createdDate" => "2023-08-21T04:14:38.544Z",
+                "updatedDate" => "2023-08-21T04:14:38.544Z",
+                "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+                "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+              },
+              "sourceId" => "f32d531e-df79-46b3-8932-cdd35f7a2264",
+              "boundWith" => nil,
+              "formerIds" => [],
+              "illPolicy" => nil,
+              "callNumber" => "E179.5 .F84 1990",
+              "instanceId" => "3e6a2511-5b6b-5c2e-aa91-57cd3c6f3392",
+              "holdingsType" => {
+                "id" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+                "name" => "Book",
+                "source" => "local"
+              },
+              "holdingsItems" => [],
+              "callNumberType" => {
+                "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "name" => "Library of Congress classification",
+                "source" => "folio"
+              },
+              "holdingsTypeId" => "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+              "callNumberTypeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+              "electronicAccess" => [],
+              "bareHoldingsItems" => [],
+              discoverySuppress: false,
+              "holdingsStatements" => [],
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              "permanentLocationId" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+              suppressFromDiscovery: false,
+              "holdingsStatementsForIndexes" => [],
+              "holdingsStatementsForSupplements" => [],
+              "location" => {
+                "effectiveLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                },
+                "permanentLocation" => {
+                  "id" => "a480fa70-db7a-4e4d-b4fd-ab986e388d50",
+                  "code" => "RUM-W7-STK-REF",
+                  "name" => "Map Center (W7 reference)",
+                  "campus" => {
+                    "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "code" => "SUL",
+                    "name" => "Stanford Libraries"
+                  },
+                  "details" => {
+                    "pageAeonSite" => "RUMSEY"
+                  },
+                  "library" => {
+                    "id" => "05241c96-6541-41ed-b2ad-61a126d62c2d",
+                    "code" => "RUMSEY-MAP",
+                    "name" => "David Rumsey Map Center"
+                  },
+                  "isActive" => true,
+                  "institution" => {
+                    "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code" => "SU",
+                    "name" => "Stanford University"
+                  }
+                }
+              }
+            }
+          ],
+          "items" => []
+        }
+      ]
+    end
+
+    it "doesn't render" do
+      expect(page).to have_no_selector("body")
+    end
+  end
+
+  context "when the items have no call number or barcodes (On order)" do
+    let(:holdings_json_struct) do
+      [
+        {
+          "holdings" => [
+            { "id" => "034911a3-10f0-4605-8278-7ddb498fb446",
+              "hrid" => "ho00000072427",
+              "notes" => [],
+              "_version" => 2,
+              "metadata" =>
+             { "createdDate" => "2024-02-14T20:14:01.361Z",
+               "updatedDate" => "2024-02-14T20:14:02.068Z",
+               "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+               "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766" },
+              "sourceId" => "f32d531e-df79-46b3-8932-cdd35f7a2264",
+              "boundWith" => nil,
+              "formerIds" => [],
+              "illPolicy" => nil,
+              "instanceId" => "9e6e95cd-2d8e-46fa-a05a-9721638ba530",
+              "holdingsType" => { "id" => "0c422f92-0f4d-4d32-8cbe-390ebc33a3e5", "name" => "Physical", "source" => "folio" },
+              "holdingsItems" => [],
+              "callNumberType" => nil,
+              "holdingsTypeId" => "0c422f92-0f4d-4d32-8cbe-390ebc33a3e5",
+              "electronicAccess" => [],
+              "bareHoldingsItems" => [],
+              "holdingsStatements" => [],
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+              "permanentLocationId" => "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+              "suppressFromDiscovery" => false,
+              "holdingsStatementsForIndexes" => [],
+              "holdingsStatementsForSupplements" => [],
+              "location" =>
+             { "effectiveLocation" =>
+               { "id" => "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+                 "code" => "LAW-BASEMENT",
+                 "name" => "Basement",
+                 "campus" => { "id" => "7003123d-ef65-45f6-b469-d2b9839e1bb3", "code" => "LAW", "name" => "Law School" },
+                 "details" => {},
+                 "library" => { "id" => "7e4c05e3-1ce6-427d-b9ce-03464245cd78", "code" => "LAW", "name" => "Law Library (Crown)" },
+                 "isActive" => true,
+                 "institution" => { "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929", "code" => "SU", "name" => "Stanford University" } },
+               "permanentLocation" =>
+               { "id" => "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+                 "code" => "LAW-BASEMENT",
+                 "name" => "Basement",
+                 "campus" => { "id" => "7003123d-ef65-45f6-b469-d2b9839e1bb3", "code" => "LAW", "name" => "Law School" },
+                 "details" => {},
+                 "library" => { "id" => "7e4c05e3-1ce6-427d-b9ce-03464245cd78", "code" => "LAW", "name" => "Law Library (Crown)" },
+                 "isActive" => true,
+                 "institution" => { "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929", "code" => "SU", "name" => "Stanford University" } } } }
+          ],
+          "items" => [
+            { "id" => "2597aac2-ff7c-489d-bd12-04b595e4f990",
+              "hrid" => "it00000071081",
+              "tags" => { "tagList" => [] },
+              "notes" => [],
+              "status" => "On order",
+              "request" => nil,
+              "_version" => 4,
+              "metadata" =>
+     { "createdDate" => "2024-02-14T20:14:01.404Z",
+       "updatedDate" => "2024-02-14T20:14:02.235Z",
+       "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+       "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766" },
+              "formerIds" => [],
+              "callNumber" => { "typeName" => nil },
+              "yearCaption" => [],
+              "materialType" => "book",
+              "callNumberType" => nil,
+              "materialTypeId" => "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+              "circulationNotes" => [],
+              "electronicAccess" => [],
+              "holdingsRecordId" => "034911a3-10f0-4605-8278-7ddb498fb446",
+              "itemDamagedStatus" => nil,
+              "permanentLoanType" => "Can circulate",
+              "temporaryLoanType" => nil,
+              "statisticalCodeIds" => [],
+              "administrativeNotes" => [],
+              "effectiveLocationId" => "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+              "permanentLoanTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe27",
+              "suppressFromDiscovery" => false,
+              "purchaseOrderLineIdentifier" => "8aec77f5-4a3f-40d8-9de5-bf0eae5ec510",
+              "effectiveCallNumberComponents" => {},
+              "location" =>
+     { "effectiveLocation" =>
+       { "id" => "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+         "code" => "LAW-BASEMENT",
+         "name" => "Basement",
+         "campus" => { "id" => "7003123d-ef65-45f6-b469-d2b9839e1bb3", "code" => "LAW", "name" => "Law School" },
+         "details" => {},
+         "library" => { "id" => "7e4c05e3-1ce6-427d-b9ce-03464245cd78", "code" => "LAW", "name" => "Law Library (Crown)" },
+         "isActive" => true,
+         "institution" => { "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929", "code" => "SU", "name" => "Stanford University" } } },
+              "courses" => [] }
+          ]
+        }
+      ]
+    end
+
+    it "has replacement text" do
+      expect(page).to have_content 'No call number'
+      expect(page).to have_content 'No barcode'
+    end
+  end
+end

--- a/spec/features/blacklight_customizations/librarian_view_spec.rb
+++ b/spec/features/blacklight_customizations/librarian_view_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Librarian View Customization", :js do
 
     expect(page).to have_css('.modal-title', text: "Librarian View", visible: true)
 
+    find('details:first-of-type > summary').click
     within("#marc_view") do
       expect(page).to have_css(".field", text: /Some intersting papers/)
     end

--- a/spec/features/brief_view_spec.rb
+++ b/spec/features/brief_view_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "Brief View" do
       expect(page).to have_css(".brief-document button.btn-preview", text: "Preview")
       expect(page).to have_css("form.bookmark-toggle label.toggle-bookmark", text: "Select")
     end
-    within '[data-preview-brief-url-value="/preview/10"]' do
-      expect(page).to have_css('.brief-document ul li', text: 'Green Library : Stacks : HF1604 .G368 2024')
-      expect(page).to have_css('.brief-document ul li', text: 'Engineering Library (Terman) : Current periodicals : (no call number)')
-      expect(page).to have_css('.brief-document ul li', text: 'Engineering Library (Terman) : Stacks : CBA')
+    within '[data-preview-brief-url-value="/preview/10"] .brief-document ul' do
+      expect(page).to have_css('li', text: 'SAL3 (off-campus storage) : Stacks : HF1604 .G368 2024')
+      expect(page).to have_css('li', text: 'Engineering Library (Terman) : Current periodicals : (no call number)')
+      expect(page).to have_css('li', text: 'Engineering Library (Terman) : Stacks : CBA')
     end
   end
 

--- a/spec/fixtures/solr_documents/10.yml
+++ b/spec/fixtures/solr_documents/10.yml
@@ -15,7 +15,8 @@ marc_json_struct: |
 genre_ssim:
   - Thesis/Dissertation
 item_display_struct:
-  - id: 0957c8b8-57c0-407b-a23e-ced89cf3f66e
+  - id: e75a4873-8899-5be8-8e1e-c2813e38fb04
+    instance_id: 19eba0e5-8bab-55f9-b799-092737ca0c86
     barcode: "123"
     library: GREEN
     home_location: GRE-STACKS
@@ -24,7 +25,7 @@ item_display_struct:
   - id: e3cf1a84-4cf6-49c9-87cc-d53afe6b4ead
     barcode: "456"
     library: ENG
-    home_location: GRE-STACKS
+    home_location: ENG-STACKS
     callnumber: DEF
     full_shelfkey: DEF
   - id: c10082be-e7d8-4a52-899c-e67b864eceab

--- a/spec/lib/holdings/item_spec.rb
+++ b/spec/lib/holdings/item_spec.rb
@@ -13,30 +13,6 @@ RSpec.describe Holdings::Item do
   let(:methods) { [:barcode, :library, :home_location, :current_location, :type, :truncated_callnumber, :shelfkey, :reverse_shelfkey, :callnumber, :full_shelfkey, :public_note, :callnumber_type, :course_id, :reserve_desk, :loan_period] }
   let(:internet_item) { Holdings::Item.new({ library: 'SUL', home_location: 'INTERNET', shelfkey: 'abc123', reverse_shelfkey: 'xyz987', scheme: 'LC' }) }
   let(:eresv_item) { Holdings::Item.new({ library: 'SUL', home_location: 'INSTRUCTOR', current_location: 'E-RESV', shelfkey: 'abc123', reverse_shelfkey: 'xyz987', scheme: 'LC' }) }
-  let(:folio_location) {
-    Folio::Location.from_dynamic(
-      {
-        'id' => '4573e824-9273-4f13-972f-cff7bf504217',
-        'code' => 'GRE-STACKS',
-        'name' => 'Green Library Stacks',
-        'institution' => {
-          'id' => '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929',
-          'code' => 'SU',
-          'name' => 'Stanford University'
-        },
-        'campus' => {
-          'id' => 'c365047a-51f2-45ce-8601-e421ca3615c5',
-          'code' => 'SUL',
-          'name' => 'Stanford Libraries'
-        },
-        'library' => {
-          'id' => 'f6b5519e-88d9-413e-924d-9ed96255f72e',
-          'code' => 'GREEN',
-          'name' => 'Cecil H. Green'
-        }
-      }
-    )
-  }
 
   it 'should have an attribute for each piece of the item display field' do
     methods.each do |method|
@@ -213,15 +189,43 @@ RSpec.describe Holdings::Item do
 
   context 'with data from FOLIO' do
     let(:folio_item) {
-      Folio::Item.new(
-        id: '64d4220b-ebae-5fb0-971c-0f98f6d9cc93',
-        status: 'Available',
-        barcode: '36105232609540',
-        material_type: Folio::Item::MaterialType.new(id: '1a54b431-2e4f-452d-9cae-9cee66c9a892', name: 'book'),
-        permanent_loan_type: Folio::Item::LoanType.new(id: '2b94c631-fca9-4892-a730-03ee529ffe27', name: 'Can circulate'),
-        effective_location: folio_location
-      )
+      Folio::Item.from_dynamic({
+                                 'id' => '64d4220b-ebae-5fb0-971c-0f98f6d9cc93',
+                                 'status' => 'Available',
+                                 'barcode' => '36105232609540',
+                                 'materialType' => 'book',
+                                 'materialTypeId' => '1a54b431-2e4f-452d-9cae-9cee66c9a892',
+                                 'permanentLoanType' => 'Can circulate',
+                                 'permanentLoanTypeId' => '2b94c631-fca9-4892-a730-03ee529ffe27',
+                                 'callNumber' => { 'typeId' => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                                                   'typeName' => "Library of Congress classification",
+                                                   'callNumber' => "PN1995.9.M6 A76 2024" },
+                                 'location' => { 'effectiveLocation' => folio_location }
+                               })
     }
+    let(:folio_location) {
+      {
+        'id' => '4573e824-9273-4f13-972f-cff7bf504217',
+        'code' => 'GRE-STACKS',
+        'name' => 'Green Library Stacks',
+        'institution' => {
+          'id' => '8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929',
+          'code' => 'SU',
+          'name' => 'Stanford University'
+        },
+        'campus' => {
+          'id' => 'c365047a-51f2-45ce-8601-e421ca3615c5',
+          'code' => 'SUL',
+          'name' => 'Stanford Libraries'
+        },
+        'library' => {
+          'id' => 'f6b5519e-88d9-413e-924d-9ed96255f72e',
+          'code' => 'GREEN',
+          'name' => 'Cecil H. Green'
+        }
+      }
+    }
+
     let(:document) { SolrDocument.new }
 
     subject(:item) { described_class.new({ barcode: '36105232609540', library: 'GREEN', home_location: 'GRE-STACKS' }, document:) }

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Folio::Item do
-  let(:json) {
+  let(:book_json) {
     {
       'id' => '64d4220b-ebae-5fb0-971c-0f98f6d9cc93',
       'status' => 'Available',
@@ -56,18 +56,27 @@ RSpec.describe Folio::Item do
       'permanentLoanType' => 'Can circulate',
       'temporaryLoanType' => nil,
       'temporaryLoanTypeId' => nil,
-      'permanentLoanTypeId' => '2b94c631-fca9-4892-a730-03ee529ffe27'
+      'permanentLoanTypeId' => '2b94c631-fca9-4892-a730-03ee529ffe27',
+      "callNumber" => {
+        "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "typeName" => "Library of Congress classification",
+        "callNumber" => "PN1995.9.M6 A76 2024"
+      }
     }
   }
 
+  subject(:instance) { described_class.from_dynamic(json) }
+
   describe '#loan_type' do
+    let(:json) { book_json }
+
+    subject { instance.loan_type }
+
     context 'when there is a temporary loan type' do
       before do
         json['temporaryLoanType'] = 'Course reserves'
         json['temporaryLoanTypeId'] = 'e8b311a6-3b21-43f2-a269-dd9310cb2d0e'
       end
-
-      subject { described_class.from_dynamic(json).loan_type }
 
       it 'returns the temporary loan type' do
         expect(subject.name).to eq 'Course reserves'
@@ -75,11 +84,74 @@ RSpec.describe Folio::Item do
     end
 
     context 'when there is not a temporary loan type' do
-      subject { described_class.from_dynamic(json).loan_type }
-
       it 'returns the permanent loan type' do
         expect(subject.name).to eq 'Can circulate'
       end
+    end
+  end
+
+  describe '#constructed_call_number' do
+    subject { instance.constructed_call_number }
+
+    context 'with a book' do
+      let(:json) { book_json }
+
+      it { is_expected.to eq 'PN1995.9.M6 A76 2024' }
+    end
+
+    context 'with a serial' do
+      let(:json) do
+        {
+          "id" => "3ea88693-29b8-5e22-bb60-5cca36deb465",
+          "status" => "Available",
+          "barcode" => "36105235737025",
+          "callNumber" => {
+            "typeId" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "typeName" => "Library of Congress classification",
+            "callNumber" => "G155 .S38 S464c f"
+          },
+          "enumeration" => "2022/2024",
+          "materialType" => "periodical",
+          "callNumberType" => {
+            "id" => "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "name" => "Library of Congress classification",
+            "source" => "system"
+          },
+          "materialTypeId" => "d934e614-215d-4667-b231-aed97887f289",
+          'permanentLoanType' => 'Can circulate',
+          'temporaryLoanType' => nil,
+          'temporaryLoanTypeId' => nil,
+          'permanentLoanTypeId' => '2b94c631-fca9-4892-a730-03ee529ffe27',
+          "location" => {
+            "effectiveLocation" => {
+              "id" => "1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2",
+              "code" => "SAL3-STACKS",
+              "name" => "Stacks",
+              "campus" => {
+                "id" => "c365047a-51f2-45ce-8601-e421ca3615c5",
+                "code" => "SUL",
+                "name" => "Stanford Libraries"
+              },
+              "details" => {
+                "availabilityClass" => "Offsite",
+                "scanServicePointCode" => "SAL3"
+              },
+              "library" => {
+                "id" => "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
+                "code" => "SAL3",
+                "name" => "SAL3 (off-campus storage)"
+              },
+              "institution" => {
+                "id" => "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                "code" => "SU",
+                "name" => "Stanford University"
+              }
+            }
+          }
+        }
+      end
+
+      it { is_expected.to eq 'G155 .S38 S464c f 2022/2024' }
     end
   end
 end

--- a/spec/views/catalog/librarian_view.html.erb_spec.rb
+++ b/spec/views/catalog/librarian_view.html.erb_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe "catalog/librarian_view" do
       render
     end
 
-    it "should render the marc_view" do
+    it "renders the marc_view" do
       expect(rendered).to have_css('#marc_view')
-      expect(rendered).to have_css('#folio-json-view')
 
       expect(rendered).to have_content('August  2, 2022  4:01pm')
       expect(rendered).to have_content('holdings_key')


### PR DESCRIPTION
Fixes #3761 

On https://searchworks-stage.stanford.edu/view/2800276
Before:
<img width="807" alt="Screenshot 2024-02-14 at 3 15 29 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/f350c407-f876-4494-be06-4ab54e192121">

After:
<img width="811" alt="Screenshot 2024-02-14 at 3 16 36 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/a1705d26-56ca-4bfa-8d47-f460f75a334c">

After clicking items:
<img width="806" alt="Screenshot 2024-02-14 at 3 16 48 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/fae3d5e8-ca16-4649-ae2c-f2802c82d8dd">


After for https://searchworks-stage.stanford.edu/view/2279186  (no items)
<img width="813" alt="Screenshot 2024-02-14 at 3 19 37 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/039ea477-3f1e-4679-845d-5fd88ba11ca4">


After for https://searchworks-stage.stanford.edu/view/14859222 (items in a different location)
<img width="809" alt="Screenshot 2024-02-14 at 3 29 25 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/9182284e-2851-4808-b388-07d09e725bf3">


After for https://searchworks-stage.stanford.edu/view/in00000008968 (on order item)

<img width="810" alt="Screenshot 2024-02-15 at 2 17 37 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/35275a22-68db-424a-8011-dffcc1addc4f">
