### PR TITLE
Extract `Holdings::Spine` and use it to drive browse nearby

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -45,7 +45,7 @@ class BrowseController < ApplicationController
                   NearbyOnShelf.forward(search_service:)
                 end
 
-      @items = service.items(params[:before] || params[:after])
+      @spines = service.spines(params[:before] || params[:after])
     else
 
       item = if params[:barcode]
@@ -54,7 +54,7 @@ class BrowseController < ApplicationController
                @original_doc.preferred_item
              end
 
-      @items = NearbyOnShelf.around_item(
+      @spines = NearbyOnShelf.around_item(
         item,
         search_service:
       )

--- a/app/models/nearby_on_shelf.rb
+++ b/app/models/nearby_on_shelf.rb
@@ -2,8 +2,8 @@ class NearbyOnShelf
   def self.around_item(item, search_service:, per: 24, **kwargs)
     return [] unless item
 
-    before = NearbyOnShelf.reverse(search_service:).items(item.reverse_shelfkey, per: per / 2, **kwargs)
-    current_and_after = NearbyOnShelf.forward(search_service:).items(item.shelfkey, per: per / 2, incl: true, **kwargs)
+    before = NearbyOnShelf.reverse(search_service:).spines(item.reverse_shelfkey, per: per / 2, **kwargs)
+    current_and_after = NearbyOnShelf.forward(search_service:).spines(item.shelfkey, per: per / 2, incl: true, **kwargs)
 
     # it's possible a document occurs before + after the current item, so we have to re-uniq the result
     (before + current_and_after).uniq { |x| x.document&.id }
@@ -27,9 +27,9 @@ class NearbyOnShelf
   end
 
   # given a shelfkey or reverse shelfkey (for a lopped call number), get the
-  #  text for the next window of items
-  # @return [Array<Holdings::Item>] a sorted array of items
-  def items(starting_value, per: 24, incl: false, max_docs: 100)
+  #  text for the next window of spines
+  # @return [Array<Holdings::Spine>] a sorted array of spines
+  def spines(starting_value, per: 24, incl: false, max_docs: 100)
     desired_values = fetch_next_terms('terms.limit' => per, 'terms.lower' => starting_value, 'terms.lower.incl' => incl)
 
     # Get the documents for a set of shelf keys
@@ -38,14 +38,11 @@ class NearbyOnShelf
       builder.where(field => desired_values.compact)
     end
 
-    # Get only the item objects that match the shelfkeys
-    spines = response.documents.flat_map(&:items).select do |item|
-      desired_values.include?(item.send(field))
+    spines = response.documents.flat_map(&:browseable_spines).select do |spine|
+      desired_values.include? spine.send(field)
     end
 
-    spines.uniq(&:spine_sort_key).uniq { |x| x.document&.id }.sort_by(&:spine_sort_key).each do |item|
-      item.document.preferred_item = item
-    end
+    spines.sort_by(&:sort_key)
   end
 
   private

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -17,19 +17,19 @@
 <% end %>
 
 <div id="content" class="callnumber-browse">
-  <% if @items.present? %>
+  <% if @spines.present? %>
     <div class="browse-toolbar mb-3">
-      <%= link_to(browse_index_path(browse_params.merge(before: @items.first.reverse_shelfkey, after: nil)), class: 'btn btn-secondary btn-sm') do %>
+      <%= link_to(browse_index_path(browse_params.merge(before: @spines.first.reverse_shelfkey, after: nil)), class: 'btn btn-secondary btn-sm') do %>
         <i class="fa fa-arrow-left" aria-hidden="true"></i><span class="sr-only">Previous</span>
       <% end %>
-      <%= @items.first.callnumber %> - <%= @items.last.callnumber %>
-      <%= link_to(browse_index_path(browse_params.merge(before: nil, after: @items.last.shelfkey)), class: 'btn btn-secondary btn-sm') do %>
+      <%= @spines.first.callnumber %> - <%= @spines.last.callnumber %>
+      <%= link_to(browse_index_path(browse_params.merge(before: nil, after: @spines.last.shelfkey)), class: 'btn btn-secondary btn-sm') do %>
         <i class="fa fa-arrow-right" aria-hidden="true"></i><span class="sr-only">Next</span>
       <% end %>
       <div class='pull-right'>
         <%= render 'catalog/view_type_group' %>
       </div>
     </div>
-    <%= render_document_index(@items.map(&:document)) %>
+    <%= render_document_index(@spines.map(&:document_with_preferred_item)) %>
   <% end %>
 </div>

--- a/app/views/browse/nearby.html.erb
+++ b/app/views/browse/nearby.html.erb
@@ -1,3 +1,3 @@
-  <% if @items.present? %>
-    <%= render_document_index(@items.map(&:document)) %>
+  <% if @spines.present? %>
+    <%= render_document_index(@spines.map(&:document_with_preferred_item)) %>
   <% end %>

--- a/lib/holdings/spine.rb
+++ b/lib/holdings/spine.rb
@@ -1,0 +1,50 @@
+class Holdings
+  class Spine
+    attr_reader :data, :document
+
+    def initialize(data, document:)
+      @data = data
+      @document = document
+    end
+
+    def document_with_preferred_item
+      document.with_preferred_item(item)
+    end
+
+    def item
+      return unless data[:item_id]
+
+      @item ||= document.items.find { |c| c.id == data[:item_id] }
+    end
+
+    # create sorting key for spine
+    # shelfkey asc, then by sorting title asc, then by pub date desc
+    # note: pub_date must be inverted for descending sort
+    def sort_key
+      sort_pub_date = if document[:pub_date].blank?
+                        '9999'
+                      else
+                        document[:pub_date].tr('0123456789', '9876543210')
+                      end
+
+      [
+        shelfkey,
+        document[:title_sort].to_s,
+        sort_pub_date,
+        document[:id].to_s
+      ]
+    end
+
+    def shelfkey
+      data[:shelfkey]
+    end
+
+    def reverse_shelfkey
+      data[:reverse_shelfkey]
+    end
+
+    def callnumber
+      data[:callnumber]
+    end
+  end
+end

--- a/spec/models/nearby_on_shelf_spec.rb
+++ b/spec/models/nearby_on_shelf_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe NearbyOnShelf do
   end
   let(:documents) do
     [
-      SolrDocument.new(id: '1', title_sort: '', pub_date: '', item_display_struct: [{ barcode: '000', shelfkey: 'A' }, { barcode: '001', shelfkey: 'A' }]),
-      SolrDocument.new(id: '3', title_sort: '', pub_date: '', item_display_struct: [{ barcode: '002', shelfkey: 'C' }]),
-      SolrDocument.new(id: '2', title_sort: '', pub_date: '', item_display_struct: [{ barcode: '003', shelfkey: 'NOT_RELATED' }, { barcode: '004', shelfkey: 'B' }])
+      SolrDocument.new(id: '1', title_sort: '', pub_date: '', item_display_struct: [{ id: '000', shelfkey: 'A', scheme: 'LC' }, { id: '001', shelfkey: 'A', scheme: 'LC' }]),
+      SolrDocument.new(id: '3', title_sort: '', pub_date: '', item_display_struct: [{ id: '002', shelfkey: 'C', scheme: 'LC' }]),
+      SolrDocument.new(id: '2', title_sort: '', pub_date: '', item_display_struct: [{ id: '003', shelfkey: 'NOT_RELATED', scheme: 'LC' }, { id: '004', shelfkey: 'B', scheme: 'LC' }])
     ]
   end
 
@@ -33,33 +33,33 @@ RSpec.describe NearbyOnShelf do
     allow(repository).to receive(:search).and_return(document_response)
   end
 
-  describe '#items' do
+  describe '#spines' do
     it 'grabs the next set of terms from Solr' do
-      service.items('A', incl: true, per: 3)
+      service.spines('A', incl: true, per: 3)
 
       expect(repository).to have_received(:send_and_receive).with('alphaTerms', hash_including('terms.fl' => 'shelfkey', 'terms.lower' => 'A', 'terms.limit' => 3))
     end
 
     it 'queries solr to get the documents that contain the next call numbers' do
-      service.items('A', incl: true, per: 3)
+      service.spines('A', incl: true, per: 3)
 
       expect(repository).to have_received(:search).with(have_attributes(to_h: hash_including('q' => '{!lucene}shelfkey:(A OR B OR C)')))
     end
 
     it 'de-dupes shelfkeys + documents' do
-      expect(service.items('A', incl: true, per: 3)).to have_attributes(length: 3)
+      expect(service.spines('A', incl: true, per: 3)).to have_attributes(length: 3)
     end
 
     it 'excludes call numbers that are not in the terms response' do
-      expect(service.items('A', incl: true, per: 3)).not_to include(have_attributes(shelfkey: 'NOT_RELATED'))
+      expect(service.spines('A', incl: true, per: 3)).not_to include(have_attributes(shelfkey: 'NOT_RELATED'))
     end
 
     it 'resorts the documents by their callnumber' do
-      expect(service.items('A', incl: true, per: 3).map(&:shelfkey)).to eq %w[A B C]
+      expect(service.spines('A', incl: true, per: 3).map(&:shelfkey)).to eq %w[A B C]
     end
 
     it 'set the preferred callnumber on the document so it can be used in the view' do
-      expect(service.items('A', incl: true, per: 3).map { |x| x.document.preferred_item.shelfkey }).to eq %w[A B C]
+      expect(service.spines('A', incl: true, per: 3).map { |x| x.document_with_preferred_item.preferred_item.shelfkey }).to eq %w[A B C]
     end
   end
 end


### PR DESCRIPTION
The temporary work-around can be removed after https://github.com/sul-dlss/searchworks_traject_indexer/pull/1363 is merged + reindexed.