### PR TITLE
Remove tests for no javascript feedback

### DIFF
--- a/spec/features/connection_form_spec.rb
+++ b/spec/features/connection_form_spec.rb
@@ -30,28 +30,3 @@ RSpec.feature 'Connection form (js)', :js do
     )
   end
 end
-
-RSpec.feature 'Connection form (no js)' do
-  before do
-    stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
-    visit articles_path
-  end
-
-  scenario 'connection form should be shown filled out and submitted' do
-    find('.connection-problem').click
-    expect(page).to have_css('#connection-form', visible: true)
-    expect(page).to have_css('a', text: 'Cancel')
-    within 'form.feedback-form' do
-      fill_in('resource_name', with: 'Resource name')
-      fill_in('problem_url', with: 'http://www.example.com/yolo')
-      fill_in('message', with: 'This is only a test')
-      fill_in('name', with: 'Ronald McDonald')
-      fill_in('to', with: 'test@kittenz.eu')
-      click_button 'Send'
-    end
-    expect(page).to have_css(
-      'div.alert-success',
-      text: 'Thank you! Your connection problem report has been sent.'
-    )
-  end
-end

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -25,23 +25,3 @@ RSpec.feature "Feedback form (js)", :js do
     expect(page).to have_css("div.alert-success", text: "Thank you! Your feedback has been sent.")
   end
 end
-
-RSpec.feature "Feedback form (no js)" do
-  before do
-    visit root_path
-  end
-
-  scenario "feedback form should be shown filled out and submitted" do
-    click_link "Feedback"
-    expect(page).to have_css("#feedback-form", visible: true)
-    expect(page).to have_css("#feedback_message", count: 1)
-    expect(page).to have_css("a", text: "Cancel")
-    within "form.feedback-form" do
-      fill_in("message", with: "This is only a test")
-      fill_in("name", with: "Ronald McDonald")
-      fill_in("to", with: "test@kittenz.eu")
-      click_button "Send"
-    end
-    expect(page).to have_css("div.alert-success", text: "Thank you! Your feedback has been sent.")
-  end
-end


### PR DESCRIPTION
The form can not be submitted without javascript turned on due to recaptcha requiring javascript

<!-- Closes #ISSUE_NUMBER -->
<img width="1190" alt="Screenshot 2024-03-14 at 10 24 33 AM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/915b69ff-a80f-43fd-8354-a5c5e883c444">

<!-- 📝 CHANGELOG update? -->
