### PR TITLE
don't update live look up status if there is an avaliability class

### DIFF
--- a/app/components/access_panels/location_item_component.html.erb
+++ b/app/components/access_panels/location_item_component.html.erb
@@ -10,7 +10,7 @@
     </td>
   <% end %>
   <% if render_item_details? %>
-    <td class="item-availability" data-live-lookup-id="<%= item.live_lookup_instance_id %>" data-status-target=".availability-icon" data-item-id="<%= item.live_lookup_item_id %>" <%= "data-request-url='#{helpers.request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if render_real_time_availability_request_link? %>>
+    <td class="item-availability" data-live-lookup-id="<%= item.live_lookup_instance_id %>" data-status-target=".availability-icon" data-update-status="<%= !has_avaliability_class? %>" data-item-id="<%= item.live_lookup_item_id %>" <%= "data-request-url='#{helpers.request_url(document, library: item.library, location: item.home_location, barcode: item.barcode)}'".html_safe if render_real_time_availability_request_link? %>>
       <span class="availability-icon-wrapper">
         <i class="availability-icon <%= item.status.availability_class %>"></i>
         <span data-available-text="<%= t('searchworks.availability.available') %>" data-unavailable-text="<%= t('searchworks.availability.unavailable') %>" class='status-text'>

--- a/app/components/access_panels/location_item_component.rb
+++ b/app/components/access_panels/location_item_component.rb
@@ -18,9 +18,13 @@ module AccessPanels
     end
 
     def current_location_text
-      return if item.effective_location&.details&.key?('availabilityClass') || item.effective_location&.details&.key?('searchworksTreatTemporaryLocationAsPermanentLocation')
+      return if has_avaliability_class? || item.effective_location&.details&.key?('searchworksTreatTemporaryLocationAsPermanentLocation')
 
       item.current_location.name
+    end
+
+    def has_avaliability_class?
+      item.effective_location&.details&.key?('availabilityClass')
     end
 
     def render_item_details?

--- a/app/javascript/controllers/live_lookup_controller.js
+++ b/app/javascript/controllers/live_lookup_controller.js
@@ -18,13 +18,16 @@ export default class extends Controller {
       const target = $(dom_item.data('status-target'), dom_item)
       const current_location = $('.current-location', dom_item)
       const status_text = target.next('.status-text')
+      const update_status = $(dom_item).data('update-status')
 
-      if (live_data.status){
-        status_text.html(live_data.status)
-      }
+      if (update_status) {
+        if (live_data.status){
+          status_text.html(live_data.status)
+        }
 
-      if (live_data.due_date) {
-        current_location.append(`Due ${live_data.due_date}`);
+        if (live_data.due_date) {
+          current_location.append(`Due ${live_data.due_date}`);
+        }
       }
 
       if (!live_data.is_available && (target.hasClass('unknown') || target.hasClass('deliver-from-offsite')) ) {


### PR DESCRIPTION
Based on Sarah's comments in #1026

Doesn't allow updating of status if there is an availability class. Still allows for live requests to form.

Not sure if this should be a separate PR, but since it is reliant on [1026-legacy-symphony-codes](https://github.com/sul-dlss/SearchWorks/tree/1026-legacy-symphony-codes) I am showing the difference between both branches.