### PR TITLE
Fix background for dropdown on small screens

### DIFF
--- a/app/assets/stylesheets/modules/record-toolbar.scss
+++ b/app/assets/stylesheets/modules/record-toolbar.scss
@@ -86,10 +86,17 @@ div.record-toolbar > div > div > ul > li:nth-child(3) > form > div > label {
       overflow-x: hidden;
     }
 
-    .navbar-nav .open .dropdown-menu > .dropdown-item {
-      color: $white;
-      &:hover, &:focus {
-        text-decoration: underline;
+    .navbar-nav .show .dropdown-menu {
+      background-color: $legacy-toolbar;
+      border: none;
+
+      .dropdown-item {
+        color: $white;
+
+        &:hover, &:focus {
+          text-decoration: underline;
+          background-color: transparent;
+        }
       }
     }
 


### PR DESCRIPTION
I believe this was broken in the BS4 upgrade

before
<img width="732" alt="Screenshot 2024-02-16 at 11 23 15 AM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/f5ad553f-7ff8-4b41-9730-f296d0ea24eb">


after
<img width="727" alt="Screenshot 2024-02-16 at 11 22 48 AM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/4066c5af-4409-4aa5-8894-41e5c8593f6a">
