### PR TITLE
Update parser to support new(?) syntax

### DIFF
--- a/app/services/folio/circulation_rules/parser.rb
+++ b/app/services/folio/circulation_rules/parser.rb
@@ -34,7 +34,7 @@ module Folio
         criterium_letter >> ws? >> (
           str('all').as(:any) |
             (name.as(:uuid) >> ws?).repeat(1).as(:or) |
-            (str('!') >> name.as(:uuid) >> ws?).repeat(1).as(:or).as(:not)
+            (str('!') >> ws? >> name.as(:uuid) >> ws?).repeat(1).as(:or).as(:not)
         ).as(:criterium_value)
       end
 


### PR DESCRIPTION
This circulation rule was added the other month:

```
/PSEUDOPATRONS
b c365047a-51f2-45ce-8601-e421ca3615c5 + g db4aed0e-a229-4ead-8ea5-d0345295e881 + m ! b4cc0696-7a37-4a39-ba8b-256b3cf71287 + t all : l 0d26a888-afeb-458a-bcdb-68b2f542d598 r 334e5a9e-94f9-4673-8d1d-ab552863886b n c4ec90cb-1139-4c59-a690-9de48c4e3fd6 o bba172e9-eb78-4471-a4a7-08761fbdfff9 i b1b08521-9754-419e-8109-19003ca4c5d3 
```

The [FOLIO grammar](https://github.com/folio-org/mod-circulation/blob/master/src/main/antlr4/org/folio/circulation/rules/CirculationRules.g4#L138-L146) and [documentation](https://github.com/folio-org/mod-circulation/blob/master/doc/circulationrules.md#-and-all) seem to suggest the `!` should be immediately followed by a UUID, but there's extra whitespace here. Maybe upstream is doing something special to support it (their hidden channel `WS` business?), or maybe it's being silently ignored by FOLIO 🤷‍♂️ 

Fixes #4641

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
