### PR TITLE
Simplify conditions for not showing the location request link

### DIFF
--- a/app/policies/location_request_link_policy.rb
+++ b/app/policies/location_request_link_policy.rb
@@ -7,7 +7,7 @@ class LocationRequestLinkPolicy
   end
 
   def show?
-    return false unless items.any? && !bound_with_or_analyzed_serial?
+    return false if items.none? || bound_with?
 
     folio_pageable?
   end
@@ -20,11 +20,9 @@ class LocationRequestLinkPolicy
 
   attr_reader :location, :library, :items
 
-  # 1. The item is "Bound-with" in folio (determined by holdingsType.name, e.g. a86041)
-  # 2. The item is a analyzed serial (determined by a SEE-OTHER folio location)
-  def bound_with_or_analyzed_serial?
-    (!folio_items? && items.first.document&.folio_holdings&.any?(&:bound_with?)) ||
-      (folio_items? && items.any? { |item| item.effective_location&.see_other? })
+  # @return [Bool] true if the item is a Bound-with child in folio
+  def bound_with?
+    items.first.document&.folio_holdings&.any?(&:bound_with?)
   end
 
   def folio_items?


### PR DESCRIPTION
We only need to look for the presence of a bound with holding to determine we shouldn't show the link

Both "bound_with" with items and "bound_with" without items can be handled in the same way. See https://searchworks.stanford.edu/view/2279186.json (no items) and https://searchworks.stanford.edu/view/396229.json (has items)

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
