### PR TITLE
Display bound-with information on search results page

### DIFF
--- a/app/views/catalog/_index_location.html.erb
+++ b/app/views/catalog/_index_location.html.erb
@@ -8,7 +8,7 @@
           <th scope='col' class='col-xs-6'>Status</th>
         </tr>
       </thead>
-      <% if document.respond_to?(:to_marc) && document.bound_with_note? %>
+      <% if document.items.any?(&:bound_with?) %>
         <tbody class="bound-with-note">
           <tr>
             <th scope='col'>

--- a/spec/features/request_link_spec.rb
+++ b/spec/features/request_link_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Request Links' do
-  describe 'Hoover links' do
-    context 'in search results' do
+  context 'in search results' do
+    context 'with Hoover links' do
       it 'renders a link to the detail/record view instead of holdings' do
         visit search_catalog_path(q: '56')
 
@@ -14,7 +14,21 @@ RSpec.describe 'Request Links' do
       end
     end
 
-    context 'on the record view' do
+    context 'with a bound-with record' do
+      it 'renders a link to the detail/record view instead of holdings' do
+        visit search_catalog_path(q: '2279186')
+
+        within 'table.availability' do
+          expect(page).to have_content 'Some records bound together'
+          expect(page).to have_link 'See full record for details'
+          expect(page).to have_no_content("Request")
+        end
+      end
+    end
+  end
+
+  context 'on the record view' do
+    context 'with Hoover links' do
       it 'renders a request button at the location level' do
         visit solr_document_path '56'
 

--- a/spec/views/catalog/_index_location.html.erb_spec.rb
+++ b/spec/views/catalog/_index_location.html.erb_spec.rb
@@ -159,29 +159,6 @@ RSpec.describe "catalog/_index_location" do
     end
   end
 
-  describe "bound with" do
-    before do
-      allow(view).to receive(:document).and_return(
-        SolrDocument.new(
-          id: '123',
-          item_display_struct: [
-            { barcode: '1234', library: 'SAL3', home_location: 'SEE-OTHER', callnumber: 'ABC 123' }
-          ],
-          marc_json_struct: linked_ckey_fixture
-        )
-      )
-      render
-    end
-
-    it "should not display request links for requestable libraries" do
-      expect(rendered).to have_no_content("Request")
-    end
-    it 'displays a link to the full record' do
-      expect(rendered).to have_css 'th', text: 'Some records bound together'
-      expect(rendered).to have_css 'a[href="/view/123"]', text: 'See full record for details'
-    end
-  end
-
   describe "mhld" do
     describe "with matching library/location" do
       before do


### PR DESCRIPTION
Previously we had code for this that was never activated.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before:
<img width="521" alt="Screenshot 2024-02-21 at 10 27 31 AM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/40168ccc-b321-4c76-b49e-8cc6fd16fb4b">
After:
<img width="551" alt="Screenshot 2024-02-21 at 10 27 15 AM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/ad59b1f7-be2d-49ba-b961-157a23fe419e">
