### PR TITLE
Use the prescribed way to configure action_mailer defaults

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  # default from: "from@example.com"
+  default from: 'no-reply@searchworks.stanford.edu'
   # layout "mailer"
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,8 +7,6 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-ActionMailer::Base.default from: 'no-reply@searchworks.stanford.edu'
-
 module SearchWorks
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
This older way doesn't work in Rails 8.  See https://guides.rubyonrails.org/v7.2/action_mailer_basics.html#generate-the-mailer
