### PR TITLE
enable blacklight on articles email form modal

### DIFF
--- a/app/views/articles/_email_form.html.erb
+++ b/app/views/articles/_email_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag email_articles_path, :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
+<%= form_tag email_articles_path, :data => { blacklight_modal: 'trigger' }, :id => 'email_form', :class => "form-horizontal modal_form", :method => :post do %>
   <div class="modal-body">
     <%= render :partial=>'shared/email_form' %>
 


### PR DESCRIPTION
closes #4632 
This was happening because without the blacklight modal trigger, the modal was redirecting to /articles/email after clicking on the send button. Someone probably refreshed the page to trigger the error. 

Change moves this in line with how email works in the catalog.

https://searchworks.stanford.edu/articles/nlebk__3435673

https://github.com/user-attachments/assets/852b8a9b-bd89-4b96-9eb2-498988c114d1

