### PR TITLE
Reject oclc citation entries that are missing the citationText and/or style keys

### DIFF
--- a/app/models/citations/oclc_citation.rb
+++ b/app/models/citations/oclc_citation.rb
@@ -40,7 +40,7 @@ module Citations
     # into data like: { oclc_number => { citation_style => citation_text } }
     def transform_grouped_citations(grouped_citations)
       grouped_citations.transform_values do |citations|
-        citations.to_h { |citation| [searchworks_style_code(citation['style']), citation['citationText']&.html_safe] } # rubocop:disable Rails/OutputSafety
+        citations.to_h { |citation| [searchworks_style_code(citation['style']), citation['citationText']&.html_safe] }.compact # rubocop:disable Rails/OutputSafety
       end
     end
 

--- a/spec/models/citations/oclc_citation_spec.rb
+++ b/spec/models/citations/oclc_citation_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Citations::OclcCitation do
   before do
     allow(OclcDiscoveryClient).to receive(:new).and_return(oclc_client)
     allow(oclc_client).to receive(:citations).and_return(
-      ['entries' => [{ 'oclcNumber' => '12345', 'style' => 'apa', 'citationText' => 'Citation Content' }]]
+      ['entries' => [{ 'oclcNumber' => '12345', 'style' => 'apa', 'citationText' => 'Citation Content' },
+                     { 'oclcNumber' => '12345', 'resultType' => 'problem', 'type' => 'UNSUPPORTED_MATERIAL_FORMAT_TYPE' }]]
     )
     allow(Settings.oclc_discovery.citations).to receive(:enabled).and_return(oclc_enabled)
   end


### PR DESCRIPTION
Accounts for case where OCLC sends a response for a citation that does not include the citation.

Example case: https://searchworks.stanford.edu/view/13644707

Before:
<img width="824" alt="Screenshot 2024-12-13 at 2 36 12 PM" src="https://github.com/user-attachments/assets/e960b683-287b-4ee2-9def-a55ef6a83722" />

After:
<img width="815" alt="Screenshot 2024-12-13 at 2 37 10 PM" src="https://github.com/user-attachments/assets/cb42e731-24c4-49dd-9fcd-cebc2071fbb5" />

