### PR TITLE
fix for eresources with no call number

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -5,7 +5,9 @@
     <div id="masthead" class="browse-masthead">
       <h1 class="my-3">Browse related items</h1>
       <p>Starting at call number:
-        <% if params[:barcode] %>
+        <% if params[:call_number].present? %>
+          <%= params[:call_number] %>
+        <% elsif params[:barcode] %>
           <%= @original_doc.holdings.find_by_barcode(params[:barcode])&.callnumber %>
         <% else %>
           <%= @original_doc.holdings.items.first.callnumber %>


### PR DESCRIPTION
closes #4223 

For pages like: 
https://searchworks.stanford.edu/view/12946310
https://searchworks.stanford.edu/view/13065921

Clicking on the view full page in the browse section errors out due to there being no call number or items for the document. However that link automatically puts the call number in the URL. This fixes the code by pulling the call number from the URL if it is already there. 

