### PR TITLE
Fix Holdings::Location#inspect and guard against nil location codes

### DIFF
--- a/lib/holdings/location.rb
+++ b/lib/holdings/location.rb
@@ -47,12 +47,12 @@ class Holdings
     end
 
     def sort
-      name || @code
+      name || @code || ''
     end
 
     # This prevents logging too much data when there is an error.
     def inspect
-      "<##{this.class.class_name} @code=#{@code}>"
+      "<##{self.class.name} @code=#{@code}>"
     end
 
     private


### PR DESCRIPTION
Apparently some of our stub records have locations with a `nil` code (and our inspect method probably never worked)