### PR TITLE
Drive browse pages using the browse_nearby_struct, not item_display_struct

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -33,7 +33,7 @@ class BrowseController < ApplicationController
   end
 
   def browse_params
-    params.permit(:start, :barcode, :before, :after, :view)
+    params.permit(:start, :barcode, :before, :after, :view, :call_number)
   end
 
   def fetch_orginal_document

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -10,7 +10,7 @@
         <% elsif params[:barcode] %>
           <%= @original_doc.holdings.find_by_barcode(params[:barcode])&.callnumber %>
         <% else %>
-          <%= @original_doc.holdings.items.first.callnumber %>
+          <%= @original_doc.browseable_spines.first&.callnumber %>
         <% end %>
       </p>
       <p><%= link_to(document_presenter(@original_doc).heading, solr_document_path(@original_doc)) %></p>

--- a/spec/views/browse/index.html.erb_spec.rb
+++ b/spec/views/browse/index.html.erb_spec.rb
@@ -3,17 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe "browse/index" do
-  let(:original_doc) {
+  let(:original_doc) do
     SolrDocument.new(
       id: 'doc-id',
-      item_display_struct: [
-        { barcode: '123', library: 'library', effective_permanent_location_code: 'location_code', temporary_location_code: 'temporary_location_code', type: 'type',
-          truncated_callnumber: 'truncated_callnumber', callnumber: 'callnumber123' },
-        { barcode: '321', library: 'library', effective_permanent_location_code: 'location_code', temporary_location_code: 'temporary_location_code', type: 'type',
-          truncated_callnumber: 'truncated_callnumber', callnumber: 'callnumber321' }
-      ]
+      browse_nearby_struct: browse_nearby_struct,
+      item_display_struct: item_display_struct
     )
-  }
+  end
+
+  let(:browse_nearby_struct) do
+    [
+      { item_id: '123', callnumber: 'callnumber123', shelfkey: 'A', scheme: 'LC' }
+    ]
+  end
+
+  let(:item_display_struct) { [] }
   let(:presenter) { OpenStruct.new(heading: "Title") }
 
   before do
@@ -35,6 +39,15 @@ RSpec.describe "browse/index" do
   end
 
   describe "with barcode" do
+    let(:item_display_struct) do
+      [
+        { barcode: '123', library: 'library', effective_permanent_location_code: 'location_code', temporary_location_code: 'temporary_location_code', type: 'type',
+          truncated_callnumber: 'truncated_callnumber', callnumber: 'callnumber123' },
+        { barcode: '321', library: 'library', effective_permanent_location_code: 'location_code', temporary_location_code: 'temporary_location_code', type: 'type',
+          truncated_callnumber: 'truncated_callnumber', callnumber: 'callnumber321' }
+      ]
+    end
+
     before do
       allow(view).to receive(:params).and_return(start: '123', barcode: '321')
     end


### PR DESCRIPTION
e-resources have `browse_nearby_struct` (and are kinda the reason we added the field) but don't have any actual items. 

Fixes #4487
