### PR TITLE
Stop using response from SearchService#fetch

### DIFF
--- a/app/components/view_type_dropdown_component.rb
+++ b/app/components/view_type_dropdown_component.rb
@@ -10,4 +10,9 @@ class ViewTypeDropdownComponent < Blacklight::Response::ViewTypeComponent
   def active_icon
     helpers.render_view_type_group_icon(@selected)
   end
+
+  # TODO: Remove this in BL8.  See https://github.com/projectblacklight/blacklight/commit/7a7ce765e9f4bcbedc213a5ce792ea89906256af
+  def render?
+    helpers.document_index_views.many? && !@response.empty?
+  end
 end

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -34,7 +34,10 @@ class BrowseController < ApplicationController
   end
 
   def fetch_orginal_document
-    @response, @original_doc = search_service.fetch(params[:start]) if params[:start]
+    _, @original_doc = search_service.fetch(params[:start]) if params[:start]
+    # NOTE: In Blacklight 8, #fetch does not return a response object, so we stub one out to satisfy:
+    # https://github.com/projectblacklight/blacklight/blob/v7.36.2/app/helpers/blacklight/catalog_helper_behavior.rb#L292
+    @document = @original_doc
   end
 
   def fetch_browse_items

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -1,5 +1,5 @@
 <%= render(ViewTypeDropdownComponent.new(
-      response: @response,
+      response: controller_name == 'browse' ? [true] : @response, # Allows browse controller to reneder without a @response
       views: document_index_view_controls,
       search_state: search_state,
-      selected: document_index_view_type)) if show_sort_and_per_page? -%>
+      selected: document_index_view_type)) -%>


### PR DESCRIPTION
This is deprecated in Blacklight

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
