### PR TITLE
Remove aria-expanded from callnumber browse

### DIFF
--- a/app/views/catalog/record/_callnumber_browse.html.erb
+++ b/app/views/catalog/record/_callnumber_browse.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <% spines.each_with_index do |item, index| %>
-    <div id="callnumber-<%=index%>" class="embed-callnumber-browse-container" aria-expanded="true" style="<%= 'display:none;' unless index == 0 %>">
+    <div id="callnumber-<%=index%>" class="embed-callnumber-browse-container" style="<%= 'display:none;' unless index == 0 %>">
       <div class="embedded-items"><div class="gallery"></div></div>
     </div>
   <% end %>


### PR DESCRIPTION
aria-expanded is supposed to go on the focusable interactive control that displays the collapsable section, not the collapsable section itself.

See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded Fixes #4087

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
