### PR TITLE
Make sure item tables have a unique-to-the-page id

### DIFF
--- a/app/components/access_panels/library_location_component.html.erb
+++ b/app/components/access_panels/library_location_component.html.erb
@@ -26,7 +26,7 @@
       <th scope="col">Status</th>
     </tr>
   </thead>
-  <%= render LongTableComponent.new(node_id: "location_#{location.code}", size: location.items.size) do %>
+  <%= render LongTableComponent.new(node_id: "doc#{document.id}_location_#{location.code}", size: location.items.size) do %>
     <%= render AccessPanels::LocationItemComponent.with_collection(location.items, document:, classes: 'availability-item', render_item_level_request_link: !location_request_link.render?) %>
   <% end %>
 </table>

--- a/app/components/search_result/location_component.html.erb
+++ b/app/components/search_result/location_component.html.erb
@@ -21,7 +21,7 @@
     </tbody>
   <% end %>
   <% locations.each do |location| %>
-    <%= render LongTableComponent.new(node_id: "location_#{location.code}", size: location.items.size) do %>
+    <%= render LongTableComponent.new(node_id: "doc#{document.id}_location_#{location.code}", size: location.items.size) do %>
       <% location_request_link = LocationRequestLinkComponent.for(document:, library_code:, location:) %>
       <tr class="location-info">
         <th scope="col">


### PR DESCRIPTION

Without unique ids, the show more/less controls on the search results pages don't work. This seems like as a regression introduced in https://github.com/sul-dlss/SearchWorks/pull/4059/files (where previously we didn't give these elements id attributes at all?)