### PR TITLE
update slac url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -173,7 +173,7 @@ libraries:
     hours_api_url: science/location/library-circulation
     name: Science Library (Li and Ma)
   SLAC:
-    hours_api_url: slac/location/slac
+    hours_api_url: slac/location/slac_library
   SPEC-COLL:
     about_url: https://library.stanford.edu/libraries/special-collections
     hours_api_url: special_collections/location/spec_coll_reading


### PR DESCRIPTION
I think this closes #3369. This is the only URL not working after https://github.com/sul-dlss/SearchWorks/pull/3683.