### PR TITLE
Define gtag as a global function

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -1,6 +1,6 @@
 // gtag initial setup
 window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
+window.gtag = function() { dataLayer.push(arguments); }
 gtag('js', new Date());
 
 


### PR DESCRIPTION
This is how it worked before we added rollup.  We noticed that events are being drastically undercounted, so this may fix the problem.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
