### PR TITLE
Colors should have a name not a purpose

### DIFF
--- a/app/assets/stylesheets/modules/availability.scss
+++ b/app/assets/stylesheets/modules/availability.scss
@@ -26,7 +26,7 @@
 
 .note-highlight {
   padding: 2px 5px;
-  background-color: $public-note-yellow;
+  background-color: $citrine-white;
 }
 
 .panel-library-location {

--- a/app/assets/stylesheets/modules/search-bar.scss
+++ b/app/assets/stylesheets/modules/search-bar.scss
@@ -46,7 +46,7 @@
         top: 70%;
 
         .highlight {
-          background-color: $public-note-yellow;
+          background-color: $citrine-white;
           color: $text-color;
 
           &:focus {

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -19,7 +19,7 @@ $light-sandstone: #F9F6EF;
 $digital-green: #008566;
 $mostly-pure-orange: #ff8000;
 $poppy: #e98300;
-$public-note-yellow: #faf8d2;
+$citrine-white: #faf8d2;
 $sandstone: #d2c295;
 $stone: #544948;
 $teal: #00505c;


### PR DESCRIPTION
All color variables except this one were named after the color rather than the purpose. This brings consistency to the palette.  Furthermore, this color is used for more than just a public note, so it's current name is misleading.  I found this name via https://colors.artyclick.com/color-names-dictionary/color-names/citrine-white-color

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
