### PR TITLE
Use Noto Serif Tibetan for Tibetan Unicode range

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 
 // SUL Style Variables/Mixins
 @import 'deja-vu-font';
+@import 'fonts';
 @import 'sul-variables';
 @import 'searchworks-mixins';
 

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -31,7 +31,7 @@ a:not(.btn):not(.dropdown-item):not(.page-link):not(.remove).disabled {
 }
 
 body {
-  font-family: 'SUL Font Overrides', 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
+  font-family: 'Source Sans Pro', 'SUL Override', 'Arial Unicode MS', Helvetica, sans-serif;
 }
 
 .page-item  {

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -31,7 +31,7 @@ a:not(.btn):not(.dropdown-item):not(.page-link):not(.remove).disabled {
 }
 
 body {
-  font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
+  font-family: 'SUL Font Overrides', 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
 }
 
 .page-item  {

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -1,0 +1,9 @@
+/* tibetan */
+@font-face {
+  font-family: 'SUL Font Overrides';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/notoseriftibetan/v22/gokzH7nwAEdtF9N45n0Vaz7O-pk0wsvbBMgmy2UTva2n.woff2) format('woff2');
+  unicode-range: U+0F00-0FFF;
+}

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -1,6 +1,20 @@
+/*
+- Chrome/Edge did not show the Tibetan characters when added to Source Sans Pro
+- Safari had rendering issues when using an "Overrides" specific font-family with just noto sans tibetan
+- So we are using a font-family of "SUL Override" for the tibetan characters, and
+  using the "Arial Unicode MS" as a fallback for the rest of the characters.
+*/
+
+@font-face {
+  font-family: "SUL Override";
+  font-style: normal;
+  font-weight: 100 900;
+  src: local('Arial Unicode MS');
+}
+
 /* tibetan */
 @font-face {
-  font-family: 'SUL Font Overrides';
+  font-family: "SUL Override";
   font-style: normal;
   font-weight: 100 900;
   font-display: swap;

--- a/app/assets/stylesheets/modules/online-resource-links.scss
+++ b/app/assets/stylesheets/modules/online-resource-links.scss
@@ -19,7 +19,7 @@ ul.links {
   border-radius: 2px;
   color: $white;
   display: inline-block;
-  font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
+  font-family: 'SUL Font Overrides', 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   font-size: 14px;
   font-weight: normal;
   height: 20px;

--- a/app/assets/stylesheets/modules/online-resource-links.scss
+++ b/app/assets/stylesheets/modules/online-resource-links.scss
@@ -19,7 +19,7 @@ ul.links {
   border-radius: 2px;
   color: $white;
   display: inline-block;
-  font-family: 'SUL Font Overrides', 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
+  font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   font-size: 14px;
   font-weight: normal;
   height: 20px;


### PR DESCRIPTION
A second attempt at adding Tibetan character support.

The first attempt added an overrides specific font family for the Tibetan unicode-range only. Safari had quirks with unicode-range, not falling back down the chain as expected which led to an odd style issue:
<img width="1003" alt="Screenshot 2025-03-17 at 3 11 09 PM" src="https://github.com/user-attachments/assets/3ef91826-483f-429e-962a-e64abf93f506" />

Our current "Source Sans Pro" stack doesn't have the Tibetan range. Adding the range to "Source Sans Pro" worked on all browsers except for Chrome/Edge, which ignored the addition.

Adding the Tibetan range to our current fallback font "Arial Unicode MS" is working as expected on Chrome, Edge, Firefox, and Safari.
<img width="995" alt="Screenshot 2025-03-17 at 3 11 28 PM" src="https://github.com/user-attachments/assets/4c721333-6636-4875-a6c1-ac1973f5ec78" />
