### PR TITLE
Don't use the -- subfield delimiter for the 752 relator term; it should be separated by a comma from the geography.

### DIFF
--- a/app/models/concerns/marc_metadata.rb
+++ b/app/models/concerns/marc_metadata.rb
@@ -52,6 +52,10 @@ module MarcMetadata
     @added_entry ||= AddedEntry.new(self)
   end
 
+  def hierarchical_place_name
+    @hierarchical_place_name ||= HierarchicalPlaceName.new(self)
+  end
+
   def local_subjects
     @local_subjects ||= LocalSubjects.new(self)
   end

--- a/app/models/marc_fields/hierarchical_place_name.rb
+++ b/app/models/marc_fields/hierarchical_place_name.rb
@@ -4,6 +4,25 @@
 # A class to handle MARC 752 field logic
 # https://www.loc.gov/marc/bibliographic/bd752.html
 class HierarchicalPlaceName < MarcField
+  def display_value(field, subfields)
+    return if subfields.blank?
+
+    subfields.inject(+'') do |acc, subfield|
+      acc << if acc.blank?
+               ''
+             elsif subfield.code == 'e'
+               if acc.ends_with?(',')
+                 ' '
+               else
+                 ', '
+               end
+             else
+               subfield_delimiter
+             end
+      acc << sanitize_marc_value(subfield_value(field, subfield))
+    end
+  end
+
   private
 
   def tags

--- a/app/models/marc_fields/hierarchical_place_name.rb
+++ b/app/models/marc_fields/hierarchical_place_name.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+##
+# A class to handle MARC 752 field logic
+# https://www.loc.gov/marc/bibliographic/bd752.html
+class HierarchicalPlaceName < MarcField
+  private
+
+  def tags
+    %w[752]
+  end
+end

--- a/app/views/catalog/record/_marc_bibliographic.html.erb
+++ b/app/views/catalog/record/_marc_bibliographic.html.erb
@@ -7,7 +7,7 @@
   310, 321, 340, 362, :unlinked_series,
   500, 501, 502, 506, 507, 508, 510, 511, 513, 514, 515, 516, 518, 521, 522, 524, 525, 526, 530, 533, 534, 535, 536, 538, 540, 541, 542, 544, 545, 547, 550, 552, 555, 556, 561, 562, 563, 565, 567, 580, 581, 583, 584, 585,
   :awards, :bound_with_note, :database_note,
-  :linked_related_works, :added_entry, 752, 753, 754, :linked_serials, :local_subjects, 796, 797, 798, 799,
+  :linked_related_works, :added_entry, :hierarchical_place_name, 753, 754, :linked_serials, :local_subjects, 796, 797, 798, 799,
   :isbn, :issn, :doi, '028', 222
   ]
 %>

--- a/spec/models/marc_fields/place_name_spec.rb
+++ b/spec/models/marc_fields/place_name_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Place names' do
 
   let(:document) { SolrDocument.new(marc_json_struct: place_name_fixture) }
 
-  subject(:place_name) { document.marc_field(752) }
+  subject(:place_name) { document.marc_field(:hierarchical_place_name) }
 
   it 'returns MARC 752' do
     expect(place_name.values).to be_present

--- a/spec/models/marc_fields/place_name_spec.rb
+++ b/spec/models/marc_fields/place_name_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Place names' do
   include MarcMetadataFixtures
 
-  let(:document) { SolrDocument.new(marc_json_struct: place_name_fixture) }
+  let(:document) { SolrDocument.new(marc_json_struct: fixture) }
+  let(:fixture) { place_name_fixture }
 
   subject(:place_name) { document.marc_field(:hierarchical_place_name) }
 
@@ -20,5 +21,71 @@ RSpec.describe 'Place names' do
   it 'joins subfields with a --' do
     expect(place_name.values.length).to eq 1
     expect(place_name.values.first).to eq 'Florida -- Tampa'
+  end
+
+  context 'with a relator term ($e)' do
+    let(:fixture) do
+      <<-JSON
+        {
+          "leader": "          22        4500",
+          "fields": [
+            {
+              "752": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Scotland"
+                  },
+                  {
+                    "d": "Edinburgh,"
+                  },
+                  {
+                    "e": "publication place."
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      JSON
+    end
+
+    it 'appends the relator term to the previous field' do
+      expect(place_name.values.first).to eq 'Scotland -- Edinburgh, publication place.'
+    end
+  end
+
+  context 'with a relator term ($e) not preceded by the appropriate punctuation' do
+    let(:fixture) do
+      <<-JSON
+        {
+          "leader": "          22        4500",
+          "fields": [
+            {
+              "752": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "England"
+                  },
+                  {
+                    "d": "London"
+                  },
+                  {
+                    "e": "publication place."
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      JSON
+    end
+
+    it 'adds a comma before the relator term' do
+      expect(place_name.values.first).to eq 'England -- London, publication place.'
+    end
   end
 end


### PR DESCRIPTION
Fixes #4531