### PR TITLE
Update IIIF links to https://iiif.io/

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -83,7 +83,7 @@
             <h3>IIIF resources</h3>
           <% end %>
           <p>Find IIIF-compatible items in the Stanford Digital Repository.</p>
-          <p><a href="https://library.stanford.edu/projects/international-image-interoperability-framework/viewers">What is IIIF?</a></p>
+          <p><a href="https://iiif.io">What is IIIF?</a></p>
         </div>
       </div>
       </div>

--- a/app/views/catalog/mastheads/_iiif_resources.html.erb
+++ b/app/views/catalog/mastheads/_iiif_resources.html.erb
@@ -10,7 +10,7 @@
           These items in the Stanford Digital Repository are IIIF-compatible. You can open these images in any IIIF-compatible viewer to manipulate them, analyze them, and compare them to images from other institutions.
         </p>
         <p>
-          Learn more about the <a href="https://iiif.io/">International Image Interoperability Framework (IIIF)</a> and <a href="https://library.stanford.edu/projects/international-image-interoperability-framework/viewers">how to open images in a IIIF viewer</a>.
+          Learn more about the <a href="https://iiif.io/">International Image Interoperability Framework (IIIF)</a> and <a href="https://iiif.io/guides/using_iiif_resources/">how to open images in a IIIF viewer</a>.
         </p>
       </div>
     </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,7 +67,7 @@ NEW_RELIC_API:
 RECAPTCHA:
   SITE_KEY: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
   SECRET_KEY: 6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx
-IIIF_DND_BASE_URL: https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?%{query}
+IIIF_DND_BASE_URL: https://iiif.io?%{query}
 REVISION: <%= File.read("#{Rails.root}/REVISION").chomp if File.exist?("#{Rails.root}/REVISION") %>
 LIB_GUIDES:
   API_URL: 'https://example.com/1.1/guides'

--- a/spec/components/record/item/mods/metadata_component_spec.rb
+++ b/spec/components/record/item/mods/metadata_component_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Record::Item::Mods::MetadataComponent, type: :component do
       end
 
       it 'includes IIIF Drag n Drop link' do
-        expect(page).to have_css 'a.iiif-dnd[href="https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?manifest=example.com"]'
+        expect(page).to have_css 'a.iiif-dnd[href="https://iiif.io?manifest=example.com"]'
       end
     end
   end

--- a/spec/views/catalog/_show_mods.html.erb_spec.rb
+++ b/spec/views/catalog/_show_mods.html.erb_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'catalog/_show_mods' do
       end
 
       it 'includes IIIF Drag n Drop link' do
-        expect(rendered).to have_css 'a.iiif-dnd[href="https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?manifest=example.com"]'
+        expect(rendered).to have_css 'a.iiif-dnd[href="https://iiif.io?manifest=example.com"]'
       end
     end
   end


### PR DESCRIPTION
After some discussion with Sarah we decided to update the IIIF links to https://iiif.io