### PR TITLE
Update "at the library" and "online" view for eresources 

### DIFF
--- a/app/components/access_panels/online_component.html.erb
+++ b/app/components/access_panels/online_component.html.erb
@@ -15,6 +15,9 @@
     <% end %>
 
     <% component.with_body do %>
+      <% if (sfx_links&.any? || links.any?) && document.eresources_library_display_name %>
+        <strong> <%= document.eresources_library_display_name %> </strong>
+      <% end %>
       <% if sfx_links&.any? %>
         <% sfx_url = sfx_links.first.href %>
         <% # Intentionally not encoding sfx_url here as the URLs from the catalog appear to already be encoded %>

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -120,6 +120,20 @@ class SolrDocument
     self[:img_info] || self[:file_id] || []
   end
 
+  # Checks holdings to see if there are any physical holdings
+  # If there aren't and the library isn't sul, return the library name
+  def eresources_library_display_name
+    library = holdings.libraries&.first
+    return unless library
+
+    has_physical_copies = holdings.libraries.any?(&:present?)
+    return if has_physical_copies
+
+    unless library.code == 'SUL'
+      library.name
+    end
+  end
+
   concerning :MarcOrganizationAndArrangement do
     def organization_and_arrangement
       @organization_and_arrangement ||= OrganizationAndArrangement.new(self)

--- a/app/views/catalog/_index_online_section.html.erb
+++ b/app/views/catalog/_index_online_section.html.erb
@@ -9,6 +9,9 @@
   </dt>
   <dd>
     <ul class="online-links" data-behavior="truncate-results-metadata-links">
+      <% if document.preferred_online_links.present? && document.eresources_library_display_name %>
+        <strong><%= document.eresources_library_display_name %></strong>
+      <% end %>
       <% document.preferred_online_links.each do |link| %>
         <li class="<%= 'stanford-only' if link.stanford_only? %>">
           <%= link.html.html_safe %>

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -26,7 +26,7 @@ class Holdings
 
     def suppressed?
       @item_display.values.none?(&:present?) ||
-        (item_display[:library] == 'SUL' && internet_resource?)
+        internet_resource?
     end
 
     def browsable?

--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       render_inline(described_class.new(document:))
     end
 
+    it 'has solr document eresources_library_display_name of nil' do
+      expect(document.eresources_library_display_name).to be_nil
+    end
+
     it 'displays the MARC 590 as a bound with note (excluding subfield $c)' do
       expect(page).to have_css('.bound-with-note.note-highlight a', text: 'Copy 1 bound with v. 140')
       expect(page).to have_no_css('.bound-with-note.note-highlight', text: '55523 (parent record’s ckey)')

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -124,6 +124,41 @@ RSpec.describe SolrDocument do
     end
   end
 
+  describe '#eresources_library_display_name' do
+    eresource_bus_library = { id: 30, item_display_struct:
+                [{ barcode: '9102385731231', callnumber: nil, current_location: nil,
+                   effective_location_id: '43c011f3-adeb-4c49-b357-06772aff11de',
+                   full_shelfkey: nil, home_location: 'BUS-ELECTRONIC', library: 'BUSINESS',
+                   permanent_location_code: 'BUS-ELECTRONIC', scheme: 'LC', type: 'ONLINE' }] }
+    context 'when it has holdings but no physical items' do
+      let(:solr_doc) { SolrDocument.new(eresource_bus_library) }
+
+      it 'is has a eresources_library_display_name' do
+        expect(solr_doc.eresources_library_display_name).to eq('Business Library')
+      end
+    end
+
+    context 'when it is an eresource and has physical copies' do
+      physical_location_hash = eresource_bus_library.deep_dup
+      physical_location_hash[:item_display_struct].push({ barcode: 123456, home_location: 'BUS', library: 'BUSINESS',
+                                                          permanent_location_code: 'BUS' })
+      let(:physical_location_doc) { SolrDocument.new(physical_location_hash) }
+
+      it 'has an eresource and physical location' do
+        expect(physical_location_doc.eresources_library_display_name).to be_nil
+      end
+    end
+
+    context 'when there are physical items and the library is SUL' do
+      solr_info = YAML.load_file(Rails.root.join('spec/fixtures/solr_documents/13553090.yml'))
+      let(:solr_doc) { SolrDocument.new(solr_info) }
+
+      it 'does not have a location display' do
+        expect(solr_doc.eresources_library_display_name).to be_nil
+      end
+    end
+  end
+
   describe 'EdsDocument' do
     let(:eds) { SolrDocument.new(eds_title: 'yup') }
     let(:non_eds) { SolrDocument.new }


### PR DESCRIPTION
closes #3944 

If the item is an eresource only item (there are no physical holdings), "At the library" will not render. This is done by updating suppressed? to work for all internet resources not just the SUL ones.

If the  view is an eresource only item there needs to be a library display in the online section if the library is not SUL. library_display looks to see if there are libraries associated with the document, if there are it checks if the record has physical copies or is a SUL location. If it isn't it will return the location name to display in the online section. See https://github.com/sul-dlss/searchWorks/issues/3944#issuecomment-1955173750 for screenshots.

 