### PR TITLE
Remove unused as_json methods

### DIFF
--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -40,8 +40,4 @@ class Holdings
   def find_by_barcode(barcode)
     items.find { |item| item.barcode == barcode }
   end
-
-  def as_json
-    libraries.select(&:present?).map(&:as_json)
-  end
 end

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -140,21 +140,6 @@ class Holdings
       folio_item? && folio_item_circulates?
     end
 
-    def as_json(*)
-      {
-        barcode:,
-        callnumber:,
-        current_location: temporary_location.as_json,
-        temporary_location: temporary_location.as_json,
-        due_date:,
-        library:,
-        home_location:,
-        public_note:,
-        status: status.as_json,
-        type:
-      }
-    end
-
     def request_link
       @request_link ||= ItemRequestLinkComponent.new(item: self)
     end

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -76,16 +76,6 @@ class Holdings
       end
     end
 
-    def as_json
-      {
-        code:,
-        locations: locations.select(&:present?).map(&:as_json),
-        mhld: mhld.select(&:present?).map(&:as_json),
-        name:,
-        library_instructions:
-      }
-    end
-
     def config
       Settings.libraries[@code] || Settings.libraries.default
     end

--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -48,15 +48,6 @@ class Holdings
       name || @code
     end
 
-    def as_json
-      {
-        code:,
-        items: items.reject(&:suppressed?).map(&:as_json),
-        mhld: mhld&.select(&:present?)&.map(&:as_json),
-        name:
-      }
-    end
-
     private
 
     def any_items?

--- a/lib/holdings/mhld.rb
+++ b/lib/holdings/mhld.rb
@@ -30,16 +30,6 @@ class Holdings
       sanitize_mhld_data(@mhld_display[4])
     end
 
-    def as_json
-      {
-        library:,
-        location:,
-        public_note:,
-        library_has:,
-        latest_received:
-      }
-    end
-
     private
 
     def standard_or_zombie_library

--- a/lib/holdings/status.rb
+++ b/lib/holdings/status.rb
@@ -38,9 +38,5 @@ class Holdings
         'unknown'
       end
     end
-
-    def as_json(*)
-      { availability_class:, status_text: }
-    end
   end
 end

--- a/spec/lib/holdings/item_spec.rb
+++ b/spec/lib/holdings/item_spec.rb
@@ -143,33 +143,6 @@ RSpec.describe Holdings::Item do
     end
   end
 
