### PR TITLE
Remove the Rack::Runtime middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,7 @@ module SearchWorks
     # config.i18n.default_locale = :de
 
     config.middleware.insert 0, Rack::UTF8Sanitizer
+    config.middleware.delete Rack::Runtime
 
     config.search_logger = ActiveSupport::Logger.new(Rails.root + 'log/search.log', 'daily')
   end


### PR DESCRIPTION
We don't need this header. https://webhint.io/docs/user-guide/hints/hint-no-disallowed-headers/\?source\=devtools\#why-is-this-important advises that it should be removed

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
