### PR TITLE
Only show the MHLD latest information once

### DIFF
--- a/app/components/access_panels/library_location_component.html.erb
+++ b/app/components/access_panels/library_location_component.html.erb
@@ -5,7 +5,7 @@
   <span class="pull-right"><%= render location_request_link %></span>
 <% end %>
 <% if location.mhld.present? %>
-  <% if location.mhld.present? && location.mhld.first.latest_received %>
+  <% if location.mhld.first.latest_received %>
     <div class='mhld note-highlight'>Latest: <%= location.mhld.first.latest_received %></div>
   <% end %>
   <% location.mhld.each do |mhld| %>

--- a/app/components/access_panels/library_location_component.html.erb
+++ b/app/components/access_panels/library_location_component.html.erb
@@ -5,12 +5,12 @@
   <span class="pull-right"><%= render location_request_link %></span>
 <% end %>
 <% if location.mhld.present? %>
+  <% if location.mhld.present? && location.mhld.first.latest_received %>
+    <div class='mhld note-highlight'>Latest: <%= location.mhld.first.latest_received %></div>
+  <% end %>
   <% location.mhld.each do |mhld| %>
     <% if mhld.public_note.present? %>
       <div class='mhld'><%= mhld.public_note %></div>
-    <% end %>
-    <% if mhld.latest_received.present? %>
-      <div class='mhld note-highlight'>Latest: <%= mhld.latest_received %></div>
     <% end %>
     <% if mhld.library_has.present? %>
       <div class='mhld'>Library has: <%= mhld.library_has %></div>

--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -38,12 +38,8 @@
             <% end %>
           </th>
           <td>
-            <% if location.mhld.present? %>
-              <% location.mhld.each do |mhld| %>
-                <% if mhld.latest_received.present? %>
-                  <span class='note-highlight'>Latest: <%= mhld.latest_received %></span>
-                <% end %>
-              <% end %>
+            <% if location.mhld.present? && location.mhld.first.latest_received %>
+              <span class='note-highlight'>Latest: <%= location.mhld.first.latest_received %></span>
             <% end %>
             <%= render location_request_link unless Settings.libraries[library.code]&.suppress_location_request_link %>
           </td>

--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -271,6 +271,26 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       end
     end
 
+    context 'with multiple mhlds' do
+      before do
+        document = SolrDocument.new(
+          id: '123',
+          item_display_struct: [
+            { barcode: '123', library: 'GREEN', home_location: 'GRE-STACKS', type: 'STKS-MONO', callnumber: 'ABC 123' }
+          ],
+          mhld_display: [
+            'GREEN -|- GRE-STACKS -|- public note -|- library has -|- latest received',
+            'GREEN -|- GRE-STACKS -|- public note -|- library has2 -|- latest received'
+          ]
+        )
+        render_inline(described_class.new(document:))
+      end
+
+      it "includes the latest received information only once" do
+        expect(page).to have_css('.panel-library-location .mhld.note-highlight', text: "Latest: latest received", count: 1)
+      end
+    end
+
     context "with no matching library/location" do
       before do
         document = SolrDocument.new(

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -203,6 +203,26 @@ RSpec.describe "catalog/_index_location" do
       end
     end
 
+    context 'with multiple library has statements' do
+      before do
+        allow(view).to receive(:document).and_return(SolrDocument.new(
+          id: '123',
+          item_display_struct: [
+            { barcode: '321', library: 'GREEN', home_location: 'STACKS', callnumber: 'ABC 123' }
+          ],
+          mhld_display: [
+            'GREEN -|- STACKS -|- public note -|- library has -|- latest received',
+            'GREEN -|- STACKS -|- public note -|- library has2 -|- latest received'
+          ]
+        ))
+        render
+      end
+
+      it "includes the latest received data only once" do
+        expect(rendered).to have_css('tbody tr .note-highlight', text: "Latest: latest received", count: 1)
+      end
+    end
+
     describe "that has no matching library/location" do
       before do
         allow(view).to receive(:document).and_return(SolrDocument.new(


### PR DESCRIPTION
Fixes #3775. Future work probably includes refactoring the indexed data (https://github.com/sul-dlss/searchworks_traject_indexer/issues/857) once we better understand what to display.

![Screenshot 2024-02-14 at 11 48 54](https://github.com/sul-dlss/SearchWorks/assets/111218/c800e181-73fe-4547-821e-e2bd647b3b54)
