### PR TITLE
Generate a button rather than transform link into button

### DIFF
--- a/app/javascript/feedback_form.js
+++ b/app/javascript/feedback_form.js
@@ -79,33 +79,11 @@ Blacklight.onLoad(function(){
       });
     }
 
-    function replaceLink(form, link) {
-      var attrs = {};
-      $.each(link[0].attributes, function(idx, attr) {
-          attrs[attr.nodeName] = attr.value;
-      });
-      attrs.class = 'cancel-link btn btn-link';
-
-      // Replace the cancel link with a button
-      link.replaceWith(function() {
-        return $('<button />', attrs).append($(this).contents());
-      });
-
-      // Cancel link should not submit form
-      form.find('button.cancel-link').on('click', function(e){
-        e.preventDefault();
-      });
-    }
-
     Plugin.prototype = {
 
         init: function() {
           var $el = $(this.element);
           var $form = $($el).find('form');
-          var $cancelLink = $el.find(".cancel-link");
-
-          // Replace "Cancel" link with link styled button
-          replaceLink($el, $cancelLink);
 
           //Add listener for form submit
           submitListener($el, $form);

--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -54,7 +54,7 @@
     <div class="form-group row">
       <div class="offset-sm-3 col-sm-9">
         <button type="submit" class="btn btn-primary">Send</button>
-        <%= link_to "Cancel", :back, class:"cancel-link", data: { toggle: 'collapse', target: target } %>
+        <button type="button" class="cancel-link btn btn-link" data-toggle="collapse" data-target="<%= target %>">Cancel</button>
       </div>
     </div>
   </div>

--- a/spec/features/connection_form_spec.rb
+++ b/spec/features/connection_form_spec.rb
@@ -40,7 +40,6 @@ RSpec.feature 'Connection form (no js)' do
   scenario 'connection form should be shown filled out and submitted' do
     find('.connection-problem').click
     expect(page).to have_css('#connection-form', visible: true)
-    expect(page).to have_css('a', text: 'Cancel')
     within 'form.feedback-form' do
       fill_in('resource_name', with: 'Resource name')
       fill_in('problem_url', with: 'http://www.example.com/yolo')

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature "Feedback form (no js)" do
     click_link "Feedback"
     expect(page).to have_css("#feedback-form", visible: true)
     expect(page).to have_css("#feedback_message", count: 1)
-    expect(page).to have_css("a", text: "Cancel")
     within "form.feedback-form" do
       fill_in("message", with: "This is only a test")
       fill_in("name", with: "Ronald McDonald")


### PR DESCRIPTION
This eliminates unnecessary code. My initial thought was that this supported a non-javascript use case, but the code before also required javascript as it did:

```html
        <a class="cancel-link" data-toggle="collapse" data-target="#feedback-form" href="javascript:history.back()">Cancel</a>
```

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
