### PR TITLE
Move model methods to the model

### DIFF
--- a/app/components/access_panels/location_item_component.rb
+++ b/app/components/access_panels/location_item_component.rb
@@ -15,22 +15,7 @@ module AccessPanels
       @render_item_note = render_item_note
     end
 
-    def availability_text
-      item.status.status_text unless temporary_location_text
-    end
-
-    def temporary_location_text
-      return if item.effective_location&.details&.key?('availabilityClass') ||
-                item.effective_location&.details&.key?('searchworksTreatTemporaryLocationAsPermanentLocation') ||
-                item.effective_permanent_location_code == item.temporary_location_code
-
-      item.temporary_location&.name
-    end
-
-    def has_in_process_availability_class?
-      availability_class = item.effective_location&.details&.dig('availabilityClass')
-      availability_class.present? && availability_class == 'In_process'
-    end
+    delegate :has_in_process_availability_class?, :temporary_location_text, :availability_text, to: :item
 
     def render_item_details?
       !item.suppressed?

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -149,6 +149,23 @@ class Holdings
       request_policy&.dig('requestTypes') || []
     end
 
+    def availability_text
+      status.status_text unless temporary_location_text
+    end
+
+    def temporary_location_text
+      return if effective_location&.details&.key?('availabilityClass') ||
+                effective_location&.details&.key?('searchworksTreatTemporaryLocationAsPermanentLocation') ||
+                effective_permanent_location_code == temporary_location_code
+
+      temporary_location&.name
+    end
+
+    def has_in_process_availability_class?
+      availability_class = effective_location&.details&.dig('availabilityClass')
+      availability_class.present? && availability_class == 'In_process'
+    end
+
     private
 
     def standard_or_zombie_library


### PR DESCRIPTION
From the component. This supports the split of the LocationItemComponent in #4070, so that there is no duplication

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
