### PR TITLE
Remove browser specific CSS for box-shadow

### DIFF
--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -71,8 +71,6 @@
     &.card {
       // A glowing border
       border: none;
-      -webkit-box-shadow: 0px 0px 10px 0px rgba(233,131,0,1);
-      -moz-box-shadow: 0px 0px 10px 0px rgba(233,131,0,1);
       box-shadow: 0px 0px 10px 0px rgba(233,131,0,1);
       position: relative;
     }

--- a/app/assets/stylesheets/modules/skip-to-nav.scss
+++ b/app/assets/stylesheets/modules/skip-to-nav.scss
@@ -25,7 +25,5 @@
       box-shadow: 0 0 6px #000000;
       padding: 6px 15px;
       margin: 0;
-      -moz-box-shadow: 0 0 6px #000000;
-      -webkit-box-shadow: 0 0 6px #000000;
     }
   }


### PR DESCRIPTION
All modern browsers support box-shadow without prefixes

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
