### PR TITLE
Rename method to showGallery as showPreview is confusing

### DIFF
--- a/app/javascript/embedded-call-number-browse.js
+++ b/app/javascript/embedded-call-number-browse.js
@@ -95,7 +95,7 @@ import PreviewContent from './preview-content'
           $galleryDoc.embedViewport.attr('aria-expanded', 'true');
           $galleryDoc.embedViewport.slideDown(function(){
             $galleryDoc.calculateDocsPerView();
-            showPreview();
+            showGallery();
           });
         } else {
           $galleryDoc.item.addClass('collapsed');
@@ -106,7 +106,7 @@ import PreviewContent from './preview-content'
         }
       }
 
-      function showPreview() {
+      function showGallery() {
         if (!$galleryDoc.hasContent()){
           PreviewContent.append($galleryDoc.url, $galleryDoc.embedContainer)
             .done(function(data){


### PR DESCRIPTION
The preview is what shows when you click the 'preview' button.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
