### PR TITLE
Remove aria-expanded from location accordion

### DIFF
--- a/app/views/catalog/_accordion_section_library.html.erb
+++ b/app/views/catalog/_accordion_section_library.html.erb
@@ -13,7 +13,7 @@
         <%= snippet %>
       </span>
     </div>
-    <div class="details <%= id %>-location" aria-expanded="false" data-controller="live-lookup" data-live-lookup-url-value="<%= availability_index_path %>">
+    <div class="details <%= id %>-location" data-controller="live-lookup" data-live-lookup-url-value="<%= availability_index_path %>">
       <% if document.holdings.present? %>
         <% document.holdings.libraries.select(&:present?).each do |library| %>
           <%= render SearchResult::LocationComponent.new(library:, document:) %>

--- a/spec/views/catalog/_accordion_section_library.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_library.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "catalog/_accordion_section_library" do
       expect(rendered).to have_css('.accordion-section.location')
       expect(rendered).to have_css('.accordion-section.location button.header[aria-expanded="false"]', text: "Check availability")
       expect(rendered).to have_css('.accordion-section.location span.snippet', text: "Green Library")
-      expect(rendered).to have_css('.accordion-section .details[aria-expanded="false"]')
+      expect(rendered).to have_css('.accordion-section .details')
       expect(rendered).to have_css('.accordion-section .details tbody tr', count: 2)
       expect(rendered).to have_css('.accordion-section .details tbody tr th', text: /Stacks/)
       expect(rendered).to have_css('.accordion-section .details tbody tr td', text: /ABC 123/)


### PR DESCRIPTION
aria-expanded is supposed to go on the focusable interactive control that displays the collapsable section, not the collapsable section itself.

See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded

<!-- Closes #ISSUE_NUMBER -->
<img width="863" alt="Screenshot 2024-03-08 at 3 07 36 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/5190789f-aa49-43f7-831d-f90765e2b826">

<!-- 📝 CHANGELOG update? -->
