### PR TITLE
onerror is now enableUncaught

### DIFF
--- a/app/views/layouts/searchworks.html.erb
+++ b/app/views/layouts/searchworks.html.erb
@@ -39,7 +39,7 @@
         apiKey: '<%= Honeybadger.config.get(:api_key) %>',
         environment: '<%= Honeybadger.config.get(:env) %>',
         debug: false,
-        onerror: true,
+        enableUncaught: true,
         ignorePatterns: [
           /reCAPTCHA placeholder element must be empty/i,
           /Undefined variable: MutationObserver/i, // Seems to only come from Opera Mini. Not in our codebase.


### PR DESCRIPTION
This was a change made in v3

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
