### PR TITLE
update data-controller live-lookup to fire once per instance record

### DIFF
--- a/app/components/search_result/location_component.html.erb
+++ b/app/components/search_result/location_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm availability" data-controller="live-lookup" data-live-lookup-url-value="<%= availability_index_path %>">
+<table class="table table-sm availability">
   <caption class='sr-only'>Status of items at <%= library.name %></caption>
   <thead>
     <tr class='active'>

--- a/app/views/catalog/_accordion_section_library.html.erb
+++ b/app/views/catalog/_accordion_section_library.html.erb
@@ -16,7 +16,7 @@
         <%= snippet %>
       </span>
     </div>
-    <div class="details <%= id %>-location" aria-expanded="false">
+    <div class="details <%= id %>-location" aria-expanded="false" data-controller="live-lookup" data-live-lookup-url-value="<%= availability_index_path %>">
       <%= render :partial => "catalog/index_location", :locals => { :document => document } %>
     </div>
   </div>


### PR DESCRIPTION
Due to the data-controller="live-lookup" being in each table for each location, it would fire the live_lookup js for each library location. Since rtac looks up an instance record we only need to fire the live lookup once record. This PR moves the data-controller="live-lookup" out of the loop into a wrapper.

closes #4050 