-  describe '#as_json' do
-    let(:as_json) { Holdings::Item.new(complex_item_display).as_json }
-
-    it "should return a hash with all of the item's public reader methods" do
-      expect(as_json).to be_a Hash
-      expect(as_json[:callnumber]).to eq 'callnumber'
-    end
-
-    it 'should return an as_json hash for status' do
-      expect(as_json[:status]).to be_a Hash
-      expect(as_json[:status]).to have_key :availability_class
-      expect(as_json[:status]).to have_key :status_text
-    end
-
-    it 'should return an as_json hash for current_location' do
-      expect(as_json[:current_location]).to be_a Hash
-      expect(as_json[:current_location]).to have_key :code
-      expect(as_json[:current_location]).to have_key :name
-    end
-
-    it 'should return an as_json hash for temporary_location' do
-      expect(as_json[:temporary_location]).to be_a Hash
-      expect(as_json[:temporary_location]).to have_key :code
-      expect(as_json[:temporary_location]).to have_key :name
-    end
-  end
-
   context 'with data from FOLIO' do
     let(:folio_item) {
       Folio::Item.from_dynamic({

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -130,30 +130,4 @@ RSpec.describe Holdings::Library do
       expect(zombie).not_to be_holding_library
     end
   end
-
-  describe '#as_json' do
-    let(:callnumbers) do
-      [
-        Holdings::Item.new({ barcode: 'barcode', library: 'library', home_location: 'home_location', temporary_location_code: 'temporary_location_code', type: 'type', truncated_callnumber: 'truncated_callnumber', shelfkey: 'shelfkey', reverse_shelfkey: 'reverse_shelfkey', callnumber: 'callnumber', full_shelfkey: 'full_shelfkey',
-                             public_note: 'public_note', callnumber_type: 'callnumber_type' }),
-        Holdings::Item.new({ barcode: 'barcode2', library: 'library', home_location: 'home_location2', temporary_location_code: 'temporary_location_code', type: 'type', truncated_callnumber: 'truncated_callnumber', shelfkey: 'shelfkey', reverse_shelfkey: 'reverse_shelfkey', callnumber: 'callnumber', full_shelfkey: 'full_shelfkey',
-                             public_note: 'public_note', callnumber_type: 'callnumber_type' }),
-        Holdings::Item.new({ barcode: 'barcode3', library: 'library', home_location: 'home_location3', temporary_location_code: 'temporary_location_code', type: 'type', truncated_callnumber: 'truncated_callnumber', shelfkey: 'shelfkey', reverse_shelfkey: 'reverse_shelfkey', callnumber: 'callnumber', full_shelfkey: 'full_shelfkey',
-                             public_note: 'public_note', callnumber_type: 'callnumber_type' })
-      ]
-    end
-    let(:as_json) { Holdings::Library.new('GREEN', callnumbers).as_json }
-
-    it 'should return a hash with all of the libraries public reader methods' do
-      expect(as_json).to be_a Hash
-      expect(as_json[:code]).to eq 'GREEN'
-      expect(as_json[:name]).to eq 'Green Library'
-    end
-    it 'shuold return an array of locations' do
-      expect(as_json[:locations]).to be_a Array
-      expect(as_json[:locations].length).to eq 3
-      expect(as_json[:locations].first).to be_a Hash
-      expect(as_json[:locations].first[:code]).to eq 'home_location'
-    end
-  end
 end

--- a/spec/lib/holdings/location_spec.rb
+++ b/spec/lib/holdings/location_spec.rb
@@ -149,26 +149,6 @@ RSpec.describe Holdings::Location do
     end
   end
 
-  describe '#as_json' do
-    let(:callnumbers) { [
-      Holdings::Item.new({ barcode: 'barcode1', library: 'GREEN', home_location: 'GRE-STACKS', lopped_callnumber: 'ABC 321', shelfkey: 'ABC+321', reverse_shelfkey: 'CBA321', callnumber: 'ABC 321', full_shelfkey: '3' }),
-      Holdings::Item.new({ barcode: 'barcode2', library: 'GREEN', home_location: 'GRE-STACKS', lopped_callnumber: 'ABC 210', shelfkey: 'ABC+210', reverse_shelfkey: 'CBA210', callnumber: 'ABC 210', full_shelfkey: '2' }),
-      Holdings::Item.new({ barcode: 'barcode3', library: 'GREEN', home_location: 'GRE-STACKS', lopped_callnumber: 'ABC 100', shelfkey: 'ABC+100', reverse_shelfkey: 'CBA100', callnumber: 'ABC 100', full_shelfkey: '1' })
-    ] }
-
-    subject(:as_json) { described_class.new('GRE-STACKS', callnumbers).as_json }
-
-    it 'returns a hash with all of the callnumbers public reader methods' do
-      expect(as_json).to be_a Hash
-      expect(as_json[:code]).to eq 'GRE-STACKS'
-      expect(as_json[:name]).to eq 'Stacks'
-      expect(as_json[:items]).to be_a Array
-      expect(as_json[:items].length).to eq 3
-      expect(as_json[:items].first).to be_a Hash
-      expect(as_json[:items].first[:library]).to eq 'GREEN'
-    end
-  end
-
   context 'with a location that has a stackmap api url' do
     subject { described_class.new("GRE-STACKS") }
 

--- a/spec/lib/holdings/mhld_spec.rb
+++ b/spec/lib/holdings/mhld_spec.rb
@@ -56,15 +56,4 @@ RSpec.describe Holdings::MHLD do
       expect(Holdings::MHLD.new(mhld)).to be_present
     end
   end
-
-  describe '#as_json' do
-    let(:as_json) { Holdings::MHLD.new(mhld_display).as_json }
-
-    it 'should return a json hash' do
-      expect(as_json).to be_a Hash
-      expect(as_json[:library]).to eq 'GREEN'
-      expect(as_json[:location]).to eq 'STACKS'
-      expect(as_json[:library_has]).to eq 'mhld library has'
-    end
-  end
 end

--- a/spec/lib/holdings/status_spec.rb
+++ b/spec/lib/holdings/status_spec.rb
@@ -3,15 +3,6 @@ require 'rails_helper'
 RSpec.describe Holdings::Status do
   let(:status) { Holdings::Status.new(OpenStruct.new) }
 
-  describe '#as_json' do
-    let(:as_json) { status.as_json }
-
-    it 'should return a json hash with the availability class and status text' do
-      expect(as_json).to have_key :availability_class
-      expect(as_json).to have_key :status_text
-    end
-  end
-
   describe '#availability_class' do
     let(:item) do
       instance_double(Holdings::Item, folio_item?: true, folio_status: nil, effective_location:)

--- a/spec/lib/holdings_spec.rb
+++ b/spec/lib/holdings_spec.rb
@@ -147,24 +147,5 @@ RSpec.describe Holdings do
       expect(location.mhld.length).to eq 1
       expect(location.mhld.first).to be_a Holdings::MHLD
     end
-    it 'should return the appropriate json hash for library and location' do
-      mhld = holdings_doc.holdings.as_json.first[:mhld]
-      expect(mhld).to be_a Array
-      expect(mhld.first).to be_a Hash
-      expect(mhld.first[:library]).to eq 'GREEN'
-      expect(mhld.first[:location]).to eq 'STACKS'
-      expect(holdings_doc.holdings.as_json.first[:locations].first[:mhld]).to eq mhld
-    end
-  end
-
-  describe '#as_json' do
-    let(:as_json) { complex_holdings.as_json }
-
-    it 'should retun the array of libraries' do
-      expect(as_json).to be_a Array
-      expect(as_json.length).to eq 2
-      expect(as_json.first[:code]).to eq 'library'
-      expect(as_json.last[:code]).to eq 'library2'
-    end
   end
 end


### PR DESCRIPTION
We used to use these for availability in #1068, but we no longer have this approach

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
