### PR TITLE
Prevent rendering of request buttons for SPEC titles with no items

### DIFF
--- a/app/policies/item_request_link_policy.rb
+++ b/app/policies/item_request_link_policy.rb
@@ -10,8 +10,9 @@ class ItemRequestLinkPolicy
     return folio_holdable? if item.folio_item?
 
     # on-order items (without a folio item) may be title-level requestable
-    # but we can't evaluate circ rules (because there's no item) to figure that out
-    item.on_order?
+    # but we can't evaluate circ rules (because there's no item) to figure that out;
+    # SPEC does not allow requests until there is a folio item present
+    item.on_order? unless item.library == 'SPEC-COLL'
   end
 
   # Check to see if request types include hold or recall.

--- a/spec/components/item_request_link_component_spec.rb
+++ b/spec/components/item_request_link_component_spec.rb
@@ -65,5 +65,19 @@ RSpec.describe ItemRequestLinkComponent, type: :component do
 
       it { is_expected.to have_link 'Request' }
     end
+
+    context 'special collections on-order without a FOLIO item' do
+      let(:item) do
+        Holdings::Item.new({
+                             barcode: '123',
+                             library: 'SPEC-COLL',
+                             effective_permanent_location_code: 'STACKS',
+                             status: 'On order',
+                             type: 'STKS-MONO'
+                           }, document:)
+      end
+
+      it { is_expected.to have_no_link 'Request' }
+    end
   end
 end


### PR DESCRIPTION
This addresses a situation that can arise from dubious data that
was reported by a tester in searchworks-stage for instance 14642011.

We normally allow a request to be made if we know an item is on
order but it hasn't been added to FOLIO yet, but SPEC is the only
library where this policy should not apply.

![Screenshot 2024-05-03 at 11 54 42 AM](https://github.com/sul-dlss/SearchWorks/assets/4924494/0082876f-c2d0-42e9-9608-815a5b858fd3)
