### PR TITLE
Use the BM25 similarity class

### DIFF
--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <schema name="Stanford Searchworks" version="1.5">
   <uniqueKey>id</uniqueKey>
-  <similarity class="solr.ClassicSimilarityFactory"/>
+  <similarity class="solr.BM25SimilarityFactory"/>
 
   <fields>
     <!-- needed by some of Solr 4.0 functionality like transaction log or partial documents update -->

--- a/spec/features/marc_results_metadata_spec.rb
+++ b/spec/features/marc_results_metadata_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe "MARC Metadata in search results" do
   describe "characteristics" do
     before do
       visit root_path
-      fill_in 'q', with: '4'
+      fill_in 'q', with: 'id:4'
       click_button 'search'
     end
 
     it 'should join the characteristics with the physical statement' do
       # this item is the 2nd search result
-      within(all('.document')[1]) do
+      within(first('.document')) do
         expect(page).to have_css('dt', text: 'Description')
         expect(page).to have_css('dd',
                                  text: 'Video — The physical statement Sound: digital; optical; surround; stereo; Dolby. Video: NTSC. Digital: video file; DVD video; Region 1.')

--- a/spec/features/mhld_spec.rb
+++ b/spec/features/mhld_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "MHLD", :feature do
     end
 
     it "should be present in the accordion section" do
-      visit search_catalog_path(q: '10')
+      visit search_catalog_path(q: 'id:10')
 
       within(first('.document')) do
         expect(page).to have_content('Check availability')

--- a/spec/features/results_page_spec.rb
+++ b/spec/features/results_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Search Results Page" do
     expect(page).to have_title(/.*\d (result|results) in SearchWorks catalog/)
   end
   scenario "vernacular title" do
-    visit search_catalog_path(q: '11')
+    visit search_catalog_path(q: 'id:11')
 
     within(first('.document')) do
       expect(page).to have_css('h3', text: "Amet ad & adipisicing ex mollit pariatur minim dolore.")


### PR DESCRIPTION
BM25 is the "new" Solr default and causes some minor relevancy changes. The major difference seems to be a little boost to exact matching:

E.g. a query for "The John" no longer ranks the stemmed match "The Johns" higher than exact matches for "The John" 
![Screenshot 2024-06-06 at 16 22 34](https://github.com/sul-dlss/SearchWorks/assets/111218/1f6da2a7-0495-4994-a621-01315fe14933)

And putting a little more weight on more unique terms:

E.g. a query for "mcrae jazz" returns titles with Mcrae above ones with Jazz: 
![Screenshot 2024-06-06 at 16 26 03](https://github.com/sul-dlss/SearchWorks/assets/111218/9a557a9d-215d-419e-8cb7-bcadf90dc48c)
