### PR TITLE
Don't underline the bookmark checkbox widget

### DIFF
--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -33,10 +33,6 @@ $btn-preview-border: darken($sul-btn-preview-bg, 9.8%);
     color: $btn-sul-toolbar-bar-color;
     border-bottom: none;
   }
-
-  &:hover, &:focus, &:active {
-    text-decoration: underline;
-  }
 }
 
 a.btn-sul-toolbar {

--- a/app/assets/stylesheets/modules/sul-toolbar.scss
+++ b/app/assets/stylesheets/modules/sul-toolbar.scss
@@ -10,4 +10,10 @@
     padding-left: 5px;
     padding-right: 10px;
   }
+
+  a, .dropdown-toggle {
+    &:hover, &:focus, &:active {
+      text-decoration: underline;
+    }
+  }
 }

--- a/app/components/view_type_dropdown_component.html.erb
+++ b/app/components/view_type_dropdown_component.html.erb
@@ -1,6 +1,6 @@
 <div class="view-type">
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
-  <div id="view-type-dropdown" class="btn-group">
+  <div id="view-type-dropdown" class="btn-group dropdown">
     <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <span class="d-none d-lg-inline">
         <%= active_icon %>

--- a/app/views/article_selections/_tool_dropdown.html.erb
+++ b/app/views/article_selections/_tool_dropdown.html.erb
@@ -1,5 +1,5 @@
 <span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
-<div id="tools-dropdown" class="btn-group">
+<div id="tools-dropdown" class="btn-group dropdown">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@bookmarks)).html_safe %>
   </button>

--- a/app/views/bookmarks/_tool_dropdown.html.erb
+++ b/app/views/bookmarks/_tool_dropdown.html.erb
@@ -1,5 +1,5 @@
 <span class="sr-only">Send current page to text, email, RefWorks, EndNote, or printer</span>
-<div id="tools-dropdown" class="btn-group">
+<div id="tools-dropdown" class="btn-group dropdown">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <%= t('blacklight.tools.send_entries', current_range: current_entries_info(@response)).html_safe %>
   </button>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,5 +1,5 @@
 <% if show_sort_and_per_page? and !active_sort_fields.blank? %>
-  <div id="sort-dropdown" class="btn-group">
+  <div id="sort-dropdown" class="btn-group dropdown">
     <button type="button" class="btn btn-sul-toolbar dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <%= t('blacklight.search.sort.label_html', :field =>current_sort_field.label).html_safe %>
     </button>


### PR DESCRIPTION
Or the select all widget. This makes the styles consistent across the search results and display page. Ref https://github.com/sul-dlss/SearchWorks/pull/3823\#issuecomment-1946361223

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
