### PR TITLE
Don't render request links for item statuses that FOLIO doesn't allow requests

### DIFF
--- a/app/policies/location_request_link_policy.rb
+++ b/app/policies/location_request_link_policy.rb
@@ -47,11 +47,11 @@ class LocationRequestLinkPolicy
 
   # Special cases where we don't allow requests for special collections items in certain statuses
   def folio_disabled_status_location?
-    return false unless library_code == 'SPEC-COLL'
-
     items.all? do |item|
-      Constants::FolioStatus::UNPAGEABLE_SPEC_COLL_STATUSES.include?(item.folio_status) ||
-        item.effective_location&.details&.dig('availabilityClass') == 'In_process_non_requestable'
+      (library_code == 'SPEC-COLL' &&
+        (Constants::FolioStatus::UNPAGEABLE_SPEC_COLL_STATUSES.include?(item.folio_status) ||
+        item.effective_location&.details&.dig('availabilityClass') == 'In_process_non_requestable')) ||
+        Settings.folio_unrequestable_statuses.include?(item.folio_status)
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -247,3 +247,16 @@ folio_hold_recall_statuses:
   - On order
   - In process
   - Restricted
+
+folio_unrequestable_statuses:
+  - Aged to lost
+  - Claims returned
+  - Declared
+  - In process (not requestable)
+  - Intellectual item
+  - Long missing
+  - Lost and paid
+  - Order closed
+  - Unavailable
+  - Unknown
+  - Withdrawn

--- a/spec/components/location_request_link_component_spec.rb
+++ b/spec/components/location_request_link_component_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe LocationRequestLinkComponent, type: :component do
       end
 
       it { expect(page).to have_link 'Request', href: 'https://host.example.com/requests/new?item_id=12345&origin=SAL3&origin_location=SAL3-STACKS' }
+
+      context 'with an aged to lost status' do
+        let(:folio_status) { 'Aged to lost' }
+
+        it { expect(page).to have_no_link }
+      end
     end
 
     context 'in a mediated location' do


### PR DESCRIPTION
When all the items in a location have an unrequestable item status, we can't place the request in FOLIO.