### PR TITLE
Remove test about SolrDocument from a component test

### DIFF
--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -116,10 +116,6 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       render_inline(described_class.new(document:))
     end
 
-    it 'has solr document eresources_library_display_name of nil' do
-      expect(document.eresources_library_display_name).to be_nil
-    end
-
     it 'displays the MARC 590 as a bound with note (excluding subfield $c)' do
       expect(page).to have_css('.bound-with-note.note-highlight a', text: 'Copy 1 bound with v. 140')
       expect(page).to have_no_css('.bound-with-note.note-highlight', text: '55523 (parent record’s ckey)')


### PR DESCRIPTION
This isn't an appropriate place to test this method. This was added in 6837a2206ce0d9492334659c68668a9034bae39b

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
