### PR TITLE
Add autocomplete hints to the feedback form

### DIFF
--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -35,13 +35,13 @@
     <div class="form-group row">
       <%= f.label(:name, 'Your name', class:"col-sm-3 col-form-label text-right") %>
       <div class="col-sm-9">
-        <%= f.text_field :name, value: "", class:"form-control", required: true %>
+        <%= f.text_field :name, value: "", class:"form-control", autocomplete: "name", required: true %>
       </div>
     </div>
     <div class="form-group row">
       <%= f.label(:to, 'Your email', class:"col-sm-3 col-form-label text-right") %>
       <div class="col-sm-9">
-        <%= f.email_field :to, value: "", class:"form-control", required: true %>
+        <%= f.email_field :to, value: "", class:"form-control", autocomplete: "email", required: true %>
       </div>
     </div>
 


### PR DESCRIPTION
This improves the user experience as this lets the browser fill in some fields for the user. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete\#values

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
