### PR TITLE
Fix the alignment of the embed viewer

### DIFF
--- a/app/assets/stylesheets/modules/managed_purl_panel.scss
+++ b/app/assets/stylesheets/modules/managed_purl_panel.scss
@@ -54,5 +54,6 @@
 }
 
 .managed-purl-embed {
-  margin: -8px;
+  margin-bottom: 15px;
+  margin-left: -15px;
 }


### PR DESCRIPTION
... and bring a little more style parity with the single item viewer.

Before:
<img width="500" alt="Screenshot 2024-02-21 at 09 17 14" src="https://github.com/sul-dlss/SearchWorks/assets/111218/07170edd-68b2-481f-a827-befbc49593fb">

After:
<img width="500" alt="Screenshot 2024-02-21 at 09 16 40" src="https://github.com/sul-dlss/SearchWorks/assets/111218/4462d449-d518-4155-a22d-c11f95cd9028">

e.g. https://searchworks.stanford.edu/view/2472159