### PR TITLE
Fix image layout when article topic overview text is short

### DIFF
--- a/app/assets/stylesheets/modules/research-starter.scss
+++ b/app/assets/stylesheets/modules/research-starter.scss
@@ -22,6 +22,7 @@
   border: 1px solid $sul-research-starter-color;
   box-shadow: 0 4px 8px -2px rgba(0,0,0,0.2);
   padding: 10px 20px;
+  overflow: auto;
   --link-decoration-line: none;
 
   img {


### PR DESCRIPTION
Before:
<img width="801" alt="Screenshot 2025-03-03 at 10 18 45 AM" src="https://github.com/user-attachments/assets/edd290b9-0950-4ab7-bac3-0001540c94de" />

After:
<img width="803" alt="Screenshot 2025-03-03 at 10 19 00 AM" src="https://github.com/user-attachments/assets/78830a31-beea-4f1c-a45f-317185cf2d79" />
