### PR TITLE
Remove role=alert from non-live region

### DIFF
--- a/app/views/shared/feedback_forms/_reporting_from.html.erb
+++ b/app/views/shared/feedback_forms/_reporting_from.html.erb
@@ -1,4 +1,4 @@
-<div class="alert alert-info" role="alert">
+<div class="alert alert-info">
   <div class="row">
     <div class="col-sm-10">
       Reporting from: <span class="reporting-from-field"><%= request.referer %></span>


### PR DESCRIPTION
This section is not an alert in the aria sense.  We don't want to disrupt the user with this information.

See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
