### PR TITLE
Keep displaying 'Stanford Libraries' on the gallery view for e-resources

### DIFF
--- a/app/views/catalog/_index_header_gallery.html.erb
+++ b/app/views/catalog/_index_header_gallery.html.erb
@@ -11,6 +11,9 @@
       <% end %>
     <% elsif document.mods? %>
       <br/>Stanford Digital Repository
+    <% elsif document.preferred_online_links.present?  %>
+      eResource<br />
+      <%= document.eresources_library_display_name || 'Stanford Libraries' %>
     <% end %>
   </div>
   <h3 class="index_title">


### PR DESCRIPTION
Part of #3469