### PR TITLE
Pick the representative item for browse_nearby_struct for each base c…

### DIFF
--- a/app/models/concerns/solr_holdings.rb
+++ b/app/models/concerns/solr_holdings.rb
@@ -29,7 +29,15 @@ module SolrHoldings
                              browseable_schemes = %w[LC DEWEY ALPHANUM]
                              browseable_items = items.select { |v| v.shelfkey.present? && browseable_schemes.include?(v.callnumber_type) }
 
-                             browseable_items.uniq(&:shelfkey).map do |v|
+                             representative_items = browseable_items.group_by(&:truncated_callnumber).map do |_base_call_number, items|
+                               if items.one?
+                                 items.first
+                               else
+                                 items.min_by(&:full_shelfkey)
+                               end
+                             end
+
+                             representative_items.map do |v|
                                Holdings::Spine.new({
                                                      lopped_callnumber: v.truncated_callnumber,
                                                      shelfkey: v.shelfkey,

--- a/spec/models/nearby_on_shelf_spec.rb
+++ b/spec/models/nearby_on_shelf_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe NearbyOnShelf do
   end
   let(:documents) do
     [
-      SolrDocument.new(id: '1', title_sort: '', pub_date: '', item_display_struct: [{ id: '000', shelfkey: 'A', scheme: 'LC' }, { id: '001', shelfkey: 'A', scheme: 'LC' }]),
-      SolrDocument.new(id: '3', title_sort: '', pub_date: '', item_display_struct: [{ id: '002', shelfkey: 'C', scheme: 'LC' }]),
-      SolrDocument.new(id: '2', title_sort: '', pub_date: '', item_display_struct: [{ id: '003', shelfkey: 'NOT_RELATED', scheme: 'LC' }, { id: '004', shelfkey: 'B', scheme: 'LC' }])
+      SolrDocument.new(id: '1', title_sort: '', pub_date: '', item_display_struct: [{ id: '000', lopped_callnumber: 'A', shelfkey: 'A', scheme: 'LC' }, { id: '001', lopped_callnumber: 'A', shelfkey: 'A', scheme: 'LC' }]),
+      SolrDocument.new(id: '3', title_sort: '', pub_date: '', item_display_struct: [{ id: '002', lopped_callnumber: 'C', shelfkey: 'C', scheme: 'LC' }]),
+      SolrDocument.new(id: '2', title_sort: '', pub_date: '', item_display_struct: [{ id: '003', lopped_callnumber: 'D', shelfkey: 'NOT_RELATED', scheme: 'LC' }, { id: '004', lopped_callnumber: 'B', shelfkey: 'B', scheme: 'LC' }])
     ]
   end
 


### PR DESCRIPTION
…all number

The lopped call number and shelfkey are, currently, effectively the same thing. It's probably better to use the original value instead of the transformed one, though.