### PR TITLE
We don't need a grid layout here

### DIFF
--- a/app/views/shared/feedback_forms/_reporting_from.html.erb
+++ b/app/views/shared/feedback_forms/_reporting_from.html.erb
@@ -1,10 +1,6 @@
 <div class="alert alert-info" role="alert">
-  <div class="row">
-    <div class="col-sm-10">
-      Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
-    </div>
-    <div class="col-sm-2">
-      <%= link_to 'Check system status', 'http://library-status.stanford.edu' %>
-    </div>
+  Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
+  <div class="pull-right">
+    <%= link_to 'Check system status', 'http://library-status.stanford.edu' %>
   </div>
 </div>


### PR DESCRIPTION
Prevent 'Check system status' from stacking up in medium viewports

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->

Before
<img width="450" alt="Screenshot 2024-03-14 at 1 22 30 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/fa1931e4-cf4b-419c-b40d-bbdbe413d0d2">

After
<img width="454" alt="Screenshot 2024-03-14 at 1 23 05 PM" src="https://github.com/sul-dlss/SearchWorks/assets/92044/22145ce3-b9cb-41b8-9b42-b7d1e75935e5">
