### PR TITLE
Remove weird counter addition.

### DIFF
--- a/app/views/catalog/_index_brief.html.erb
+++ b/app/views/catalog/_index_brief.html.erb
@@ -10,7 +10,7 @@
           <span class="document-counter">
             <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
           </span>
-          <%= link_to_document document, counter: (counter + @response.params[:start].to_i) %>
+          <%= link_to_document document, counter: %>
           <span class="main-title-date"><%= get_main_title_date(document) %></span>
         </h3>
         <% if document[:vern_title_display].present? %>


### PR DESCRIPTION
This was added in https://github.com/sul-dlss/SearchWorks/commit/2bd9c1fece4b498a358c742b4341b34a814205e1\#diff-9af593bf6c40bab14a30c549ca631cbbcb51fdb139f6c0ea164409718ac1730e but it's unclear why. We don't do this in any other usage of link_to_document with counter.

fixes #4103

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
