### PR TITLE
Include the course ID in HB notice

### DIFF
--- a/app/services/folio/courses.rb
+++ b/app/services/folio/courses.rb
@@ -26,7 +26,7 @@ module Folio
         # Debugging https://github.com/sul-dlss/SearchWorks/issues/4631
         if end_date.blank?
           Honeybadger.notify('Course has no end date',
-                             context: { course_number: v['courseNumber'], name: v['name'], start_date: v.dig('courseListingObject', 'termObject', 'startDate') })
+                             context: { id: v['id'], course_number: v['courseNumber'], name: v['name'], start_date: v.dig('courseListingObject', 'termObject', 'startDate') })
         end
 
         CourseReserve.where(id: v['id']).first_or_create(id: v['id']).update(


### PR DESCRIPTION
I think we also need the course ID here. All the current reported course numbers have valid start/end dates. We need to confirm we are comparing the exact same courses and not a course with the same code/name that's not associated with a term.