### PR TITLE
Fix facet event label.

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -129,14 +129,14 @@ Blacklight.onLoad(function() {
     sendAnalyticsEvent({
       category: 'Facet',
       action: 'SW/closed-facet',
-      label: getText(e)
+      label: $(e.currentTarget).parent().find('h3').text().trim()
     })
   })
   $('.facet-content').on('show.bs.collapse', function(e) {
     sendAnalyticsEvent({
       category: 'Facet',
       action: 'SW/expanded-facet',
-      label: getText(e)
+      label: $(e.currentTarget).parent().find('h3').text().trim()
     })
   })
 


### PR DESCRIPTION
This seems like a regression from #3036. The previous implementation used the H3 value, not the facet panel text:

https://github.com/sul-dlss/SearchWorks/blame/cb3f26265f3e5c4f2b6d19fe82687c82466ae5ea/app/assets/javascripts/analytics.js#L134-L144
