### PR TITLE
Configure whenever_roles so cron jobs are installed where we expect them

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,6 +39,8 @@ set :linked_dirs, %w{config/settings log tmp/pids tmp/cache tmp/sockets tmp/fara
 # We want Honeybadger to report deployments to our Capistrano stage names (e.g., dev, stage, prod)
 set :honeybadger_env, fetch(:stage)
 
+set :whenever_roles, %i[app courses]
+
 desc 'Clear EDS cache on all web hosts'
 task :clear_eds_cache do
   on roles(:web) do


### PR DESCRIPTION
Removing this db role from some of the searchworks webapp VMs had the side effect of revealing that we hadn't configured the `whenever_roles`. See the whenever docs: https://github.com/javan/whenever?tab=readme-ov-file#capistrano-roles:

> However, if you want to restrict certain jobs to only run on subset of servers, you can add a roles: [...] argument to their definitions. Make sure to add that role to the whenever_roles list in your deploy.rb.

Turns out if you don't add the roles you're using the the `whenever_roles` list the cron jobs are added all of the VMs with the `db` role by default.

I think there's more cleanup we could do (I'll put up separate PRs for these), such as:

- I don't understand why we'd need to run the `searchworks:prune_old_guest_user_data` on all the VMs. This is a database cleanup task and probably should only be run VMs with the `db` role.
- The `courses` role may be unnecessary now the `db` role is assigned properly.