### PR TITLE
Use new OCLC Citation API feature to fetch multiple citation styles per request

### DIFF
--- a/app/models/citations/oclc_citation.rb
+++ b/app/models/citations/oclc_citation.rb
@@ -45,9 +45,7 @@ module Citations
     end
 
     def oclc_citations
-      CITATION_STYLES.flat_map do |citation_style|
-        Thread.new { oclc_client.citations(oclc_numbers:, citation_style:) }
-      end.flat_map(&:value)
+      oclc_client.citations(oclc_numbers: oclc_numbers, citation_styles: CITATION_STYLES)
     end
 
     def oclc_client

--- a/app/services/oclc_discovery_client.rb
+++ b/app/services/oclc_discovery_client.rb
@@ -38,11 +38,11 @@ class OclcDiscoveryClient
 
   # Fetch one or more citations from the OCLC Discovery API
   # @param [Array] or [String] the OCLC numbers to fetch citations for
-  # @param [String] citation_style the citation style to fetch (only one style may be requested at a time)
+  # @param [Array] or [String] citation_styles one or more citation styles to fetch
   # @return [Array] one or more citation responses
-  def citations(oclc_numbers:, citation_style: 'apa')
+  def citations(oclc_numbers:, citation_styles: ['apa'])
     Array(oclc_numbers).each_slice(MAX_CITATIONS_PER_REQUEST).map do |ids|
-      Thread.new { get_json(citation_query(ids.join(','), citation_style)) }
+      Thread.new { get_json(citation_query(ids.join(','), Array(citation_styles).join(','))) }
     end.map(&:value)
   end
 
@@ -50,8 +50,8 @@ class OclcDiscoveryClient
 
   # OCLC Citation API documentation:
   # https://developer.api.oclc.org/citations-api
-  def citation_query(oclc_number, citation_style)
-    query = { oclcNumbers: oclc_number, style: citation_style }.to_query
+  def citation_query(oclc_number, citation_styles)
+    query = { oclcNumbers: oclc_number, style: citation_styles }.to_query
     "/reference/citations?#{query}"
   end
 

--- a/spec/services/oclc_discovery_client_spec.rb
+++ b/spec/services/oclc_discovery_client_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe OclcDiscoveryClient do
   end
 
   describe '#citations' do
-    subject(:citations) { client.citations(oclc_numbers: '905869', citation_style: 'modern-language-association') }
+    subject(:citations) { client.citations(oclc_numbers: '905869', citation_styles: 'modern-language-association') }
 
     before do
       stub_request(:get, "https://oclc.example.edu/reference/citations?oclcNumbers=905869&style=modern-language-association")


### PR DESCRIPTION
OCLC now supports requesting more than one citation style at once so we no longer need to send separate requests for each style we want to display.
