### PR TITLE
Encapsulate location details

### DIFF
--- a/app/components/access_panels/location_item_component.rb
+++ b/app/components/access_panels/location_item_component.rb
@@ -18,7 +18,7 @@ module AccessPanels
     end
 
     def current_location_text
-      return if item.effective_location&.details&.key?('availabilityClass') || item.effective_location&.details&.key?('searchworksTreatTemporaryLocationAsPermanentLocation')
+      return if item.effective_location&.availability_class || item.effective_location&.treat_temporary_location_as_permanent?
 
       item.current_location.name
     end

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -57,7 +57,7 @@ module Folio
     end
 
     def location_provided_availability
-      effective_location.details['availabilityClass']
+      effective_location.availability_class
     end
 
     def loan_type

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -27,8 +27,24 @@ module Folio
       cached_location_data&.dig('name') || @name
     end
 
-    def details
-      cached_location_data&.dig('details') || {}
+    def treat_temporary_location_as_permanent?
+      details.key?('searchworksTreatTemporaryLocationAsPermanentLocation')
+    end
+
+    def in_process_non_requestable?
+      availability_class == 'In_process_non_requestable'
+    end
+
+    def availability_class
+      details['availabilityClass']
+    end
+
+    def page_mediation_group_key
+      details['pageMediationGroupKey']
+    end
+
+    def page_aeon_site
+      details['pageAeonSite']
     end
 
     def self.from_dynamic(json)
@@ -42,6 +58,12 @@ module Folio
 
     def see_other?
       code.ends_with?('-SEE-OTHER')
+    end
+
+    private
+
+    def details
+      cached_location_data&.dig('details') || {}
     end
 
     def cached_location_data

--- a/app/policies/location_request_link_policy.rb
+++ b/app/policies/location_request_link_policy.rb
@@ -15,7 +15,7 @@ class LocationRequestLinkPolicy
   def aeon_pageable?
     return false if !folio_items? || folio_permanent_locations.none?
 
-    folio_permanent_locations.all? { |location| location.dig('details', 'pageAeonSite') }
+    folio_permanent_locations.all?(&:page_aeon_site)
   end
 
   private
@@ -48,14 +48,14 @@ class LocationRequestLinkPolicy
 
     items.all? do |item|
       Constants::FolioStatus::UNPAGEABLE_SPEC_COLL_STATUSES.include?(item.folio_status) ||
-        item.effective_location&.details&.dig('availabilityClass') == 'In_process_non_requestable'
+        item.effective_location&.in_process_non_requestable?
     end
   end
 
   def folio_mediated_pageable?
     return false unless folio_items? && folio_permanent_locations.any?
 
-    folio_permanent_locations.all? { |location| location.dig('details', 'pageMediationGroupKey') }
+    folio_permanent_locations.all?(&:page_mediation_group_key)
   end
 
   def folio_item_pageable?
@@ -66,6 +66,6 @@ class LocationRequestLinkPolicy
 
   # there probably is only one FOLIO location.
   def folio_permanent_locations
-    @folio_permanent_locations ||= items.filter_map(&:permanent_location).uniq(&:id).map(&:cached_location_data)
+    @folio_permanent_locations ||= items.filter_map(&:permanent_location).uniq(&:id)
   end
 end

--- a/lib/holdings/library.rb
+++ b/lib/holdings/library.rb
@@ -21,7 +21,7 @@ class Holdings
         # use the effective location's library name if we're treating it as the permanent location;
         # by the time we get here, we're already grouped by the item's library code which respects
         # the same rules
-        name = folio_item.effective_location&.library&.name if folio_item.effective_location&.details&.dig('searchworksTreatTemporaryLocationAsPermanentLocation')
+        name = folio_item.effective_location&.library&.name if folio_item.effective_location&.treat_temporary_location_as_permanent?
         # prefer the name from the cached folio data (for consistency across records)
         name ||= folio_item.permanent_location&.library&.name
         # fall back on the name from the document

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Holdings::Library do
 
     context 'with a FOLIO item in a temporary location we treat at the permanent location for display' do
       let(:items) { [instance_double(Holdings::Item, folio_item?: true, permanent_location: double(sal3:), effective_location:)] }
-      let(:effective_location) { instance_double(Folio::Location, details: { 'searchworksTreatTemporaryLocationAsPermanentLocation' => true }, library:) }
+      let(:effective_location) { instance_double(Folio::Location, treat_temporary_location_as_permanent?: true, library:) }
       let(:library) { Folio::Library.new(id: 'green', code: 'GREEN', name: 'Cecil R. Green Library') }
       let(:sal3) { Folio::Library.new(id: 'sal3', code: 'SAL3', name: 'SAL3') }
 


### PR DESCRIPTION
This ensures that only the Folio::Location class needs to understand the serialization for Location.  This keeps us from spreading the structure of the serialzied data throughout the codebase. Instead of 4 classes that depend on the structure of the data, now we have only one. 

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
