### PR TITLE
Change stackmap controls into buttons

### DIFF
--- a/app/assets/stylesheets/modules/stackmap.scss
+++ b/app/assets/stylesheets/modules/stackmap.scss
@@ -20,22 +20,8 @@
       overflow: auto;
       padding: 20px 0 10px 0;
 
-      .zoom-controls {
-        a {
-          border-bottom: 0;
-        }
-
-        .zoom-in, .zoom-out, .zoom-fit {
-          margin-right: 10px;
-        }
-      }
-
       .show-description {
         text-align: right;
-
-        a {
-          border-bottom: 0;
-        }
       }
     }
 

--- a/app/javascript/jquery.stackmap.js
+++ b/app/javascript/jquery.stackmap.js
@@ -27,7 +27,7 @@ import L from "leaflet";
         if (response.stat === "OK" && response.results.maps.length > 0) {
           plugContent(response);
         } else {
-          $container.html('').html('<p>No map available for this item</p>');
+          $container.html('<p>No map available for this item</p>');
         }
       });
 
@@ -86,10 +86,10 @@ import L from "leaflet";
       }
 
       function attachEvents(index) {
-        $container.find('.show-description a').click(function(e) {
-          var $link = $(this),
-              $textSwap = $link.find('.text-swap'),
-              $stackmap = $link.parents('.map-template'),
+        $container.find('[data-action="reveal-text-directions"]').click(function(e) {
+          var $button = $(this),
+              $textSwap = $button.find('.text-swap'),
+              $stackmap = $button.parents('.map-template'),
               $osd = $stackmap.find('.osd'),
               $textDirections = $stackmap.find('.text-directions'),
               $zoomControls = $stackmap.find('.zoom-controls');

--- a/app/views/catalog/_stackmap_link.html.erb
+++ b/app/views/catalog/_stackmap_link.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <% if stackmapable %>
-  <%= link_to t('blacklight.tools.find_it').html_safe, stackmap_link(document,location), { :data => { blacklight_modal: "trigger" }, :class => "btn btn-xs stackmap-find-it" } %>
+  <%= link_to t('blacklight.tools.find_it_html'), stackmap_link(document,location), { :data => { blacklight_modal: "trigger" }, :class => "btn btn-xs stackmap-find-it" } %>
 <% end %>
 <strong class="<%=location_name_class%>">
   <% if location.location_link.present? %>

--- a/app/views/catalog/stackmap.html.erb
+++ b/app/views/catalog/stackmap.html.erb
@@ -8,12 +8,14 @@
     <div class="map-template">
       <div class="controls row">
         <div class="zoom-controls col-md-7 col-xs-6">
-          <%= link_to t('blacklight.tools.stackmap.zoom_in').html_safe, "", class: "zoom-in" %>
-          <%= link_to t('blacklight.tools.stackmap.zoom_out').html_safe, "", class: "zoom-out" %>
-          <%= link_to t('blacklight.tools.stackmap.reset_size').html_safe, "", class: "zoom-fit" %>
+          <%= button_tag t('blacklight.tools.stackmap.zoom_in_html'), class: "zoom-in btn btn-link p-sm-1" %>
+          <%= button_tag t('blacklight.tools.stackmap.zoom_out_html'), class: "zoom-out btn btn-link p-sm-1" %>
+          <%= button_tag t('blacklight.tools.stackmap.reset_size_html'), class: "zoom-fit btn btn-link p-sm-1" %>
         </div>
         <div class="show-description col-md-5 col-xs-6">
-          <%= link_to '<i class="fa fa-list"></i> <span class="text-swap">Show</span> text directions'.html_safe, "" %>
+          <%= button_tag class: 'btn btn-link p-sm-1', data: { action: "reveal-text-directions" } do %>
+            <i class="fa fa-list"></i> <span class="text-swap">Show</span> text directions
+          <% end %>
         </div>
       </div>
       <div class="osd col-md-12">

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -63,11 +63,11 @@ en:
       cite_entries: '<i class="fa fa-quote-left"></i> Cite %{current_range}'
       send_entries: '<i class=" fa fa-share-alt"></i> Send %{current_range} to'
       librarian_view: 'Librarian view'
-      find_it: '<i class="fa fa-map-marker"></i> Find it'
+      find_it_html: '<i class="fa fa-map-marker"></i> Find it'
       stackmap:
-        zoom_in: '<i class="fa fa-plus-circle"></i><span class="d-none d-sm-inline"> Zoom in</span>'
-        zoom_out: '<i class="fa fa-minus-circle"></i><span class="d-none d-sm-inline">  Zoom out</span>'
-        reset_size: '<i class="fa fa-compress"></i><span class="d-none d-sm-inline">  Reset size</span>'
+        zoom_in_html: '<i class="fa fa-plus-circle"></i><span class="d-none d-sm-inline"> Zoom in</span>'
+        zoom_out_html: '<i class="fa fa-minus-circle"></i><span class="d-none d-sm-inline">  Zoom out</span>'
+        reset_size_html: '<i class="fa fa-compress"></i><span class="d-none d-sm-inline">  Reset size</span>'
     sms:
       text:
         library_location: '%{library} - %{location}'

--- a/spec/views/catalog/stackmap.html.erb_spec.rb
+++ b/spec/views/catalog/stackmap.html.erb_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe 'catalog/stackmap' do
       expect(rendered).to have_css('span.library')
       expect(rendered).to have_css('span.floorname')
 
-      expect(rendered).to have_css('.zoom-controls a.zoom-in')
-      expect(rendered).to have_css('.zoom-controls a.zoom-out')
-      expect(rendered).to have_css('.zoom-controls a.zoom-fit')
+      expect(rendered).to have_css('.zoom-controls .zoom-in')
+      expect(rendered).to have_css('.zoom-controls .zoom-out')
+      expect(rendered).to have_css('.zoom-controls .zoom-fit')
       expect(rendered).to have_css('.controls .show-description')
 
       expect(rendered).to have_css('.map-template .osd')


### PR DESCRIPTION
Using an anchor isn't appropriate since they don't have an href.  Also increased the spacing to comply with WCAG AA recommended target size

<!-- Closes #ISSUE_NUMBER -->
<img width="807" alt="Screenshot 2024-02-16 at 12 46 39 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/6246ba73-3fb9-4d96-9dfb-0dab811c198b">

<!-- 📝 CHANGELOG update? -->
