### PR TITLE
Fix regressions in online links

### DIFF
--- a/app/components/access_panels/online_link_list_component.html.erb
+++ b/app/components/access_panels/online_link_list_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.ul class: "links", id: "online-link-list", data: truncate? ? { controller: "long-list" } : nil do %>
   <% links.each.with_index do |link, index| %>
-    <%= tag.li data: index > 5 ? { long_list_target: 'hideable' } : nil do %>
+    <%= tag.li data: index >= 5 ? { long_list_target: 'hideable' } : nil do %>
       <span class="<%= 'stanford-only' if link.stanford_only? %>">
         <%= link.html&.html_safe %>
       </span>

--- a/app/models/links/link.rb
+++ b/app/models/links/link.rb
@@ -75,7 +75,15 @@ class Links
     end
 
     def link_html
-      content_tag(:a, @link_text, href: @href, title: @link_title, class: link_class)
+      tooltip_attr = if @link_title.present?
+                       {
+                         title: @link_title,
+                         data: { placement: 'right', toggle: 'tooltip' }
+                       }
+                     else
+                       {}
+                     end
+      content_tag(:a, @link_text, href: @href, class: link_class, **tooltip_attr)
     end
   end
 end


### PR DESCRIPTION
Restoring the access condition tooltip:
![Screenshot 2025-03-07 at 12 17 02](https://github.com/user-attachments/assets/cdbad9a2-d5f7-436a-9dfb-4a93f65393ea)

and fix the list truncation (e.g. for https://searchworks.stanford.edu/view/in00000162623)
![Screenshot 2025-03-07 at 12 18 06](https://github.com/user-attachments/assets/af0d88f7-e1ea-4b33-8b2f-d3592d088ecd)
