### PR TITLE
Consolidate to one color name

### DIFF
--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -4,7 +4,7 @@ $primary: $cardinal-red;
 $secondary: $light-sandstone;
 $success: $digital-green;
 $info: $lagunita;
-$warning: $pantone-144;
+$warning: $poppy;
 $danger: $bright-red;
 
 // Body

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -19,7 +19,6 @@ $light-sandstone: #F9F6EF;
 $digital-green: #008566;
 $mostly-pure-orange: #ff8000;
 $poppy: #e98300;
-$pantone-144: #E98300;
 $public-note-yellow: #faf8d2;
 $sandstone: #d2c295;
 $stone: #544948;


### PR DESCRIPTION
We had one color defined with two separate names. We settled on Poppy as that is what is in the brand guide: https://identity.stanford.edu/design-elements/color/accent-colors/

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
