### PR TITLE
Use browseable_spines instead of browsable_items

### DIFF
--- a/app/views/catalog/record/_marc_metadata_sections.html.erb
+++ b/app/views/catalog/record/_marc_metadata_sections.html.erb
@@ -11,7 +11,7 @@
       contents_summary: contents_summary.present?,
       subjects: subjects.present?,
       bibliography_info: bibliography.present?,
-      browse_nearby: document.holdings.present? && document.holdings.browsable_items.present?
+      browse_nearby: document.browseable_spines.present?
     }
   }
 

--- a/app/views/catalog/record/_mods_metadata_sections.html.erb
+++ b/app/views/catalog/record/_mods_metadata_sections.html.erb
@@ -13,7 +13,7 @@
       subjects: subjects.present?,
       bibliography_info: bibliography.present?,
       access_conditions: access_conditions.present?,
-      browse_nearby: document.holdings.browsable_items.present?
+      browse_nearby: document.browseable_spines.present?
     }
   }
 %>

--- a/app/views/catalog/record/_record_metadata_default.html.erb
+++ b/app/views/catalog/record/_record_metadata_default.html.erb
@@ -13,6 +13,6 @@
   </div>
 </div>
 
-<% if document.holdings.browsable_items.present? %>
+<% if document.browseable_spines.present? %>
   <%= render 'catalog/record/callnumber_browse', document: document %>
 <% end %>

--- a/lib/holdings.rb
+++ b/lib/holdings.rb
@@ -14,10 +14,6 @@ class Holdings
     end
   end
 
-  def browsable_items
-    items.select(&:browsable?).uniq(&:truncated_callnumber)
-  end
-
   # @return [Array<Holdings::Library>] the list of libraries with holdings
   def libraries
     unless @libraries

--- a/spec/lib/holdings_spec.rb
+++ b/spec/lib/holdings_spec.rb
@@ -90,13 +90,6 @@ RSpec.describe Holdings do
     end
   end
 
-  describe "#browsable_items" do
-    it "should collapse callnumbers on the truncated callnumber" do
-      expect(complex_holdings.items.length).to eq 2
-      expect(complex_holdings.browsable_items.length).to eq 1
-    end
-  end
-
   describe "#find_by_barcode" do
     let(:found) { complex_holdings.find_by_barcode('barcode2') }
 


### PR DESCRIPTION
With #4073, we shouldn't use items to drive browse nearby.