### PR TITLE
Remove current_location code check for on-orderness

### DIFF
--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -36,8 +36,7 @@ class Holdings
     end
 
     def on_order?
-      folio_status == 'On order' ||
-        current_location.code == 'ON-ORDER'
+      folio_status == 'On order'
     end
 
     def barcode

--- a/spec/components/item_request_link_component_spec.rb
+++ b/spec/components/item_request_link_component_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe ItemRequestLinkComponent, type: :component do
     context 'on-order item' do
       let(:folio_status) { 'On order' }
       let(:allowed_request_types) { [] }
-      let(:current_location) { instance_double(Holdings::Location, code: 'ON-ORDER') }
 
       it { is_expected.to have_no_link 'Request' }
     end


### PR DESCRIPTION
Part of #3892; folio_status and the current location code are both populated consistently:
https://github.com/sul-dlss/searchworks_traject_indexer/blob/main/lib/folio_record.rb#L183-L213

