### PR TITLE
Add aria-label attribute to subject links

### DIFF
--- a/app/views/marc_fields/_subjects.html.erb
+++ b/app/views/marc_fields/_subjects.html.erb
@@ -6,7 +6,7 @@
         <%= ' > ' unless index == 0 %>
         <% link_text = value[0..index].join(' ') %>
         <% title_text = value[0..index].join(' - ') %>
-        <%= link_to(field.strip, search_catalog_path(q: "\"#{link_text}\"", search_field: 'subject_terms'), title: title_text) %>
+        <%= link_to(field.strip, search_catalog_path(q: "\"#{link_text}\"", search_field: 'subject_terms'), title: title_text, 'aria-label' => title_text) %>
       <% end %>
     </dd>
   <% end  %>

--- a/spec/views/catalog/record/_marc_subjects.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_subjects.html.erb_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe "catalog/record/_marc_subjects" do
       expect(rendered).to have_css('dt', text: "Subject")
       expect(rendered).to have_css('dd a', text: "Subject A1")
     end
+
+    it "should include an aria-label attribute" do
+      expect(rendered).to have_css('dd a[aria-label="Subject A1"]')
+    end
+
     it "should render non-marc 655 subjects under 'Genre'" do
       expect(rendered).to have_css('dt', text: "Genre")
       expect(rendered).to have_css('dd a', text: "Subject A1")


### PR DESCRIPTION
The subject links on record pages such as https://searchworks.stanford.edu/view/in00000067099 are getting flagged by SiteImprove as links with the same text (in this case "Leiden") that go to different pages (despite their different title attribute values). @alundgard and I took a look at this and it seemed like we got the best behavior out the screen reader when we added an aria-label attribute with the same value as the title attribute. The screen reader reads the full link text "Printing  Netherlands  Leiden" from the aria-label instead of "Leiden, Printing Netherlands Leiden" from both the link text and the title attribute.
<img width="479" alt="Screenshot 2024-05-17 at 2 07 16 PM" src="https://github.com/sul-dlss/SearchWorks/assets/458247/3adcfa91-089e-43d2-8e8d-597bd78dc3fc">
