### PR TITLE
Stop safari from wrapping the 'catalog start' button.

### DIFF
--- a/app/assets/stylesheets/modules/constraints.scss
+++ b/app/assets/stylesheets/modules/constraints.scss
@@ -3,6 +3,7 @@
     font-size: $h4-font-size;
     font-variant: all-small-caps;
     line-height: $h4-font-size;
+    white-space: nowrap;
   }
 
   span.constraint.btn-group {


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->

Before:
<img width="354" alt="Screenshot 2025-03-18 at 10 14 59" src="https://github.com/user-attachments/assets/7c7fefb9-9078-496e-ac49-9291b17499d7" />

After:
<img width="244" alt="Screenshot 2025-03-18 at 10 14 55" src="https://github.com/user-attachments/assets/31174cf3-d8d7-4bb7-8062-5f3ec5d0a981" />
