### PR TITLE
fix included works parsing of marc, closes #3487

### DIFF
--- a/app/models/marc_fields/included_works.rb
+++ b/app/models/marc_fields/included_works.rb
@@ -19,7 +19,7 @@ class IncludedWorks < MarcField
 
     # With values until we get to subfield t
     text_only_subfields = ["e", "j", "4"]
-    before_t.each do |subfield|
+    before_t&.each do |subfield|
       if subfield.code == "i"
         before_text << subfield.value.gsub(/\s*\(.+\)\s*/, '')
       else
@@ -30,7 +30,7 @@ class IncludedWorks < MarcField
 
     # with values between the subfield t and some punctuation
     text_only_subfields = ["e", "i", "j", "4"]
-    within_t.each do |subfield|
+    within_t&.each do |subfield|
       href_text << subfield.value unless text_only_subfields.include?(subfield.code)
       link_text << subfield.value
     end


### PR DESCRIPTION
before_t, *after_t = relevant_subfields.slice_before { |subfield| subfield.code == 't' }.to_a
within_t, *extra_fields = after_t.flatten.slice_after { |subfield| subfield.value =~ /[\.|;]\s*$/ }.to_a

Expect the result to be a list with two items in them. When slice_after doesn't find anything it returns an empty array [], not what it expects: [[], []]. This causes a problem when looping on the Included works field if there are items that aren't after the t field like the record 8113045. This has the subfields [#<MARC::Subfield:0x00000001725ae128 @code="t", @value="Works.">, #<MARC::Subfield:0x00000001725ae100 @code="f", @value="1999.">] which means within_t returns nil.
