### PR TITLE
update page icons to bootstrap

### DIFF
--- a/app/assets/stylesheets/modules/constraints.scss
+++ b/app/assets/stylesheets/modules/constraints.scss
@@ -5,6 +5,10 @@
     line-height: $h4-font-size;
   }
 
+  .bi-skip-backward-fill {
+    font-size: .9rem;
+  }
+
   span.constraint.btn-group {
     span.constraint-value {
       border-top-left-radius: $sul-constraint-btn-radius;

--- a/app/assets/stylesheets/modules/side-nav-minimap.scss
+++ b/app/assets/stylesheets/modules/side-nav-minimap.scss
@@ -44,7 +44,12 @@
           background-color: $sul-side-nav-minimap-active-btn-bg;
       }
 
-      i.fa, .sul-icon {
+      i.bi.bi-arrow-up-short, i.bi.bi-arrow-down-short {
+        font-size: 1.5rem;
+        vertical-align: sub;
+      }
+
+      i.bi, .sul-icon {
         display: inline-block;
         text-align: center;
         width: 35px;

--- a/app/components/blacklight/start_over_button_component.rb
+++ b/app/components/blacklight/start_over_button_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   class StartOverButtonComponent < Blacklight::Component
     def call
-      link_to("<i class='fa fa-fast-backward'></i> <span class='d-none d-sm-inline'>#{label}</span></a>".html_safe, start_over_path, class: 'btn btn-primary btn-reset')
+      link_to("<i class='bi bi-skip-backward-fill'></i> <span class='d-none d-sm-inline'>#{label}</span></a>".html_safe, start_over_path, class: 'btn btn-primary btn-reset')
     end
 
     private

--- a/app/views/shared/_side_nav_minimap.html.erb
+++ b/app/views/shared/_side_nav_minimap.html.erb
@@ -2,7 +2,7 @@
   <li>
     <button data-target-id="topnav-container" aria-label="Jump to top">
       <span class="nav-label">Top</span>
-      <i class="fa fa-arrow-up"></i>
+      <i class="bi bi-arrow-up-short"></i>
     </button>
   </li>
 
@@ -25,7 +25,7 @@
   <li>
     <button data-target-id="sul-footer-container" aria-label="Jump to bottom">
       <span class="nav-label">Bottom</span>
-      <i class="fa fa-arrow-down"></i>
+      <i class="bi bi-arrow-down-short"></i>
     </button>
   </li>
 </ul>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -322,7 +322,7 @@ en:
       sms: 'text'
       printer: 'printer'
 
-    back_to_search: '<i class="fa fa-fast-backward"></i><span class="d-none d-sm-inline">&nbsp; Back to results</span>'
+    back_to_search: '<i class="bi bi-skip-backward-fill"></i><span class="d-none d-sm-inline">&nbsp; Back to results</span>'
     feedback_form:
       success: '<strong>Thank you!</strong> Your feedback has been sent.'
     connection_form:
@@ -333,35 +333,35 @@ en:
   record_side_nav:
     abstract:
       id: "abstract"
-      icon: '<i class="fa fa-align-justify"></i>'
+      icon: '<i class="bi bi-justify"></i>'
       label: "Abstract"
     abstract_contents:
       id: "abstract-contents"
-      icon: '<i class="fa fa-align-justify"></i>'
+      icon: '<i class="bi bi-justify"></i>'
       label: "Contents"
     contributors:
       id: "contributors"
-      icon: '<i class="fa fa-user"></i>'
+      icon: '<i class="bi bi-person-fill"></i>'
       label: "Contributors"
     access_conditions:
       id: "access-conditions"
-      icon: '<i class="fa fa-key"></i>'
+      icon: '<i class="bi bi-key-fill"></i>'
       label: "Access"
     contents_summary:
       id: "contents-summary"
-      icon: '<i class="fa fa-align-justify"></i>'
+      icon: '<i class="bi bi-justify"></i>'
       label: "Summary"
     subjects:
       id: "subjects"
-      icon: '<i class="fa fa-tags"></i>'
+      icon: '<i class="bi bi-tags-fill"></i>'
       label: "Subjects"
     bibliography_info:
       id: "bibliography-info"
-      icon: '<i class="fa fa-info"></i>'
+      icon: '<i class="bi bi-info-circle"></i>'
       label: "Info"
     details:
       id: "details"
-      icon: '<i class="fa fa-info"></i>'
+      icon: '<i class="bi bi-info-circle"></i>'
       label: "Details"
     browse_nearby:
       id: "browse-nearby"
@@ -369,9 +369,9 @@ en:
       label: "Browse"
     fulltext:
       id: "full-text"
-      icon: '<i class="fa fa-align-justify"></i>'
+      icon: '<i class="bi bi-justify"></i>'
       label: "Full Text"
     summary:
       id: "summary"
-      icon: '<i class="fa fa-align-justify"></i>'
+      icon: '<i class="bi bi-justify"></i>'
       label: "Summary"

--- a/spec/views/catalog/record/_marc_metadata_sections.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_metadata_sections.html.erb_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "catalog/record/_marc_metadata_sections" do
     it "should render side nav content" do
       expect(rendered).to have_css("ul.side-nav-minimap")
 
-      expect(rendered).to have_css(".side-nav-minimap button i.fa.fa-arrow-up")
-      expect(rendered).to have_css(".side-nav-minimap button i.fa.fa-arrow-down")
+      expect(rendered).to have_css(".side-nav-minimap button i.bi.bi-arrow-up-short")
+      expect(rendered).to have_css(".side-nav-minimap button i.bi.bi-arrow-down-short")
 
       expect(rendered).to have_css(".side-nav-minimap button.contributors")
       expect(rendered).to have_css(".side-nav-minimap button.contents-summary")

--- a/spec/views/catalog/record/_mods_metadata_sections.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_metadata_sections.html.erb_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "catalog/record/_mods_metadata_sections" do
     it "renders side nav content" do
       expect(rendered).to have_css("ul.side-nav-minimap")
 
-      expect(rendered).to have_css(".side-nav-minimap button i.fa.fa-arrow-up")
-      expect(rendered).to have_css(".side-nav-minimap button i.fa.fa-arrow-down")
+      expect(rendered).to have_css(".side-nav-minimap button i.bi.bi-arrow-up-short")
+      expect(rendered).to have_css(".side-nav-minimap button i.bi.bi-arrow-down-short")
 
       expect(rendered).to have_css(".side-nav-minimap button.contributors")
       expect(rendered).to have_css(".side-nav-minimap button.abstract-contents")


### PR DESCRIPTION
Considering the number of font-awesome icons and the visual changes this will cause I think it will need to be done in phases. Here is the first PR for updating the icons the details page.

New            |  Old
:-------------------------:|:-------------------------:
![Screenshot 2024-06-21 at 12 53 36 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/95723dc0-175a-4a49-b179-297f898124ba) ![Screenshot 2024-06-21 at 12 53 42 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/9bde73fe-7d68-4fdc-9fb3-fa7d0348e83d) | ![Screenshot 2024-06-20 at 5 19 12 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/ece4ed80-b6c0-45bf-8047-a1b64ce8628d) ![Screenshot 2024-06-21 at 12 53 48 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/0c651114-38f9-463e-aa5f-1e298c108b76)


New            |  Old
:-------------------------:|:-------------------------:
![new](https://github.com/sul-dlss/SearchWorks/assets/19173991/62383f30-730a-4c32-8f57-640ecd48bd37) | ![old](https://github.com/sul-dlss/SearchWorks/assets/19173991/328970ab-c1b8-4861-ba2b-30ec9de12200) 

New            |  Old
:-------------------------:|:-------------------------:
![Screenshot 2024-06-20 at 5 20 50 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/9b5a9df2-0013-45fa-baaa-3626e4002878) | ![Screenshot 2024-06-20 at 5 20 55 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/d2390a82-e32e-4bdf-821a-dee52b4a908a)


New            |  Old
:-------------------------:|:-------------------------:
![Screenshot 2024-06-20 at 5 21 02 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/9e60d630-d76f-4e89-ada9-093169b3cada) | ![Screenshot 2024-06-20 at 5 21 09 PM](https://github.com/sul-dlss/SearchWorks/assets/19173991/1e12390e-d0db-4392-80f0-f35dff625b2f)



Ref #4662
