### PR TITLE
Don't instantiate the long-list controller if the list is short

### DIFF
--- a/app/components/access_panels/online_component.html.erb
+++ b/app/components/access_panels/online_component.html.erb
@@ -1,3 +1,4 @@
+<% # NOTE: this is hidden if there are no links, but jquery.plug-google-content.js may unhide it %>
 <%= tag.div class: "panel-online", hidden: !links.any? do %>
   <%= render @layout.new do |component| %>
     <% component.with_header do %>

--- a/app/components/access_panels/online_link_list_component.html.erb
+++ b/app/components/access_panels/online_link_list_component.html.erb
@@ -1,4 +1,4 @@
-<ul class="links" data-controller="long-list" id="online-link-list">
+<%= tag.ul class: "links", id: "online-link-list", data: truncate? ? { controller: "long-list" } : nil do %>
   <% links.each.with_index do |link, index| %>
     <%= tag.li data: index > 5 ? { long_list_target: 'hideable' } : nil do %>
       <span class="<%= 'stanford-only' if link.stanford_only? %>">
@@ -7,7 +7,7 @@
     <% end %>
   <% end %>
 
-  <% if links.size > 5 %>
+  <% if truncate? %>
     <li>
       <button class="btn btn-secondary btn-xs" aria-expanded="false" aria-controls="online-link-list" data-action="click->long-list#expand" data-long-list-target="expandButton">show all<span class="sr-only"> online links</span></button>
       <button class="btn btn-secondary btn-xs" aria-expanded="true" aria-controls="online-link-list" data-action="click->long-list#collapse" data-long-list-target="collapseButton">show less<span class="sr-only"> online links</span></button>
@@ -15,4 +15,4 @@
   <% end %>
 
   <%= render AccessPanels::GoogleBooksPreviewComponent.new(document: document, link_text: 'Full view') %>
-</ul>
+<% end %>

--- a/app/components/access_panels/online_link_list_component.rb
+++ b/app/components/access_panels/online_link_list_component.rb
@@ -9,5 +9,9 @@ module AccessPanels
     end
 
     attr_accessor :document, :links
+
+    def truncate?
+      links.size > 5
+    end
   end
 end


### PR DESCRIPTION
This prevents the controller from raising an error because the buttons it uses aren't drawn

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->

Fixes #4071