### PR TITLE
Stop rotating search logger

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,6 @@ module SearchWorks
 
     config.middleware.insert 0, Rack::UTF8Sanitizer
 
-    config.search_logger = ActiveSupport::Logger.new(Rails.root + 'log/search.log', 'daily')
+    config.search_logger = ActiveSupport::Logger.new(Rails.root + 'log/search.log')
   end
 end


### PR DESCRIPTION
@jonrober says:
> On sw-webapp*, it seems like the application is doing its own log rotation of /var/log/Searchworks/search.log.  logrotate is often rotating an almost empty file, with something else rotating the log first at one minute til midnight.  I’m guessing that it’s the application doing that early rotation.  The result is that a lot of logs are filling extra disk space since the thing rotating them first doesn’t do gzipping and doesn’t do expiration of old logfiles after X days like logrotate. 