### PR TITLE
Add best_author_title_search field for the 'the is the one' uniform (or otherwise) title for the record

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -435,10 +435,10 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf:  'author_title_search',
-        pf:  'author_title_search^10',
-        pf3: 'author_title_search^5',
-        pf2: 'author_title_search^2'
+        qf:  '${qf_author_title}',
+        pf:  '${pf_author_title}',
+        pf3: '${pf3_author_title}',
+        pf2: '${pf2_author_title}'
       }
     end
 

--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -88,6 +88,7 @@
     <field name="vern_author_title_1xx_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="author_title_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="author_title_unstem_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="best_author_title_search" type="text" indexed="true" stored="true" multiValued="false" />
 
     <!-- Author Search Fields -->
     <field name="author_1xx_search" type="text" indexed="true" stored="true" />

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -917,6 +917,15 @@
       <str name="pf3_number">callnum_search^3</str>
       <str name="pf2_number">callnum_search^2</str>
 
+      <!-- for uniform titles + included works search -->
+      <str name="qf_author_title">
+        best_author_title_search^100
+        author_title_search
+      </str>
+      <str name="pf_author_title">author_title_search^10</str>
+      <str name="pf3_author_title">author_title_search^5</str>
+      <str name="pf2_author_title">author_title_search^2</str>
+
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>
       <int name="facet.limit">21</int>


### PR DESCRIPTION
This new field will help address a regression from https://github.com/sul-dlss/searchworks_traject_indexer/pull/382, which started penalizing more complete records that end up with multiple `author_title_search` values (e.g. a 100 + 240 and a 100 + 245) over other records.

This new field should let us boost uniform title matches over other sorts of titles while not excluding relevant results.

sul-solr configs: https://github.com/sul-dlss/sul-solr-configs/pull/325
Indexing PR: https://github.com/sul-dlss/searchworks_traject_indexer/pull/1457