### PR TITLE
Enable RSpec/ExampleWording

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,16 +9,16 @@
 # Offense count: 21
 Capybara/SpecificActions:
   Exclude:
-    - 'spec/features/blacklight_customizations/emailing_records_spec.rb'
-    - 'spec/features/brief_view_spec.rb'
-    - 'spec/features/image_collection_spec.rb'
-    - 'spec/features/merged_file_collection_spec.rb'
-    - 'spec/features/merged_image_collections_spec.rb'
-    - 'spec/features/mhld_spec.rb'
-    - 'spec/features/responsive/record_toolbar_responsive_spec.rb'
-    - 'spec/features/skip_to_nav_spec.rb'
-    - 'spec/features/sort_and_per_page_dropdown_spec.rb'
-    - 'spec/features/tabbed_selections_spec.rb'
+    - "spec/features/blacklight_customizations/emailing_records_spec.rb"
+    - "spec/features/brief_view_spec.rb"
+    - "spec/features/image_collection_spec.rb"
+    - "spec/features/merged_file_collection_spec.rb"
+    - "spec/features/merged_image_collections_spec.rb"
+    - "spec/features/mhld_spec.rb"
+    - "spec/features/responsive/record_toolbar_responsive_spec.rb"
+    - "spec/features/skip_to_nav_spec.rb"
+    - "spec/features/sort_and_per_page_dropdown_spec.rb"
+    - "spec/features/tabbed_selections_spec.rb"
 
 # Offense count: 64
 Capybara/SpecificMatcher:
@@ -34,9 +34,9 @@ Capybara/VisibilityMatcher:
 # SupportedStyles: with_first_argument, with_fixed_indentation
 Layout/ArgumentAlignment:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/helpers/feedback_form_helper.rb'
-    - 'spec/models/eds/repository_spec.rb'
+    - "app/controllers/catalog_controller.rb"
+    - "app/helpers/feedback_form_helper.rb"
+    - "spec/models/eds/repository_spec.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
@@ -44,62 +44,62 @@ Layout/ArgumentAlignment:
 # SupportedStylesAlignWith: start_of_line, begin
 Layout/BeginEndAlignment:
   Exclude:
-    - 'app/models/performance_alerts.rb'
+    - "app/models/performance_alerts.rb"
 
 # Offense count: 10
 # This cop supports safe autocorrection (--autocorrect).
 Layout/BlockEndNewline:
   Exclude:
-    - 'spec/lib/holdings/library_spec.rb'
-    - 'spec/lib/holdings/location_spec.rb'
-    - 'spec/models/concerns/cjk_query_spec.rb'
-    - 'spec/models/concerns/collection_member_spec.rb'
-    - 'spec/models/concerns/digital_collection_spec.rb'
-    - 'spec/models/concerns/index_authors_spec.rb'
-    - 'spec/views/collection_members/_file_collection_members.html.erb_spec.rb'
+    - "spec/lib/holdings/library_spec.rb"
+    - "spec/lib/holdings/location_spec.rb"
+    - "spec/models/concerns/cjk_query_spec.rb"
+    - "spec/models/concerns/collection_member_spec.rb"
+    - "spec/models/concerns/digital_collection_spec.rb"
+    - "spec/models/concerns/index_authors_spec.rb"
+    - "spec/views/collection_members/_file_collection_members.html.erb_spec.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Layout/ClosingParenthesisIndentation:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
+    - "app/views/catalog/index.atom.builder"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment.
 Layout/CommentIndentation:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
+    - "app/controllers/catalog_controller.rb"
 
 # Offense count: 5
 # This cop supports safe autocorrection (--autocorrect).
 Layout/ElseAlignment:
   Exclude:
-    - 'app/components/access_panels/library_component.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/models/concerns/schema_dot_org.rb'
+    - "app/components/access_panels/library_component.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/models/concerns/schema_dot_org.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Layout/EmptyLineAfterGuardClause:
   Exclude:
-    - 'lib/hours_request.rb'
+    - "lib/hours_request.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EmptyLineBetweenMethodDefs, EmptyLineBetweenClassDefs, EmptyLineBetweenModuleDefs, DefLikeMacros, AllowAdjacentOneLineDefs, NumberOfEmptyLines.
 Layout/EmptyLineBetweenDefs:
   Exclude:
-    - 'app/models/concerns/cjk_query.rb'
+    - "app/models/concerns/cjk_query.rb"
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
 Layout/EmptyLines:
   Exclude:
-    - 'app/models/concerns/cjk_query.rb'
-    - 'app/views/catalog/index.atom.builder'
-    - 'config/initializers/new_framework_defaults_7_1.rb'
-    - 'spec/views/catalog/thumbnails/_collection_thumbnail.html.erb_spec.rb'
+    - "app/models/concerns/cjk_query.rb"
+    - "app/views/catalog/index.atom.builder"
+    - "config/initializers/new_framework_defaults_7_1.rb"
+    - "spec/views/catalog/thumbnails/_collection_thumbnail.html.erb_spec.rb"
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
@@ -107,13 +107,13 @@ Layout/EmptyLines:
 # AllowedMethods: alias_method, public, protected, private
 Layout/EmptyLinesAroundAttributeAccessor:
   Exclude:
-    - 'app/models/concerns/eds_subjects.rb'
-    - 'app/models/marc_fields/marc_field_wrapper.rb'
-    - 'app/models/search_tips.rb'
-    - 'app/services/eds/search_service.rb'
-    - 'config/initializers/okcomputer.rb'
-    - 'spec/presenters/facet_options_presenter_spec.rb'
-    - 'spec/support/stub_article_service.rb'
+    - "app/models/concerns/eds_subjects.rb"
+    - "app/models/marc_fields/marc_field_wrapper.rb"
+    - "app/models/search_tips.rb"
+    - "app/services/eds/search_service.rb"
+    - "config/initializers/okcomputer.rb"
+    - "spec/presenters/facet_options_presenter_spec.rb"
+    - "spec/support/stub_article_service.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -121,7 +121,7 @@ Layout/EmptyLinesAroundAttributeAccessor:
 # SupportedStyles: empty_lines, no_empty_lines
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
+    - "app/views/catalog/index.atom.builder"
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
@@ -129,20 +129,20 @@ Layout/EmptyLinesAroundBlockBody:
 # SupportedStylesAlignWith: keyword, variable, start_of_line
 Layout/EndAlignment:
   Exclude:
-    - 'app/components/access_panels/library_component.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/models/concerns/schema_dot_org.rb'
+    - "app/components/access_panels/library_component.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/models/concerns/schema_dot_org.rb"
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
 Layout/ExtraSpacing:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
-    - 'spec/controllers/concerns/replace_special_quotes_spec.rb'
-    - 'spec/features/article_record_toolbar_spec.rb'
-    - 'spec/models/concerns/marc_links_spec.rb'
-    - 'spec/models/marc_fields/marc_field_wrapper_spec.rb'
+    - "app/views/catalog/index.atom.builder"
+    - "spec/controllers/concerns/replace_special_quotes_spec.rb"
+    - "spec/features/article_record_toolbar_spec.rb"
+    - "spec/models/concerns/marc_links_spec.rb"
+    - "spec/models/marc_fields/marc_field_wrapper_spec.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -150,8 +150,8 @@ Layout/ExtraSpacing:
 # SupportedStyles: consistent, consistent_relative_to_receiver, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
 Layout/FirstArgumentIndentation:
   Exclude:
-    - 'spec/views/catalog/record/_marc_contents_summary.html.erb_spec.rb'
-    - 'spec/views/catalog/record/_marc_subjects.html.erb_spec.rb'
+    - "spec/views/catalog/record/_marc_contents_summary.html.erb_spec.rb"
+    - "spec/views/catalog/record/_marc_subjects.html.erb_spec.rb"
 
 # Offense count: 46
 # This cop supports safe autocorrection (--autocorrect).
@@ -166,8 +166,8 @@ Layout/FirstArrayElementIndentation:
 # SupportedStyles: special_inside_parentheses, consistent, align_braces
 Layout/FirstHashElementIndentation:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/controllers/catalog_controller.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/controllers/catalog_controller.rb"
 
 # Offense count: 131
 # This cop supports safe autocorrection (--autocorrect).
@@ -177,40 +177,40 @@ Layout/FirstHashElementIndentation:
 # SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
 Layout/HashAlignment:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/models/concerns/eds_links.rb'
-    - 'app/models/eds/session.rb'
-    - 'app/models/marc_fields/linked_related_works.rb'
-    - 'app/views/catalog/index.atom.builder'
-    - 'spec/features/article_searching_spec.rb'
-    - 'spec/models/concerns/cjk_query_spec.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/controllers/catalog_controller.rb"
+    - "app/models/concerns/eds_links.rb"
+    - "app/models/eds/session.rb"
+    - "app/models/marc_fields/linked_related_works.rb"
+    - "app/views/catalog/index.atom.builder"
+    - "spec/features/article_searching_spec.rb"
+    - "spec/models/concerns/cjk_query_spec.rb"
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Width, AllowedPatterns.
 Layout/IndentationWidth:
   Exclude:
-    - 'app/components/access_panels/library_component.rb'
-    - 'app/controllers/concerns/stanford_work_facet.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/models/concerns/schema_dot_org.rb'
-    - 'app/models/marc_fields/marc_field_wrapper.rb'
+    - "app/components/access_panels/library_component.rb"
+    - "app/controllers/concerns/stanford_work_facet.rb"
+    - "app/helpers/application_helper.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/models/concerns/schema_dot_org.rb"
+    - "app/models/marc_fields/marc_field_wrapper.rb"
 
 # Offense count: 10
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowDoxygenCommentStyle, AllowGemfileRubyComment, AllowRBSInlineAnnotation, AllowSteepAnnotation.
 Layout/LeadingCommentSpace:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/models/application_record.rb'
-    - 'app/views/catalog/index.mobile.builder'
-    - 'spec/components/access_panels/at_the_library_component_spec.rb'
-    - 'spec/features/file_collection_spec.rb'
-    - 'spec/features/image_collection_spec.rb'
+    - "app/controllers/catalog_controller.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
+    - "app/models/application_record.rb"
+    - "app/views/catalog/index.mobile.builder"
+    - "spec/components/access_panels/at_the_library_component_spec.rb"
+    - "spec/features/file_collection_spec.rb"
+    - "spec/features/image_collection_spec.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -218,8 +218,8 @@ Layout/LeadingCommentSpace:
 # SupportedStyles: space, no_space
 Layout/LineContinuationSpacing:
   Exclude:
-    - 'spec/features/alternate_catalog_spec.rb'
-    - 'spec/views/catalog/_alternate_catalog.html.erb_spec.rb'
+    - "spec/features/alternate_catalog_spec.rb"
+    - "spec/views/catalog/_alternate_catalog.html.erb_spec.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -227,20 +227,20 @@ Layout/LineContinuationSpacing:
 # SupportedStyles: aligned, indented
 Layout/LineEndStringConcatenationIndentation:
   Exclude:
-    - 'spec/features/alternate_catalog_spec.rb'
-    - 'spec/views/catalog/_alternate_catalog.html.erb_spec.rb'
+    - "spec/features/alternate_catalog_spec.rb"
+    - "spec/views/catalog/_alternate_catalog.html.erb_spec.rb"
 
 # Offense count: 9
 # This cop supports safe autocorrection (--autocorrect).
 Layout/MultilineBlockLayout:
   Exclude:
-    - 'spec/lib/holdings/library_spec.rb'
-    - 'spec/lib/holdings/location_spec.rb'
-    - 'spec/models/concerns/cjk_query_spec.rb'
-    - 'spec/models/concerns/collection_member_spec.rb'
-    - 'spec/models/concerns/digital_collection_spec.rb'
-    - 'spec/models/concerns/index_authors_spec.rb'
-    - 'spec/views/collection_members/_file_collection_members.html.erb_spec.rb'
+    - "spec/lib/holdings/library_spec.rb"
+    - "spec/lib/holdings/location_spec.rb"
+    - "spec/models/concerns/cjk_query_spec.rb"
+    - "spec/models/concerns/collection_member_spec.rb"
+    - "spec/models/concerns/digital_collection_spec.rb"
+    - "spec/models/concerns/index_authors_spec.rb"
+    - "spec/views/collection_members/_file_collection_members.html.erb_spec.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -248,7 +248,7 @@ Layout/MultilineBlockLayout:
 # SupportedStyles: symmetrical, new_line, same_line
 Layout/MultilineHashBraceLayout:
   Exclude:
-    - 'app/helpers/browse_helper.rb'
+    - "app/helpers/browse_helper.rb"
 
 # Offense count: 5
 # This cop supports safe autocorrection (--autocorrect).
@@ -256,8 +256,8 @@ Layout/MultilineHashBraceLayout:
 # SupportedStyles: symmetrical, new_line, same_line
 Layout/MultilineMethodCallBraceLayout:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
-    - 'spec/models/eds/repository_spec.rb'
+    - "app/views/catalog/index.atom.builder"
+    - "spec/models/eds/repository_spec.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
@@ -265,7 +265,7 @@ Layout/MultilineMethodCallBraceLayout:
 # SupportedStyles: aligned, indented, indented_relative_to_receiver
 Layout/MultilineMethodCallIndentation:
   Exclude:
-    - 'config/environments/production.rb'
+    - "config/environments/production.rb"
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
@@ -273,21 +273,21 @@ Layout/MultilineMethodCallIndentation:
 # SupportedStyles: aligned, indented
 Layout/MultilineOperationIndentation:
   Exclude:
-    - 'lib/search_query_modifier.rb'
-    - 'spec/helpers/application_helper_spec.rb'
+    - "lib/search_query_modifier.rb"
+    - "spec/helpers/application_helper_spec.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Layout/RescueEnsureAlignment:
   Exclude:
-    - 'app/models/performance_alerts.rb'
+    - "app/models/performance_alerts.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Layout/SpaceAfterComma:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
-    - 'app/views/catalog/opensearch.xml.builder'
+    - "app/views/catalog/index.atom.builder"
+    - "app/views/catalog/opensearch.xml.builder"
 
 # Offense count: 15
 # This cop supports safe autocorrection (--autocorrect).
@@ -296,15 +296,15 @@ Layout/SpaceAfterComma:
 # SupportedStylesForRationalLiterals: space, no_space
 Layout/SpaceAroundOperators:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
-    - 'app/views/catalog/opensearch.xml.builder'
+    - "app/views/catalog/index.atom.builder"
+    - "app/views/catalog/opensearch.xml.builder"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment.
 Layout/SpaceBeforeFirstArg:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
+    - "app/views/catalog/index.atom.builder"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
@@ -313,7 +313,7 @@ Layout/SpaceBeforeFirstArg:
 # SupportedStylesForEmptyBrackets: space, no_space
 Layout/SpaceInsideArrayLiteralBrackets:
   Exclude:
-    - 'config/environments/production.rb'
+    - "config/environments/production.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -322,7 +322,7 @@ Layout/SpaceInsideArrayLiteralBrackets:
 # SupportedStylesForEmptyBraces: space, no_space
 Layout/SpaceInsideBlockBraces:
   Exclude:
-    - 'spec/models/search_builder_spec.rb'
+    - "spec/models/search_builder_spec.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -331,7 +331,7 @@ Layout/SpaceInsideBlockBraces:
 # SupportedStylesForEmptyBraces: space, no_space
 Layout/SpaceInsideHashLiteralBraces:
   Exclude:
-    - 'spec/helpers/catalog_helper_spec.rb'
+    - "spec/helpers/catalog_helper_spec.rb"
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
@@ -339,70 +339,70 @@ Layout/SpaceInsideHashLiteralBraces:
 # SupportedStyles: space, compact, no_space
 Layout/SpaceInsideParens:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
-    - 'spec/components/access_panels/at_the_library_component_spec.rb'
+    - "app/views/catalog/index.atom.builder"
+    - "spec/components/access_panels/at_the_library_component_spec.rb"
 
 # Offense count: 10
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowInHeredoc.
 Layout/TrailingWhitespace:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
-    - 'config/initializers/new_framework_defaults_7_1.rb'
+    - "app/views/catalog/index.atom.builder"
+    - "config/initializers/new_framework_defaults_7_1.rb"
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - 'spec/controllers/catalog_controller_spec.rb'
+    - "spec/controllers/catalog_controller_spec.rb"
 
 # Offense count: 13
 # This cop supports safe autocorrection (--autocorrect).
 Lint/AmbiguousRegexpLiteral:
   Exclude:
-    - 'spec/controllers/concerns/callnumber_search_spec.rb'
-    - 'spec/helpers/collection_helper_spec.rb'
-    - 'spec/helpers/masthead_helper_spec.rb'
-    - 'spec/helpers/record_helper_spec.rb'
-    - 'spec/models/concerns/mods_data_spec.rb'
-    - 'spec/tasks/fixtures_indexer_spec.rb'
+    - "spec/controllers/concerns/callnumber_search_spec.rb"
+    - "spec/helpers/collection_helper_spec.rb"
+    - "spec/helpers/masthead_helper_spec.rb"
+    - "spec/helpers/record_helper_spec.rb"
+    - "spec/models/concerns/mods_data_spec.rb"
+    - "spec/tasks/fixtures_indexer_spec.rb"
 
 # Offense count: 1
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches, IgnoreDuplicateElseBranch.
 Lint/DuplicateBranch:
   Exclude:
-    - 'app/models/concerns/eds_subjects.rb'
+    - "app/models/concerns/eds_subjects.rb"
 
 # Offense count: 1
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:
   Exclude:
-    - 'app/controllers/bookmarks_controller.rb'
+    - "app/controllers/bookmarks_controller.rb"
 
 # Offense count: 7
 # Configuration parameters: AllowedParentClasses.
 Lint/MissingSuper:
   Exclude:
-    - 'app/components/access_panels/base.rb'
-    - 'app/components/access_panels/layout_component.rb'
-    - 'app/components/access_panels/library_component.rb'
-    - 'app/components/access_panels/library_location_component.rb'
-    - 'app/components/advanced_search_range_limit_component.rb'
-    - 'app/components/searchworks/response/facet_group_component.rb'
-    - 'app/models/marc_fields/linked_author.rb'
+    - "app/components/access_panels/base.rb"
+    - "app/components/access_panels/layout_component.rb"
+    - "app/components/access_panels/library_component.rb"
+    - "app/components/access_panels/library_location_component.rb"
+    - "app/components/advanced_search_range_limit_component.rb"
+    - "app/components/searchworks/response/facet_group_component.rb"
+    - "app/models/marc_fields/linked_author.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
-    - 'spec/features/home_page_spec.rb'
+    - "spec/features/home_page_spec.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Lint/RedundantCopDisableDirective:
   Exclude:
-    - 'spec/models/marc_fields/linked_author_spec.rb'
+    - "spec/models/marc_fields/linked_author_spec.rb"
 
 # Offense count: 11
 # This cop supports safe autocorrection (--autocorrect).
@@ -410,19 +410,19 @@ Lint/RedundantCopDisableDirective:
 # SupportedStyles: strict, consistent
 Lint/SymbolConversion:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
-    - 'spec/models/citation_spec.rb'
-    - 'spec/models/json_results_document_presenter_spec.rb'
+    - "app/controllers/catalog_controller.rb"
+    - "spec/models/citation_spec.rb"
+    - "spec/models/json_results_document_presenter_spec.rb"
 
 # Offense count: 12
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AutoCorrect, IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
   Exclude:
-    - 'app/models/article_search_builder.rb'
-    - 'app/models/marc_fields/issn.rb'
-    - 'config/initializers/devise.rb'
-    - 'lib/tasks/searchworks.rake'
+    - "app/models/article_search_builder.rb"
+    - "app/models/marc_fields/issn.rb"
+    - "config/initializers/devise.rb"
+    - "lib/tasks/searchworks.rake"
 
 # Offense count: 9
 # This cop supports safe autocorrection (--autocorrect).
@@ -430,18 +430,18 @@ Lint/UnusedBlockArgument:
 # NotImplementedExceptions: NotImplementedError
 Lint/UnusedMethodArgument:
   Exclude:
-    - 'app/components/advanced_search_range_limit_component.rb'
-    - 'app/components/metadata_field_layout_component.rb'
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/helpers/collection_helper.rb'
-    - 'app/helpers/thumbnail_helper.rb'
-    - 'app/services/eds/search_service.rb'
+    - "app/components/advanced_search_range_limit_component.rb"
+    - "app/components/metadata_field_layout_component.rb"
+    - "app/controllers/catalog_controller.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/helpers/collection_helper.rb"
+    - "app/helpers/thumbnail_helper.rb"
+    - "app/services/eds/search_service.rb"
 
 # Offense count: 1
 Naming/AccessorMethodName:
   Exclude:
-    - 'app/helpers/collection_access_point_helper.rb'
+    - "app/helpers/collection_access_point_helper.rb"
 
 # Offense count: 58
 # This cop supports safe autocorrection (--autocorrect).
@@ -449,9 +449,9 @@ Naming/AccessorMethodName:
 # SupportedStyles: lowercase, uppercase
 Naming/HeredocDelimiterCase:
   Exclude:
-    - 'spec/fixtures/marc_records/marc_856_fixtures.rb'
-    - 'spec/fixtures/marc_records/marc_metadata_fixtures.rb'
-    - 'spec/fixtures/mods_records/mods_fixtures.rb'
+    - "spec/fixtures/marc_records/marc_856_fixtures.rb"
+    - "spec/fixtures/marc_records/marc_metadata_fixtures.rb"
+    - "spec/fixtures/mods_records/mods_fixtures.rb"
 
 # Offense count: 4
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -459,10 +459,10 @@ Naming/HeredocDelimiterCase:
 # SupportedStylesForLeadingUnderscores: disallowed, required, optional
 Naming/MemoizedInstanceVariableName:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/helpers/article_helper.rb'
-    - 'app/models/concerns/solr_set.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/controllers/catalog_controller.rb"
+    - "app/helpers/article_helper.rb"
+    - "app/models/concerns/solr_set.rb"
 
 # Offense count: 3
 # Configuration parameters: NamePrefix, ForbiddenPrefixes, AllowedMethods, MethodDefinitionMacros, UseSorbetSigs.
@@ -472,9 +472,9 @@ Naming/MemoizedInstanceVariableName:
 # MethodDefinitionMacros: define_method, define_singleton_method
 Naming/PredicateName:
   Exclude:
-    - 'app/models/concerns/collection_member.rb'
-    - 'app/models/concerns/database_document.rb'
-    - 'app/models/concerns/digital_collection.rb'
+    - "app/models/concerns/collection_member.rb"
+    - "app/models/concerns/database_document.rb"
+    - "app/models/concerns/digital_collection.rb"
 
 # Offense count: 23
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
@@ -482,41 +482,41 @@ Naming/PredicateName:
 # AllowedIdentifiers: TLS1_1, TLS1_2, capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339, x86_64
 Naming/VariableNumber:
   Exclude:
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/models/hoover_open_url_request.rb'
-    - 'spec/fixtures/marc_records/marc_856_fixtures.rb'
-    - 'spec/fixtures/mods_records/mods_fixtures.rb'
-    - 'spec/helpers/results_document_helper_spec.rb'
-    - 'spec/models/concerns/cjk_query_spec.rb'
+    - "app/helpers/xml_api_helper.rb"
+    - "app/models/hoover_open_url_request.rb"
+    - "spec/fixtures/marc_records/marc_856_fixtures.rb"
+    - "spec/fixtures/mods_records/mods_fixtures.rb"
+    - "spec/helpers/results_document_helper_spec.rb"
+    - "spec/models/concerns/cjk_query_spec.rb"
 
 # Offense count: 15
 RSpec/AnyInstance:
   Exclude:
-    - 'spec/controllers/catalog_controller_spec.rb'
-    - 'spec/controllers/feedback_forms_controller_spec.rb'
-    - 'spec/features/access_panels/online_spec.rb'
-    - 'spec/features/article_display_spec.rb'
-    - 'spec/lib/purl_embed_spec.rb'
-    - 'spec/presenters/sms_presenter_spec.rb'
-    - 'spec/support/stub_article_service.rb'
-    - 'spec/tasks/fixtures_indexer_spec.rb'
+    - "spec/controllers/catalog_controller_spec.rb"
+    - "spec/controllers/feedback_forms_controller_spec.rb"
+    - "spec/features/access_panels/online_spec.rb"
+    - "spec/features/article_display_spec.rb"
+    - "spec/lib/purl_embed_spec.rb"
+    - "spec/presenters/sms_presenter_spec.rb"
+    - "spec/support/stub_article_service.rb"
+    - "spec/tasks/fixtures_indexer_spec.rb"
 
 # Offense count: 2
 RSpec/BeforeAfterAll:
   Exclude:
-    - 'spec/helpers/results_document_helper_spec.rb'
-    - 'spec/lib/sms_spec.rb'
+    - "spec/helpers/results_document_helper_spec.rb"
+    - "spec/lib/sms_spec.rb"
 
 # Offense count: 18
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/ContextMethod:
   Exclude:
-    - 'spec/helpers/article_helper_spec.rb'
-    - 'spec/models/concerns/eds_links_spec.rb'
-    - 'spec/models/concerns/eds_subjects_spec.rb'
-    - 'spec/models/marc_fields/linked_related_works_spec.rb'
-    - 'spec/routing/article_routes_spec.rb'
-    - 'spec/services/eds/search_service_spec.rb'
+    - "spec/helpers/article_helper_spec.rb"
+    - "spec/models/concerns/eds_links_spec.rb"
+    - "spec/models/concerns/eds_subjects_spec.rb"
+    - "spec/models/marc_fields/linked_related_works_spec.rb"
+    - "spec/routing/article_routes_spec.rb"
+    - "spec/services/eds/search_service_spec.rb"
 
 # Offense count: 214
 # Configuration parameters: Prefixes, AllowedPatterns.
@@ -541,35 +541,28 @@ RSpec/EmptyLineAfterExample:
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/EmptyLineAfterFinalLet:
   Exclude:
-    - 'spec/features/access_panels/exhibit_spec.rb'
-    - 'spec/models/marc_extractor_spec.rb'
+    - "spec/features/access_panels/exhibit_spec.rb"
+    - "spec/models/marc_extractor_spec.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/EmptyLineAfterSubject:
   Exclude:
-    - 'spec/components/access_panels/library_component_spec.rb'
+    - "spec/components/access_panels/library_component_spec.rb"
 
 # Offense count: 217
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
   Max: 30
 
-# Offense count: 402
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: CustomTransform, IgnoredWords, DisallowedExamples.
-# DisallowedExamples: works
-RSpec/ExampleWording:
-  Enabled: false
-
 # Offense count: 8
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/ExcessiveDocstringSpacing:
   Exclude:
-    - 'spec/features/responsive/record_toolbar_responsive_spec.rb'
-    - 'spec/features/responsive/results_toolbar_spec.rb'
-    - 'spec/features/responsive/search_toolbar_responsive_spec.rb'
-    - 'spec/mailers/search_works_record_mailer_spec.rb'
+    - "spec/features/responsive/record_toolbar_responsive_spec.rb"
+    - "spec/features/responsive/results_toolbar_spec.rb"
+    - "spec/features/responsive/search_toolbar_responsive_spec.rb"
+    - "spec/mailers/search_works_record_mailer_spec.rb"
 
 # Offense count: 34
 RSpec/ExpectInHook:
@@ -578,36 +571,36 @@ RSpec/ExpectInHook:
 # Offense count: 2
 RSpec/IdenticalEqualityAssertion:
   Exclude:
-    - 'spec/controllers/concerns/callnumber_search_spec.rb'
-    - 'spec/models/marc_fields/marc_field_wrapper_spec.rb'
+    - "spec/controllers/concerns/callnumber_search_spec.rb"
+    - "spec/models/marc_fields/marc_field_wrapper_spec.rb"
 
 # Offense count: 4
 # Configuration parameters: Max, AllowedIdentifiers, AllowedPatterns.
 RSpec/IndexedLet:
   Exclude:
-    - 'spec/controllers/recent_selections_controller_spec.rb'
-    - 'spec/models/concerns/cjk_query_spec.rb'
+    - "spec/controllers/recent_selections_controller_spec.rb"
+    - "spec/models/concerns/cjk_query_spec.rb"
 
 # Offense count: 18
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:
-    - 'spec/helpers/bookmarks_helper_spec.rb'
-    - 'spec/helpers/results_document_helper_spec.rb'
-    - 'spec/services/eds/search_service_spec.rb'
+    - "spec/helpers/bookmarks_helper_spec.rb"
+    - "spec/helpers/results_document_helper_spec.rb"
+    - "spec/services/eds/search_service_spec.rb"
 
 # Offense count: 13
 RSpec/IteratedExpectation:
   Exclude:
-    - 'spec/lib/holdings_spec.rb'
-    - 'spec/lib/search_works_marc/instrumentation_spec.rb'
-    - 'spec/models/concerns/collection_member_spec.rb'
-    - 'spec/models/concerns/digital_collection_spec.rb'
-    - 'spec/models/concerns/eds_links_spec.rb'
-    - 'spec/models/concerns/eds_subjects_spec.rb'
-    - 'spec/models/concerns/index_links_spec.rb'
-    - 'spec/models/concerns/solr_bookplates_spec.rb'
-    - 'spec/tasks/fixtures_indexer_spec.rb'
+    - "spec/lib/holdings_spec.rb"
+    - "spec/lib/search_works_marc/instrumentation_spec.rb"
+    - "spec/models/concerns/collection_member_spec.rb"
+    - "spec/models/concerns/digital_collection_spec.rb"
+    - "spec/models/concerns/eds_links_spec.rb"
+    - "spec/models/concerns/eds_subjects_spec.rb"
+    - "spec/models/concerns/index_links_spec.rb"
+    - "spec/models/concerns/solr_bookplates_spec.rb"
+    - "spec/tasks/fixtures_indexer_spec.rb"
 
 # Offense count: 72
 # This cop supports safe autocorrection (--autocorrect).
@@ -617,16 +610,16 @@ RSpec/LeadingSubject:
 # Offense count: 6
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/recent_selections_controller_spec.rb'
-    - 'spec/presenters/facet_options_presenter_spec.rb'
+    - "spec/controllers/recent_selections_controller_spec.rb"
+    - "spec/presenters/facet_options_presenter_spec.rb"
 
 # Offense count: 4
 RSpec/MultipleDescribes:
   Exclude:
-    - 'spec/features/connection_form_spec.rb'
-    - 'spec/features/feedback_form_spec.rb'
-    - 'spec/features/preview_spec.rb'
-    - 'spec/features/quick_report_spec.rb'
+    - "spec/features/connection_form_spec.rb"
+    - "spec/features/feedback_form_spec.rb"
+    - "spec/features/preview_spec.rb"
+    - "spec/features/quick_report_spec.rb"
 
 # Offense count: 604
 RSpec/MultipleExpectations:
@@ -641,7 +634,7 @@ RSpec/MultipleMemoizedHelpers:
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/MultipleSubjects:
   Exclude:
-    - 'spec/services/eds/search_service_spec.rb'
+    - "spec/services/eds/search_service_spec.rb"
 
 # Offense count: 281
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
@@ -659,16 +652,16 @@ RSpec/NestedGroups:
 # AllowedPatterns: ^expect_, ^assert_
 RSpec/NoExpectationExample:
   Exclude:
-    - 'spec/lib/purl_embed_spec.rb'
+    - "spec/lib/purl_embed_spec.rb"
 
 # Offense count: 8
 RSpec/PendingWithoutReason:
   Exclude:
-    - 'spec/components/access_panels/at_the_library_component_spec.rb'
-    - 'spec/features/marc_results_metadata_spec.rb'
-    - 'spec/features/preview_spec.rb'
-    - 'spec/views/catalog/record/_callnumber_browse.html.erb_spec.rb'
-    - 'spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb'
+    - "spec/components/access_panels/at_the_library_component_spec.rb"
+    - "spec/features/marc_results_metadata_spec.rb"
+    - "spec/features/preview_spec.rb"
+    - "spec/views/catalog/record/_callnumber_browse.html.erb_spec.rb"
+    - "spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb"
 
 # Offense count: 42
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -676,43 +669,43 @@ RSpec/PendingWithoutReason:
 # SupportedStyles: inflected, explicit
 RSpec/PredicateMatcher:
   Exclude:
-    - 'spec/components/access_panels/online_component_spec.rb'
-    - 'spec/helpers/application_helper_spec.rb'
-    - 'spec/helpers/bookmarks_helper_spec.rb'
-    - 'spec/helpers/collection_access_point_helper_spec.rb'
-    - 'spec/helpers/feedback_form_helper_spec.rb'
-    - 'spec/lib/search_query_modifier_spec.rb'
-    - 'spec/models/concerns/collection_member_spec.rb'
-    - 'spec/models/concerns/database_document_spec.rb'
-    - 'spec/models/concerns/eds_links_spec.rb'
-    - 'spec/models/eds/repository_spec.rb'
+    - "spec/components/access_panels/online_component_spec.rb"
+    - "spec/helpers/application_helper_spec.rb"
+    - "spec/helpers/bookmarks_helper_spec.rb"
+    - "spec/helpers/collection_access_point_helper_spec.rb"
+    - "spec/helpers/feedback_form_helper_spec.rb"
+    - "spec/lib/search_query_modifier_spec.rb"
+    - "spec/models/concerns/collection_member_spec.rb"
+    - "spec/models/concerns/database_document_spec.rb"
+    - "spec/models/concerns/eds_links_spec.rb"
+    - "spec/models/eds/repository_spec.rb"
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/ReceiveCounts:
   Exclude:
-    - 'spec/helpers/collection_access_point_helper_spec.rb'
-    - 'spec/tasks/fixtures_indexer_spec.rb'
-    - 'spec/views/collection_members/_file_collection_members.html.erb_spec.rb'
+    - "spec/helpers/collection_access_point_helper_spec.rb"
+    - "spec/tasks/fixtures_indexer_spec.rb"
+    - "spec/views/collection_members/_file_collection_members.html.erb_spec.rb"
 
 # Offense count: 9
 RSpec/RepeatedDescription:
   Exclude:
-    - 'spec/controllers/catalog_controller_spec.rb'
-    - 'spec/features/blacklight_customizations/devise_spec.rb'
+    - "spec/controllers/catalog_controller_spec.rb"
+    - "spec/features/blacklight_customizations/devise_spec.rb"
 
 # Offense count: 4
 RSpec/RepeatedExample:
   Exclude:
-    - 'spec/controllers/catalog_controller_spec.rb'
-    - 'spec/models/marc_fields/unlinked_series_spec.rb'
+    - "spec/controllers/catalog_controller_spec.rb"
+    - "spec/models/marc_fields/unlinked_series_spec.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AutoCorrect.
 RSpec/ScatteredLet:
   Exclude:
-    - 'spec/presenters/sms_presenter_spec.rb'
+    - "spec/presenters/sms_presenter_spec.rb"
 
 # Offense count: 54
 RSpec/StubbedMock:
@@ -721,26 +714,26 @@ RSpec/StubbedMock:
 # Offense count: 6
 RSpec/SubjectDeclaration:
   Exclude:
-    - 'spec/controllers/concerns/callnumber_search_spec.rb'
-    - 'spec/models/bookplate_spec.rb'
-    - 'spec/models/concerns/solr_bookplates_spec.rb'
-    - 'spec/models/concerns/stacks_images_spec.rb'
-    - 'spec/models/eds/date_range_parser_spec.rb'
-    - 'spec/models/user_spec.rb'
+    - "spec/controllers/concerns/callnumber_search_spec.rb"
+    - "spec/models/bookplate_spec.rb"
+    - "spec/models/concerns/solr_bookplates_spec.rb"
+    - "spec/models/concerns/stacks_images_spec.rb"
+    - "spec/models/eds/date_range_parser_spec.rb"
+    - "spec/models/user_spec.rb"
 
 # Offense count: 18
 RSpec/SubjectStub:
   Exclude:
-    - 'spec/components/access_panels/sfx_component_spec.rb'
-    - 'spec/controllers/concerns/callnumber_search_spec.rb'
-    - 'spec/models/concerns/solr_set_spec.rb'
-    - 'spec/models/performance_alerts_spec.rb'
-    - 'spec/models/search_builder_spec.rb'
-    - 'spec/models/sfx_data_spec.rb'
-    - 'spec/models/user_spec.rb'
-    - 'spec/presenters/article_fulltext_link_presenter_spec.rb'
-    - 'spec/presenters/facet_options_presenter_spec.rb'
-    - 'spec/presenters/presenter_format_spec.rb'
+    - "spec/components/access_panels/sfx_component_spec.rb"
+    - "spec/controllers/concerns/callnumber_search_spec.rb"
+    - "spec/models/concerns/solr_set_spec.rb"
+    - "spec/models/performance_alerts_spec.rb"
+    - "spec/models/search_builder_spec.rb"
+    - "spec/models/sfx_data_spec.rb"
+    - "spec/models/user_spec.rb"
+    - "spec/presenters/article_fulltext_link_presenter_spec.rb"
+    - "spec/presenters/facet_options_presenter_spec.rb"
+    - "spec/presenters/presenter_format_spec.rb"
 
 # Offense count: 67
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
@@ -750,52 +743,52 @@ RSpec/VerifiedDoubles:
 # Offense count: 2
 RSpec/VoidExpect:
   Exclude:
-    - 'spec/controllers/concerns/database_access_point_spec.rb'
+    - "spec/controllers/concerns/database_access_point_spec.rb"
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/ApplicationRecord:
   Exclude:
-    - 'app/models/user.rb'
+    - "app/models/user.rb"
 
 # Offense count: 11
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: NilOrEmpty, NotPresent, UnlessPresent.
 Rails/Blank:
   Exclude:
-    - 'app/components/access_panels/online_component.rb'
-    - 'app/controllers/availability_controller.rb'
-    - 'app/controllers/concerns/advanced_search_params_mapping.rb'
-    - 'app/helpers/article_helper.rb'
-    - 'app/helpers/masthead_helper.rb'
-    - 'app/models/concerns/extent.rb'
-    - 'app/models/concerns/marc_bound_with_note.rb'
-    - 'app/models/marc_field.rb'
+    - "app/components/access_panels/online_component.rb"
+    - "app/controllers/availability_controller.rb"
+    - "app/controllers/concerns/advanced_search_params_mapping.rb"
+    - "app/helpers/article_helper.rb"
+    - "app/helpers/masthead_helper.rb"
+    - "app/models/concerns/extent.rb"
+    - "app/models/concerns/marc_bound_with_note.rb"
+    - "app/models/marc_field.rb"
 
 # Offense count: 5
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/CompactBlank:
   Exclude:
-    - 'app/controllers/concerns/email_validation.rb'
-    - 'app/models/concerns/extent.rb'
-    - 'app/models/hoover_open_url_request.rb'
-    - 'app/models/marc_fields/language.rb'
-    - 'app/models/marc_fields/subjects.rb'
+    - "app/controllers/concerns/email_validation.rb"
+    - "app/models/concerns/extent.rb"
+    - "app/models/hoover_open_url_request.rb"
+    - "app/models/marc_fields/language.rb"
+    - "app/models/marc_fields/subjects.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforceForPrefixed.
 Rails/Delegate:
   Exclude:
-    - 'app/components/access_panels/course_reserves_component.rb'
-    - 'app/components/searchworks_search_bar_component.rb'
-    - 'app/models/marc_fields/linked_author.rb'
+    - "app/components/access_panels/course_reserves_component.rb"
+    - "app/components/searchworks_search_bar_component.rb"
+    - "app/models/marc_fields/linked_author.rb"
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 Rails/DurationArithmetic:
   Exclude:
-    - 'spec/models/performance_alerts_spec.rb'
+    - "spec/models/performance_alerts_spec.rb"
 
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -805,7 +798,7 @@ Rails/DurationArithmetic:
 # AllowedReceivers: Gem::Specification, page
 Rails/DynamicFindBy:
   Exclude:
-    - 'spec/lib/holdings_spec.rb'
+    - "spec/lib/holdings_spec.rb"
 
 # Offense count: 10
 # This cop supports safe autocorrection (--autocorrect).
@@ -813,13 +806,13 @@ Rails/DynamicFindBy:
 # SupportedStyles: slashes, arguments
 Rails/FilePath:
   Exclude:
-    - 'app/controllers/concerns/backend_lookup.rb'
-    - 'app/controllers/hours_controller.rb'
-    - 'app/controllers/sfx_data_controller.rb'
-    - 'config/initializers/add_local_config_settings.rb'
-    - 'config/initializers/assets.rb'
-    - 'lib/fixtures_indexer.rb'
-    - 'lib/tasks/searchworks.rake'
+    - "app/controllers/concerns/backend_lookup.rb"
+    - "app/controllers/hours_controller.rb"
+    - "app/controllers/sfx_data_controller.rb"
+    - "config/initializers/add_local_config_settings.rb"
+    - "config/initializers/assets.rb"
+    - "lib/fixtures_indexer.rb"
+    - "lib/tasks/searchworks.rake"
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -827,39 +820,39 @@ Rails/FilePath:
 # AllowedMethods: order, limit, select, lock
 Rails/FindEach:
   Exclude:
-    - 'spec/models/concerns/eds_links_spec.rb'
+    - "spec/models/concerns/eds_links_spec.rb"
 
 # Offense count: 11
 # Configuration parameters: Include.
 # Include: app/helpers/**/*.rb
 Rails/HelperInstanceVariable:
   Exclude:
-    - 'app/helpers/article_helper.rb'
-    - 'app/helpers/collection_access_point_helper.rb'
-    - 'app/helpers/collection_helper.rb'
-    - 'app/helpers/masthead_helper.rb'
+    - "app/helpers/article_helper.rb"
+    - "app/helpers/collection_access_point_helper.rb"
+    - "app/helpers/collection_helper.rb"
+    - "app/helpers/masthead_helper.rb"
 
 # Offense count: 4
 Rails/I18nLocaleTexts:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/mailers/feedback_mailer.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/mailers/feedback_mailer.rb"
 
 # Offense count: 13
 # Configuration parameters: Include.
 # Include: app/controllers/**/*.rb, app/mailers/**/*.rb
 Rails/LexicallyScopedActionFilter:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/controllers/concerns/advanced_search_params_mapping.rb'
-    - 'app/controllers/concerns/all_caps_params.rb'
-    - 'app/controllers/concerns/callnumber_search.rb'
-    - 'app/controllers/concerns/database_access_point.rb'
-    - 'app/controllers/concerns/location_facet.rb'
-    - 'app/controllers/concerns/replace_special_quotes.rb'
-    - 'app/controllers/concerns/search_relevancy_logging.rb'
-    - 'app/controllers/concerns/stanford_work_facet.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/controllers/catalog_controller.rb"
+    - "app/controllers/concerns/advanced_search_params_mapping.rb"
+    - "app/controllers/concerns/all_caps_params.rb"
+    - "app/controllers/concerns/callnumber_search.rb"
+    - "app/controllers/concerns/database_access_point.rb"
+    - "app/controllers/concerns/location_facet.rb"
+    - "app/controllers/concerns/replace_special_quotes.rb"
+    - "app/controllers/concerns/search_relevancy_logging.rb"
+    - "app/controllers/concerns/stanford_work_facet.rb"
 
 # Offense count: 4
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -867,28 +860,28 @@ Rails/LexicallyScopedActionFilter:
 # Include: app/**/*.rb, config/**/*.rb, db/**/*.rb, lib/**/*.rb
 Rails/Output:
   Exclude:
-    - 'config/deploy/preview.rb'
+    - "config/deploy/preview.rb"
 
 # Offense count: 21
 Rails/OutputSafety:
   Exclude:
-    - 'app/components/blacklight/start_over_button_component.rb'
-    - 'app/helpers/article_helper.rb'
-    - 'app/helpers/catalog_helper.rb'
-    - 'app/helpers/collection_helper.rb'
-    - 'app/helpers/marc_helper.rb'
-    - 'app/helpers/preview_helper.rb'
-    - 'app/helpers/record_helper.rb'
-    - 'app/helpers/results_document_helper.rb'
-    - 'app/models/concerns/mods_data.rb'
-    - 'app/models/marc_fields/bound_with_note.rb'
-    - 'lib/holdings/mhld.rb'
+    - "app/components/blacklight/start_over_button_component.rb"
+    - "app/helpers/article_helper.rb"
+    - "app/helpers/catalog_helper.rb"
+    - "app/helpers/collection_helper.rb"
+    - "app/helpers/marc_helper.rb"
+    - "app/helpers/preview_helper.rb"
+    - "app/helpers/record_helper.rb"
+    - "app/helpers/results_document_helper.rb"
+    - "app/models/concerns/mods_data.rb"
+    - "app/models/marc_fields/bound_with_note.rb"
+    - "lib/holdings/mhld.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Rails/PluralizationGrammar:
   Exclude:
-    - 'config/schedule.rb'
+    - "config/schedule.rb"
 
 # Offense count: 37
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -896,23 +889,23 @@ Rails/PluralizationGrammar:
 # AllowedReceivers: ActionMailer::Preview, ActiveSupport::TimeZone
 Rails/RedundantActiveRecordAllMethod:
   Exclude:
-    - 'spec/models/concerns/eds_links_spec.rb'
-    - 'spec/models/concerns/index_links_spec.rb'
-    - 'spec/models/concerns/marc_links_spec.rb'
+    - "spec/models/concerns/eds_links_spec.rb"
+    - "spec/models/concerns/index_links_spec.rb"
+    - "spec/models/concerns/marc_links_spec.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 Rails/RootPublicPath:
   Exclude:
-    - 'app/controllers/concerns/backend_lookup.rb'
-    - 'app/controllers/hours_controller.rb'
-    - 'app/controllers/sfx_data_controller.rb'
+    - "app/controllers/concerns/backend_lookup.rb"
+    - "app/controllers/hours_controller.rb"
+    - "app/controllers/sfx_data_controller.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Rails/StripHeredoc:
   Exclude:
-    - 'lib/fixtures_indexer.rb'
+    - "lib/fixtures_indexer.rb"
 
 # Offense count: 23
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -920,15 +913,15 @@ Rails/StripHeredoc:
 # SupportedStyles: always, conditionals
 Style/AndOr:
   Exclude:
-    - 'app/controllers/article_selections_controller.rb'
-    - 'app/controllers/feedback_forms_controller.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/helpers/results_document_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/views/catalog/_index_default.mobile.builder'
-    - 'app/views/catalog/index.mobile.builder'
-    - 'app/views/catalog/show.mobile.builder'
+    - "app/controllers/article_selections_controller.rb"
+    - "app/controllers/feedback_forms_controller.rb"
+    - "app/helpers/application_helper.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/helpers/results_document_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
+    - "app/views/catalog/_index_default.mobile.builder"
+    - "app/views/catalog/index.mobile.builder"
+    - "app/views/catalog/show.mobile.builder"
 
 # Offense count: 74
 # This cop supports safe autocorrection (--autocorrect).
@@ -945,7 +938,7 @@ Style/BlockDelimiters:
 # Configuration parameters: AllowOnConstant, AllowOnSelfClass.
 Style/CaseEquality:
   Exclude:
-    - 'app/helpers/xml_api_helper.rb'
+    - "app/helpers/xml_api_helper.rb"
 
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -955,8 +948,8 @@ Style/CaseEquality:
 # SupportedStylesForModules: , nested, compact
 Style/ClassAndModuleChildren:
   Exclude:
-    - 'app/models/concerns/searchworks/document/email.rb'
-    - 'app/models/concerns/searchworks/document/sms.rb'
+    - "app/models/concerns/searchworks/document/email.rb"
+    - "app/models/concerns/searchworks/document/sms.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -964,15 +957,15 @@ Style/ClassAndModuleChildren:
 # SupportedStyles: is_a?, kind_of?
 Style/ClassCheck:
   Exclude:
-    - 'app/models/concerns/cjk_query.rb'
+    - "app/models/concerns/cjk_query.rb"
 
 # Offense count: 5
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/CommentedKeyword:
   Exclude:
-    - 'app/views/catalog/index.mobile.builder'
-    - 'app/views/catalog/show.mobile.builder'
-    - 'spec/models/concerns/cjk_query_spec.rb'
+    - "app/views/catalog/index.mobile.builder"
+    - "app/views/catalog/show.mobile.builder"
+    - "spec/models/concerns/cjk_query_spec.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -980,9 +973,9 @@ Style/CommentedKeyword:
 # SupportedStyles: assign_to_condition, assign_inside_condition
 Style/ConditionalAssignment:
   Exclude:
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/models/eds/repository.rb'
-    - 'app/views/catalog/_show_default.mobile.builder'
+    - "app/helpers/xml_api_helper.rb"
+    - "app/models/eds/repository.rb"
+    - "app/views/catalog/_show_default.mobile.builder"
 
 # Offense count: 166
 # Configuration parameters: AllowedConstants.
@@ -993,10 +986,10 @@ Style/Documentation:
 # This cop supports safe autocorrection (--autocorrect).
 Style/EmptyCaseCondition:
   Exclude:
-    - 'app/controllers/concerns/email_validation.rb'
-    - 'app/models/concerns/schema_dot_org.rb'
-    - 'lib/holdings/status.rb'
-    - 'lib/page_location.rb'
+    - "app/controllers/concerns/email_validation.rb"
+    - "app/models/concerns/schema_dot_org.rb"
+    - "lib/holdings/status.rb"
+    - "lib/page_location.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -1004,7 +997,7 @@ Style/EmptyCaseCondition:
 # SupportedStyles: compact, expanded
 Style/EmptyMethod:
   Exclude:
-    - 'app/controllers/feedback_forms_controller.rb'
+    - "app/controllers/feedback_forms_controller.rb"
 
 # Offense count: 17
 # This cop supports safe autocorrection (--autocorrect).
@@ -1015,41 +1008,41 @@ Style/Encoding:
 # This cop supports safe autocorrection (--autocorrect).
 Style/ExpandPathArguments:
   Exclude:
-    - 'Rakefile'
+    - "Rakefile"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars.
 Style/FetchEnvVar:
   Exclude:
-    - 'app/models/user.rb'
+    - "app/models/user.rb"
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/GlobalStdStream:
   Exclude:
-    - 'config/environments/production.rb'
+    - "config/environments/production.rb"
 
 # Offense count: 17
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
 Style/GuardClause:
   Exclude:
-    - 'app/controllers/article_selections_controller.rb'
-    - 'app/controllers/articles_controller.rb'
-    - 'app/controllers/availability_controller.rb'
-    - 'app/controllers/concerns/all_caps_params.rb'
-    - 'app/controllers/concerns/callnumber_search.rb'
-    - 'app/controllers/concerns/database_access_point.rb'
-    - 'app/controllers/feedback_forms_controller.rb'
-    - 'app/controllers/quick_reports_controller.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/collection_access_point_helper.rb'
-    - 'app/helpers/collection_helper.rb'
-    - 'app/helpers/facets_helper.rb'
-    - 'app/helpers/feedback_form_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/models/user.rb'
+    - "app/controllers/article_selections_controller.rb"
+    - "app/controllers/articles_controller.rb"
+    - "app/controllers/availability_controller.rb"
+    - "app/controllers/concerns/all_caps_params.rb"
+    - "app/controllers/concerns/callnumber_search.rb"
+    - "app/controllers/concerns/database_access_point.rb"
+    - "app/controllers/feedback_forms_controller.rb"
+    - "app/controllers/quick_reports_controller.rb"
+    - "app/helpers/application_helper.rb"
+    - "app/helpers/collection_access_point_helper.rb"
+    - "app/helpers/collection_helper.rb"
+    - "app/helpers/facets_helper.rb"
+    - "app/helpers/feedback_form_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
+    - "app/models/user.rb"
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -1057,7 +1050,7 @@ Style/GuardClause:
 # AllowedReceivers: Thread.current
 Style/HashEachMethods:
   Exclude:
-    - 'app/models/article_search_builder.rb'
+    - "app/models/article_search_builder.rb"
 
 # Offense count: 40
 # This cop supports safe autocorrection (--autocorrect).
@@ -1066,9 +1059,9 @@ Style/HashEachMethods:
 # SupportedShorthandSyntax: always, never, either, consistent, either_consistent
 Style/HashSyntax:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/views/catalog/index.atom.builder'
-    - 'app/views/catalog/opensearch.xml.builder'
+    - "app/controllers/catalog_controller.rb"
+    - "app/views/catalog/index.atom.builder"
+    - "app/views/catalog/opensearch.xml.builder"
 
 # Offense count: 24
 # This cop supports safe autocorrection (--autocorrect).
@@ -1079,7 +1072,7 @@ Style/IfUnlessModifier:
 # This cop supports safe autocorrection (--autocorrect).
 Style/KeywordParametersOrder:
   Exclude:
-    - 'spec/support/stub_article_service.rb'
+    - "spec/support/stub_article_service.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -1087,17 +1080,17 @@ Style/KeywordParametersOrder:
 # SupportedStyles: line_count_dependent, lambda, literal
 Style/Lambda:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
+    - "app/controllers/catalog_controller.rb"
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Style/MethodCallWithoutArgsParentheses:
   Exclude:
-    - 'spec/models/concerns/collection_member_spec.rb'
-    - 'spec/models/concerns/extent_spec.rb'
-    - 'spec/models/concerns/index_authors_spec.rb'
-    - 'spec/models/concerns/mods_data_spec.rb'
+    - "spec/models/concerns/collection_member_spec.rb"
+    - "spec/models/concerns/extent_spec.rb"
+    - "spec/models/concerns/index_authors_spec.rb"
+    - "spec/models/concerns/mods_data_spec.rb"
 
 # Offense count: 8
 # This cop supports safe autocorrection (--autocorrect).
@@ -1105,23 +1098,23 @@ Style/MethodCallWithoutArgsParentheses:
 # SupportedStyles: require_parentheses, require_no_parentheses, require_no_parentheses_except_multiline
 Style/MethodDefParentheses:
   Exclude:
-    - 'app/components/blacklight/start_over_button_component.rb'
-    - 'app/controllers/article_selections_controller.rb'
-    - 'app/controllers/concerns/all_caps_params.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'spec/helpers/bookmarks_helper_spec.rb'
-    - 'spec/spec_helper.rb'
+    - "app/components/blacklight/start_over_button_component.rb"
+    - "app/controllers/article_selections_controller.rb"
+    - "app/controllers/concerns/all_caps_params.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "spec/helpers/bookmarks_helper_spec.rb"
+    - "spec/spec_helper.rb"
 
 # Offense count: 1
 Style/MultilineBlockChain:
   Exclude:
-    - 'lib/holdings/library.rb'
+    - "lib/holdings/library.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Style/MultilineIfModifier:
   Exclude:
-    - 'app/views/catalog/index.atom.builder'
+    - "app/views/catalog/index.atom.builder"
 
 # Offense count: 12
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -1129,10 +1122,10 @@ Style/MultilineIfModifier:
 # SupportedStyles: literals, strict
 Style/MutableConstant:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/helpers/article_helper.rb'
-    - 'lib/constants.rb'
-    - 'spec/support/stub_article_service.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/helpers/article_helper.rb"
+    - "lib/constants.rb"
+    - "spec/support/stub_article_service.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -1140,7 +1133,7 @@ Style/MutableConstant:
 # SupportedStyles: both, prefix, postfix
 Style/NegatedIf:
   Exclude:
-    - 'app/helpers/results_document_helper.rb'
+    - "app/helpers/results_document_helper.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -1148,7 +1141,7 @@ Style/NegatedIf:
 # AllowedMethods: be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with
 Style/NestedParenthesizedCalls:
   Exclude:
-    - 'app/views/catalog/_show_default.mobile.builder'
+    - "app/views/catalog/_show_default.mobile.builder"
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
@@ -1162,22 +1155,22 @@ Style/NumericLiterals:
 # SupportedStyles: predicate, comparison
 Style/NumericPredicate:
   Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/bookmarks_helper.rb'
-    - 'app/models/concerns/cjk_query.rb'
+    - "app/helpers/application_helper.rb"
+    - "app/helpers/bookmarks_helper.rb"
+    - "app/models/concerns/cjk_query.rb"
 
 # Offense count: 23
 Style/OpenStructUse:
   Exclude:
-    - 'spec/controllers/concerns/database_access_point_spec.rb'
-    - 'spec/helpers/collection_helper_spec.rb'
-    - 'spec/helpers/record_helper_spec.rb'
-    - 'spec/lib/holdings/status_spec.rb'
-    - 'spec/lib/hours_request_spec.rb'
-    - 'spec/lib/search_query_modifier_spec.rb'
-    - 'spec/models/links_spec.rb'
-    - 'spec/views/browse/index.html.erb_spec.rb'
-    - 'spec/views/collection_members/_file_collection_members.html.erb_spec.rb'
+    - "spec/controllers/concerns/database_access_point_spec.rb"
+    - "spec/helpers/collection_helper_spec.rb"
+    - "spec/helpers/record_helper_spec.rb"
+    - "spec/lib/holdings/status_spec.rb"
+    - "spec/lib/hours_request_spec.rb"
+    - "spec/lib/search_query_modifier_spec.rb"
+    - "spec/models/links_spec.rb"
+    - "spec/views/browse/index.html.erb_spec.rb"
+    - "spec/views/collection_members/_file_collection_members.html.erb_spec.rb"
 
 # Offense count: 31
 # This cop supports safe autocorrection (--autocorrect).
@@ -1191,12 +1184,12 @@ Style/PercentLiteralDelimiters:
 # SupportedStyles: short, verbose
 Style/PreferredHashMethods:
   Exclude:
-    - 'app/helpers/facets_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/views/catalog/_index_default.mobile.builder'
-    - 'app/views/catalog/_show_default.mobile.builder'
-    - 'app/views/catalog/index.mobile.builder'
-    - 'app/views/catalog/show.mobile.builder'
+    - "app/helpers/facets_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
+    - "app/views/catalog/_index_default.mobile.builder"
+    - "app/views/catalog/_show_default.mobile.builder"
+    - "app/views/catalog/index.mobile.builder"
+    - "app/views/catalog/show.mobile.builder"
 
 # Offense count: 32
 # This cop supports safe autocorrection (--autocorrect).
@@ -1204,11 +1197,11 @@ Style/PreferredHashMethods:
 # SupportedStyles: same_as_string_literals, single_quotes, double_quotes
 Style/QuotedSymbols:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
-    - 'app/models/concerns/schema_dot_org.rb'
-    - 'app/models/marc_field.rb'
-    - 'app/models/marc_fields/production_notice.rb'
-    - 'spec/models/json_results_document_presenter_spec.rb'
+    - "app/controllers/catalog_controller.rb"
+    - "app/models/concerns/schema_dot_org.rb"
+    - "app/models/marc_field.rb"
+    - "app/models/marc_fields/production_notice.rb"
+    - "spec/models/json_results_document_presenter_spec.rb"
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -1216,13 +1209,13 @@ Style/QuotedSymbols:
 # SupportedStyles: compact, exploded
 Style/RaiseArgs:
   Exclude:
-    - 'lib/tasks/searchworks.rake'
+    - "lib/tasks/searchworks.rake"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantBegin:
   Exclude:
-    - 'app/models/concerns/schema_dot_org.rb'
+    - "app/models/concerns/schema_dot_org.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
@@ -1230,57 +1223,57 @@ Style/RedundantBegin:
 # AllowedMethods: nonzero?
 Style/RedundantCondition:
   Exclude:
-    - 'app/views/catalog/_index_default.mobile.builder'
-    - 'app/views/catalog/index.mobile.builder'
+    - "app/views/catalog/_index_default.mobile.builder"
+    - "app/views/catalog/index.mobile.builder"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantConstantBase:
   Exclude:
-    - 'config/environments/production.rb'
+    - "config/environments/production.rb"
 
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/RedundantInterpolation:
   Exclude:
-    - 'app/helpers/article_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
+    - "app/helpers/article_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantParentheses:
   Exclude:
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/presenters/article_fulltext_link_presenter.rb'
+    - "app/helpers/xml_api_helper.rb"
+    - "app/presenters/article_fulltext_link_presenter.rb"
 
 # Offense count: 21
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpEscape:
   Exclude:
-    - 'app/helpers/article_helper.rb'
-    - 'spec/components/access_panels/online_component_spec.rb'
-    - 'spec/components/access_panels/online_eds_component_spec.rb'
-    - 'spec/helpers/browse_helper_spec.rb'
-    - 'spec/helpers/collection_helper_spec.rb'
-    - 'spec/models/concerns/index_links_spec.rb'
+    - "app/helpers/article_helper.rb"
+    - "spec/components/access_panels/online_component_spec.rb"
+    - "spec/components/access_panels/online_eds_component_spec.rb"
+    - "spec/helpers/browse_helper_spec.rb"
+    - "spec/helpers/collection_helper_spec.rb"
+    - "spec/models/concerns/index_links_spec.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMultipleReturnValues.
 Style/RedundantReturn:
   Exclude:
-    - 'app/helpers/masthead_helper.rb'
+    - "app/helpers/masthead_helper.rb"
 
 # Offense count: 8
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantSelf:
   Exclude:
-    - 'app/controllers/concerns/advanced_search_params_mapping.rb'
-    - 'app/controllers/concerns/all_caps_params.rb'
-    - 'app/controllers/concerns/callnumber_search.rb'
-    - 'app/controllers/concerns/database_access_point.rb'
-    - 'app/models/concerns/searchworks/document/sms.rb'
-    - 'app/models/marc_fields/marc_field_wrapper.rb'
+    - "app/controllers/concerns/advanced_search_params_mapping.rb"
+    - "app/controllers/concerns/all_caps_params.rb"
+    - "app/controllers/concerns/callnumber_search.rb"
+    - "app/controllers/concerns/database_access_point.rb"
+    - "app/models/concerns/searchworks/document/sms.rb"
+    - "app/models/marc_fields/marc_field_wrapper.rb"
 
 # Offense count: 17
 # This cop supports safe autocorrection (--autocorrect).
@@ -1288,19 +1281,19 @@ Style/RedundantSelf:
 # SupportedStyles: slashes, percent_r, mixed
 Style/RegexpLiteral:
   Exclude:
-    - 'app/helpers/article_helper.rb'
-    - 'app/helpers/feedback_form_helper.rb'
-    - 'app/models/concerns/eds_subjects.rb'
-    - 'config/routes.rb'
-    - 'spec/features/article_searching_spec.rb'
-    - 'spec/helpers/application_helper_spec.rb'
-    - 'spec/helpers/collection_helper_spec.rb'
-    - 'spec/helpers/record_helper_spec.rb'
-    - 'spec/lib/holdings/mhld_spec.rb'
-    - 'spec/mailers/search_works_record_mailer_spec.rb'
-    - 'spec/models/json_results_document_presenter_spec.rb'
-    - 'spec/tasks/fixtures_indexer_spec.rb'
-    - 'spec/views/marc_fields/_linked_author_index.html.erb_spec.rb'
+    - "app/helpers/article_helper.rb"
+    - "app/helpers/feedback_form_helper.rb"
+    - "app/models/concerns/eds_subjects.rb"
+    - "config/routes.rb"
+    - "spec/features/article_searching_spec.rb"
+    - "spec/helpers/application_helper_spec.rb"
+    - "spec/helpers/collection_helper_spec.rb"
+    - "spec/helpers/record_helper_spec.rb"
+    - "spec/lib/holdings/mhld_spec.rb"
+    - "spec/mailers/search_works_record_mailer_spec.rb"
+    - "spec/models/json_results_document_presenter_spec.rb"
+    - "spec/tasks/fixtures_indexer_spec.rb"
+    - "spec/views/marc_fields/_linked_author_index.html.erb_spec.rb"
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -1308,9 +1301,9 @@ Style/RegexpLiteral:
 # SupportedStyles: implicit, explicit
 Style/RescueStandardError:
   Exclude:
-    - 'app/controllers/articles_controller.rb'
-    - 'app/models/sfx_data.rb'
-    - 'app/presenters/sms_presenter.rb'
+    - "app/controllers/articles_controller.rb"
+    - "app/models/sfx_data.rb"
+    - "app/presenters/sms_presenter.rb"
 
 # Offense count: 11
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -1318,48 +1311,48 @@ Style/RescueStandardError:
 # AllowedMethods: present?, blank?, presence, try, try!
 Style/SafeNavigation:
   Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/article_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
-    - 'app/models/concerns/cjk_query.rb'
-    - 'app/models/concerns/digital_collection.rb'
-    - 'app/models/concerns/extent.rb'
-    - 'app/views/catalog/_show_default.mobile.builder'
+    - "app/helpers/application_helper.rb"
+    - "app/helpers/article_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
+    - "app/models/concerns/cjk_query.rb"
+    - "app/models/concerns/digital_collection.rb"
+    - "app/models/concerns/extent.rb"
+    - "app/views/catalog/_show_default.mobile.builder"
 
 # Offense count: 5
 # Configuration parameters: Max.
 Style/SafeNavigationChainLength:
   Exclude:
-    - 'app/components/access_panels/sfx_component.rb'
-    - 'app/components/request_links/hoover_request_link_component.rb'
-    - 'app/models/concerns/cjk_query.rb'
-    - 'app/models/solr_document.rb'
-    - 'app/services/live_lookup/folio.rb'
+    - "app/components/access_panels/sfx_component.rb"
+    - "app/components/request_links/hoover_request_link_component.rb"
+    - "app/models/concerns/cjk_query.rb"
+    - "app/models/solr_document.rb"
+    - "app/services/live_lookup/folio.rb"
 
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SelectByRegexp:
   Exclude:
-    - 'app/models/concerns/digital_image.rb'
-    - 'app/models/marc_fields/issn.rb'
+    - "app/models/concerns/digital_image.rb"
+    - "app/models/marc_fields/issn.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowModifier.
 Style/SoleNestedConditional:
   Exclude:
-    - 'app/views/catalog/_show_default.mobile.builder'
+    - "app/views/catalog/_show_default.mobile.builder"
 
 # Offense count: 5
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Mode.
 Style/StringConcatenation:
   Exclude:
-    - 'app/helpers/article_helper.rb'
-    - 'app/models/concerns/cjk_query.rb'
-    - 'app/models/marc_fields/linked_author.rb'
-    - 'config/application.rb'
-    - 'config/initializers/okcomputer.rb'
+    - "app/helpers/article_helper.rb"
+    - "app/models/concerns/cjk_query.rb"
+    - "app/models/marc_fields/linked_author.rb"
+    - "config/application.rb"
+    - "config/initializers/okcomputer.rb"
 
 # Offense count: 4429
 # This cop supports safe autocorrection (--autocorrect).
@@ -1374,14 +1367,14 @@ Style/StringLiterals:
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiteralsInInterpolation:
   Exclude:
-    - 'app/helpers/results_document_helper.rb'
-    - 'app/helpers/xml_api_helper.rb'
+    - "app/helpers/results_document_helper.rb"
+    - "app/helpers/xml_api_helper.rb"
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/StructInheritance:
   Exclude:
-    - 'app/models/concerns/eds_subjects.rb'
+    - "app/models/concerns/eds_subjects.rb"
 
 # Offense count: 13
 # This cop supports safe autocorrection (--autocorrect).
@@ -1397,7 +1390,7 @@ Style/SymbolArray:
 # SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma
 Style/TrailingCommaInArrayLiteral:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
+    - "app/controllers/catalog_controller.rb"
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -1405,13 +1398,13 @@ Style/TrailingCommaInArrayLiteral:
 # SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma
 Style/TrailingCommaInHashLiteral:
   Exclude:
-    - 'app/controllers/catalog_controller.rb'
+    - "app/controllers/catalog_controller.rb"
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Style/WhileUntilModifier:
   Exclude:
-    - 'app/services/eds/search_service.rb'
+    - "app/services/eds/search_service.rb"
 
 # Offense count: 58
 # This cop supports safe autocorrection (--autocorrect).

--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       Folio::Item::MaterialType.new(**Folio::Types.material_types.values.find { |x| x['name'] == 'book' }.slice('id', 'name'))
     end
 
-    it 'should have the request link at the location level' do
+    it 'has the request link at the location level' do
       document = SolrDocument.new(
         id: '123',
         item_display_struct: [
@@ -122,7 +122,7 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       expect(page).to have_css('.location a', text: "Request")
     end
 
-    it 'should not have the location level request link for inprocess noncirculating collections' do
+    it 'does not have the location level request link for inprocess noncirculating collections' do
       document = SolrDocument.new(
         id: '123',
         item_display_struct: [
@@ -284,7 +284,7 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
         render_inline(described_class.new(document:))
       end
 
-      it "should be present" do
+      it "is present" do
         expect(page).to have_css('.location a', text: 'Request')
       end
 
@@ -391,7 +391,7 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
       render_inline(described_class.new(document:))
     end
 
-    it 'should display finding aid sections with link' do
+    it 'displays finding aid sections with link' do
       expect(page).to have_css('h4', text: 'Finding aid')
       expect(page).to have_css('a', text: 'Online Archive of California')
     end

--- a/spec/components/access_panels/course_reserves_component_spec.rb
+++ b/spec/components/access_panels/course_reserves_component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AccessPanels::CourseReservesComponent, type: :component do
                                                '00a45880-2088-4bbd-8b37-929093f1a032'])
     }
 
-    it "should show three course reservations" do
+    it "shows three course reservations" do
       expect(page).to have_css('div.panel-course-reserve')
       expect(page).to have_css('dl')
       expect(page).to have_css('dt', count: 3, text: "Course")
@@ -47,7 +47,7 @@ RSpec.describe AccessPanels::CourseReservesComponent, type: :component do
       expect(page).to have_css('dt', text: "Instructor(s)")
     end
 
-    it "should have all three links correctly formatted" do
+    it "has all three links correctly formatted" do
       expect(page).to have_link('ENGLISH-17Q-01 -- After 2001: A 21st Century Science Fiction Odyssey',
                                 href: '/catalog?f%5Bcourses_folio_id_ssim%5D%5B%5D=00254a1b-d0f5-4a9a-88a0-1dd596075d08')
 

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -70,15 +70,15 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
   end
 
   describe '#links' do
-    it 'should not return links when they are present in MODS records' do
+    it 'does not return links when they are present in MODS records' do
       expect(mods.links).not_to be_present
     end
 
-    it 'should return fulltext links' do
+    it 'returns fulltext links' do
       expect(fulltext.links.all?(&:fulltext?)).to be_truthy
     end
 
-    it 'should return the SFX link even if there are other links' do
+    it 'returns the SFX link even if there are other links' do
       links = sfx.links
       expect(links.length).to eq 1
       expect(links.first).to be_sfx
@@ -93,7 +93,7 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
       expect(managed_purl_doc.links).to be_blank
     end
 
-    it 'should not return any non-fulltext links' do
+    it 'does not return any non-fulltext links' do
       expect(supplemental.links).to be_blank
     end
   end
@@ -141,21 +141,21 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
       SolrDocument.new
     end
 
-    it "should render nothing" do
+    it "renders nothing" do
       render_inline(described_class.new(document:))
       expect(page).to have_no_css(".panel-online")
     end
   end
 
   describe "marc record" do
-    it "should render the panel with a link" do
+    it "renders the panel with a link" do
       document = SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }])
       render_inline(described_class.new(document:))
       expect(page).to have_css(".panel-online")
       expect(page).to have_css(".card-header", text: "Available online")
       expect(page).to have_css("ul.links li a", text: "Link text")
     end
-    it "should add the stanford-only class to Stanford only resources" do
+    it "adds the stanford-only class to Stanford only resources" do
       document = SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', additional_text: '4 at one time', fulltext: true, stanford_only: true }])
       render_inline(described_class.new(document:))
       expect(page).to have_css(".panel-online")
@@ -194,11 +194,11 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
         SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }], format_main_ssim: ["Database"])
       end
 
-      it "should render a special card heading" do
+      it "renders a special card heading" do
         render_inline(described_class.new(document:))
         expect(page).to have_css(".card-header", text: "Search this database")
       end
-      it "should render a special card footer" do
+      it "renders a special card footer" do
         render_inline(described_class.new(document:))
         expect(page).to have_css(".card-footer a", text: "Report a connection problem")
       end

--- a/spec/components/access_panels/related_component_spec.rb
+++ b/spec/components/access_panels/related_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AccessPanels::RelatedComponent, type: :component do
-  it 'should be hidden by default' do
+  it 'is hidden by default' do
     render_inline(described_class.new(document: SolrDocument.new))
     expect(page).to have_css('div.panel-related', visible: false)
   end
@@ -13,7 +13,7 @@ RSpec.describe AccessPanels::RelatedComponent, type: :component do
       render_inline(described_class.new(document: SolrDocument.new(oclc: ['12345'])))
     end
 
-    it 'should render an OCLC link' do
+    it 'renders an OCLC link' do
       expect(page).to have_css('div.panel-related', visible: true)
       expect(page).to have_css('li.worldcat a', text: 'Find it at other libraries via WorldCat')
     end

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ArticlesController do
   include Devise::Test::ControllerHelpers
-  it 'should include the EmailValidation concern' do
+  it 'includes the EmailValidation concern' do
     expect(subject).to be_a(EmailValidation)
   end
 
@@ -163,19 +163,19 @@ RSpec.describe ArticlesController do
       allow(controller).to receive_messages(session: user_session, on_campus_or_su_affiliated_user?: true)
     end
 
-    it 'will create a new session' do
+    it 'creates a new session' do
       expect(EBSCO::EDS::Session).to receive(:new).with(
         hash_including(caller: 'new-session', guest: false)
       ).and_return(eds_session)
       controller.eds_init
     end
-    it 'will reuse the session if in the user session data' do
+    it 'reuses the session if in the user session data' do
       user_session['eds_guest'] = false
       user_session['eds_session_token'] = 'def'
       expect(EBSCO::EDS::Session).not_to receive(:new)
       controller.eds_init
     end
-    it 'will require the session token in the user session data' do
+    it 'requires the session token in the user session data' do
       user_session['eds_guest'] = false
       expect(EBSCO::EDS::Session).to receive(:new).and_return(eds_session)
       controller.eds_init
@@ -185,20 +185,20 @@ RSpec.describe ArticlesController do
   describe '#email' do
     before { stub_article_service(type: :single, docs: [SolrDocument.new(id: '123')]) }
 
-    it 'should set the provided subject' do
+    it 'sets the provided subject' do
       expect { post :email, params: { to: 'email@example.com', subject: 'Email Subject', type: 'brief', id: '123' } }.to change {
         ActionMailer::Base.deliveries.count
       }.by(1)
       expect(ActionMailer::Base.deliveries.last.subject).to eq 'Email Subject'
     end
-    it 'should send a brief email when requested' do
+    it 'sends a brief email when requested' do
       email = double('email')
       expect(SearchWorksRecordMailer).to receive(:article_email_record).and_return(email)
       expect(email).to receive(:deliver_now)
       post :email, params: { to: 'email@example.com', subject: 'Email Subject', type: 'brief', id: '123' }
     end
 
-    it 'should be able to send emails to multiple addresses' do
+    it 'is able to send emails to multiple addresses' do
       expect do
         post :email, params: { to: 'e1@example.com, e2@example.com, e3@example.com', subject: 'Subject', type: 'full', id: '123' }
       end.to change { ActionMailer::Base.deliveries.count }.by(3)

--- a/spec/controllers/availability_controller_spec.rb
+++ b/spec/controllers/availability_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AvailabilityController do
   describe "bot traffic" do
-    it "should return a forbidden status" do
+    it "returns a forbidden status" do
       request.env['HTTP_USER_AGENT'] = 'robot'
       get :index, params: { ids: ['123'] }
       expect(response).to be_forbidden
@@ -12,7 +12,7 @@ RSpec.describe AvailabilityController do
   end
 
   describe "without IDs" do
-    it "should render a blank JSON array w/o making a live lookup request" do
+    it "renders a blank JSON array w/o making a live lookup request" do
       expect(LiveLookup).not_to receive(:new)
       get :index
       expect(response.body).to eq '[]'
@@ -20,7 +20,7 @@ RSpec.describe AvailabilityController do
   end
 
   describe "with a blank ID" do
-    it "should render a blank JSON array w/o making a live lookup request" do
+    it "renders a blank JSON array w/o making a live lookup request" do
       expect(LiveLookup).not_to receive(:new)
       get :index, params: { ids: [''] }
       expect(response.body).to eq '[]'
@@ -35,7 +35,7 @@ RSpec.describe AvailabilityController do
       allow(lookup).to receive(:as_json).and_return(json)
     end
 
-    it "should return the #to_json response from the LiveLookup class" do
+    it "returns the #to_json response from the LiveLookup class" do
       expect(LiveLookup).to receive(:new).with(['12345', '54321']).and_return(lookup)
       get :index, params: { ids: ['12345', '54321'] }
       expect(response.body).to eq json.to_json

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -5,27 +5,27 @@ require 'rails_helper'
 RSpec.describe CatalogController do
   include Devise::Test::ControllerHelpers
 
-  it 'should include the AdvancedSearchParamsMapping concern' do
+  it 'includes the AdvancedSearchParamsMapping concern' do
     expect(subject).to be_a(AdvancedSearchParamsMapping)
   end
-  it "should include the DatabaseAccessPoint concern" do
+  it "includes the DatabaseAccessPoint concern" do
     expect(subject).to be_a(DatabaseAccessPoint)
   end
-  it "should include the CallnumberSearch concern" do
+  it "includes the CallnumberSearch concern" do
     expect(subject).to be_a(CallnumberSearch)
   end
-  it "should include the AllCapsParams concern" do
+  it "includes the AllCapsParams concern" do
     expect(subject).to be_a(AllCapsParams)
   end
-  it "should include the ReplaceSpecialQuotes concern" do
+  it "includes the ReplaceSpecialQuotes concern" do
     expect(subject).to be_a(ReplaceSpecialQuotes)
   end
 
-  it "should include the EmailValidation concern" do
+  it "includes the EmailValidation concern" do
     expect(subject).to be_a(EmailValidation)
   end
   describe "#index" do
-    it "should set the search modifier" do
+    it "sets the search modifier" do
       get :index
       expect(assigns(:search_modifier)).to be_a SearchQueryModifier
     end
@@ -70,39 +70,39 @@ RSpec.describe CatalogController do
         allow(controller).to receive(:current_user).and_return(User.new(email: 'user@stanford.edu'))
       end
 
-      it 'should set the provided subject' do
+      it 'sets the provided subject' do
         expect { post :email, params: { to: 'email@example.com', subject: 'Email Subject', type: 'brief', id: '1' } }.to change {
           ActionMailer::Base.deliveries.count
         }.by(1)
         expect(ActionMailer::Base.deliveries.last.subject).to eq 'Email Subject'
       end
-      it 'should send a brief email when requested' do
+      it 'sends a brief email when requested' do
         email = double('email')
         expect(SearchWorksRecordMailer).to receive(:email_record).and_return(email)
         expect(email).to receive(:deliver_now)
         post :email, params: { to: 'email@example.com', subject: 'Email Subject', type: 'brief', id: '1' }
       end
-      it 'should send a full email when requested' do
+      it 'sends a full email when requested' do
         email = double('email')
         expect(SearchWorksRecordMailer).to receive(:full_email_record).and_return(email)
         expect(email).to receive(:deliver_now)
         post :email, params: { to: 'email@example.com', subject: 'Email Subject', type: 'full', id: '1' }
       end
 
-      it 'should be able to send emails to multiple addresses' do
+      it 'is able to send emails to multiple addresses' do
         expect do
           post :email, params: { to: 'e1@example.com, e2@example.com, e3@example.com', subject: 'Subject', type: 'full', id: '1' }
         end.to change { ActionMailer::Base.deliveries.count }.by(3)
       end
       describe 'validations' do
-        it 'should prevent incorrect email types from being sent' do
+        it 'prevents incorrect email types from being sent' do
           expect do
             post :email, params: { to: 'email@example.com', type: 'not-a-type' }
           end.not_to change { ActionMailer::Base.deliveries.count }
           expect(flash[:error]).to eq 'Invalid email type provided'
         end
 
-        it 'should validate multiple emails correctly' do
+        it 'validates multiple emails correctly' do
           expect do
             post(
               :email,
@@ -116,7 +116,7 @@ RSpec.describe CatalogController do
           expect(flash[:error]).to eq 'You must enter only valid email addresses.'
         end
 
-        it 'should prevent emails with too many addresses from being sent' do
+        it 'prevents emails with too many addresses from being sent' do
           expect do
             post(
               :email,
@@ -140,31 +140,31 @@ RSpec.describe CatalogController do
 
   describe "routes" do
     describe "customized from Blacklight" do
-      it "should route /view/:id properly" do
+      it "routes /view/:id properly" do
         expect({ get: '/view/1234' }).to route_to(controller: 'catalog', action: 'show', id: '1234')
       end
-      it "should route solr_document_path to /view" do
+      it "routes solr_document_path to /view" do
         expect(solr_document_path('1234')).to eq '/view/1234'
       end
-      it "should route solr_document_path to /view" do
+      it "routes solr_document_path to /view" do
         expect(solr_document_path('1234')).to eq '/view/1234'
       end
-      it "should route the librarian view properly" do
+      it "routes the librarian view properly" do
         expect({ get: '/view/1234/librarian_view' }).to route_to(controller: 'catalog', action: 'librarian_view', id: '1234')
       end
-      it "should route the stackmap view properly" do
+      it "routes the stackmap view properly" do
         expect({ get: '/view/1234/stackmap' }).to route_to(controller: 'catalog', action: 'stackmap', id: '1234')
       end
     end
 
     describe "/databases" do
-      it "should route to the database format" do
+      it "routes to the database format" do
         expect({ get: "/databases" }).to route_to(controller: 'catalog', action: 'index', f: { "format_main_ssim" => ["Database"] })
       end
     end
 
     describe "/backend_lookup" do
-      it "should route to the backend lookup path as json" do
+      it "routes to the backend lookup path as json" do
         expect({ get: "/backend_lookup" }).to route_to(controller: 'catalog', action: 'backend_lookup', format: :json)
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe CatalogController do
   describe "blacklight config" do
     let(:config) { controller.blacklight_config }
 
-    it "should have the correct facet order" do
+    it "has the correct facet order" do
       keys = config.facet_fields.keys
       expect(keys.index("access_facet")).to be < keys.index("format_main_ssim")
       expect(keys.index("format_main_ssim")).to be < keys.index("format_physical_ssim")
@@ -190,24 +190,24 @@ RSpec.describe CatalogController do
       expect(keys.index("author_other_facet")).to be < keys.index("format")
     end
     describe 'facet sort' do
-      it 'should set an index sort for the resource type facet' do
+      it 'sets an index sort for the resource type facet' do
         expect(config.facet_fields['format_main_ssim'].sort).to eq :index
       end
-      it 'should set an index sort for the building type facet' do
+      it 'sets an index sort for the building type facet' do
         expect(config.facet_fields['building_facet'].sort).to eq :index
       end
-      it 'should set an index sort for the database topic facet' do
+      it 'sets an index sort for the database topic facet' do
         expect(config.facet_fields['db_az_subject'].sort).to eq :index
       end
     end
 
     describe "facet limits" do
-      it "should set a very high facet limit on building and format" do
+      it "sets a very high facet limit on building and format" do
         ['building_facet', 'format_main_ssim'].each do |facet|
           expect(config.facet_fields[facet].limit).to eq 100
         end
       end
-      it "should set the correct facet limits on standard facets" do
+      it "sets the correct facet limits on standard facets" do
         ['author_person_facet', 'topic_facet', 'genre_ssim'].each do |facet|
           expect(config.facet_fields[facet].limit).to eq 20
         end
@@ -215,7 +215,7 @@ RSpec.describe CatalogController do
     end
 
     describe 'search types' do
-      it 'should include Author+Title search' do
+      it 'includes Author+Title search' do
         search_field = config.search_fields["author_title"]
         expect(search_field).to be_present
         expect(search_field.label).to eq "Author + Title"

--- a/spec/controllers/concerns/all_caps_params_spec.rb
+++ b/spec/controllers/concerns/all_caps_params_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AllCapsParams do
   describe "parameters with all capitals" do
     let(:params) { { q: "ALL CAPS", clause: { '1': { query: "TITLE CAPS" } } } }
 
-    it "should downcase the parameter if it is all caps" do
+    it "downcases the parameter if it is all caps" do
       expect(controller.params[:q]).to eq "ALL CAPS"
       expect(controller.params.dig(:clause, '1', :query)).to eq "TITLE CAPS"
       controller.send(:downcase_all_caps_params)
@@ -25,7 +25,7 @@ RSpec.describe AllCapsParams do
   describe "parameters w/o all capitals" do
     let(:params) { { q: "all CAPS", clause: { '1': { query: "title CAPS" } } } }
 
-    it "should not downcase the parameter if it not is all caps" do
+    it "does not downcase the parameter if it not is all caps" do
       expect(controller.params[:q]).to eq "all CAPS"
       expect(controller.params.dig(:clause, '1', :query)).to eq "title CAPS"
       controller.send(:downcase_all_caps_params)

--- a/spec/controllers/concerns/callnumber_search_spec.rb
+++ b/spec/controllers/concerns/callnumber_search_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe CallnumberSearch do
       subject.send(:quote_and_downcase_callnumber_search)
     end
 
-    it "should downcase the q parameter" do
+    it "downcases the q parameter" do
       expect(params[:q]).to match /abc 123/
       expect(params[:q]).not_to include "ABC"
     end
-    it "should quote the q parameter" do
+    it "quotes the q parameter" do
       expect(params[:q]).to eq '"abc 123"'
     end
     describe "when already quoted" do
@@ -32,7 +32,7 @@ RSpec.describe CallnumberSearch do
         subject.send(:quote_and_downcase_callnumber_search)
       end
 
-      it "should not double quote" do
+      it "does not double quote" do
         expect(params[:q]).to eq '"abc 123"'
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe CallnumberSearch do
         allow(subject).to receive(:params).and_return(params)
       end
 
-      it "should not change the q parameter" do
+      it "does not change the q parameter" do
         subject.send(:quote_and_downcase_callnumber_search)
         expect(params[:q]).to eq 'ABC 123'
       end
@@ -57,7 +57,7 @@ RSpec.describe CallnumberSearch do
         allow(subject).to receive(:params).and_return(params)
       end
 
-      it "should not change any parameters" do
+      it "does not change any parameters" do
         subject.send(:quote_and_downcase_callnumber_search)
         expect(params).to eq params
       end

--- a/spec/controllers/concerns/replace_special_quotes_spec.rb
+++ b/spec/controllers/concerns/replace_special_quotes_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ReplaceSpecialQuotes do
   describe "with special quotes" do
     let(:params) { { clause: { '1': { query: "«#{q}» ‘#{q}’ ‚#{q}‛ “#{q}” „#{q}‟ ‹#{q}› 「#{q}」『#{q}』 〝#{q}〞 〟#{q}〟 ﹂#{q}﹁  ﹄#{q}﹃ ＂#{q}＂ ｢#{q}｣" } } }.with_indifferent_access }
 
-    it "should replace the special quote characters w/ actual quote characters" do
+    it "replaces the special quote characters w/ actual quote characters" do
       controller.send(:replace_special_quotes)
       expect(params.dig(:clause, '1', :query).scan("\"#{q}\"").length).to eq 14
       ["«", "「", "〟", "』"].each do |character|
@@ -37,7 +37,7 @@ RSpec.describe ReplaceSpecialQuotes do
         }.with_indifferent_access
       end
 
-      it 'should be replaced with an apostrophe' do
+      it 'is replaced with an apostrophe' do
         controller.send(:replace_special_quotes)
 
         expect(params.dig(:clause, :a_param, :query)).to eq "query's"
@@ -59,7 +59,7 @@ RSpec.describe ReplaceSpecialQuotes do
         }.with_indifferent_access
       end
 
-      it 'should be replaced with the standard double quote character' do
+      it 'is replaced with the standard double quote character' do
         controller.send(:replace_special_quotes)
 
         expect(params.dig(:clause, :a_param, :query)).to eq '"query"'
@@ -73,7 +73,7 @@ RSpec.describe ReplaceSpecialQuotes do
   describe "without special quotes" do
     let(:params) { { clause: { '1': { query: 'Hello' } } }.with_indifferent_access }
 
-    it "should not modify the parameter" do
+    it "does not modify the parameter" do
       expect(params.dig(:clause, '1', :query)).to eq 'Hello'
       controller.send(:replace_special_quotes)
       expect(params.dig(:clause, '1', :query)).to eq 'Hello'

--- a/spec/controllers/course_reserves_controller_spec.rb
+++ b/spec/controllers/course_reserves_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CourseReservesController do
       allow(CourseReserve).to receive(:where).and_return([build(:reg_course), build(:reg_course_add)])
     end
 
-    it "should get the course reserves page" do
+    it "gets the course reserves page" do
       get :index
       expect(assigns(:course_reserves).length).to equal(2)
       expect(response).to render_template("index")

--- a/spec/controllers/feedback_forms_controller_spec.rb
+++ b/spec/controllers/feedback_forms_controller_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe FeedbackFormsController do
     let(:user) { User.new }
 
     describe "format json" do
-      it "should return json success" do
+      it "returns json success" do
         post :create, params: { url: "http://test.host/", message: "Hello Kittenz", format: "json" }
         expect(flash[:success]).to eq "<strong>Thank you!</strong> Your feedback has been sent."
       end
-      it "should return html success" do
+      it "returns html success" do
         post :create, params: { url: "http://test.host/", message: "Hello Kittenz" }
         expect(flash[:success]).to eq "<strong>Thank you!</strong> Your feedback has been sent."
       end
     end
 
     describe "validate" do
-      it "should return an error if no message is sent" do
+      it "returns an error if no message is sent" do
         post :create, params: { url: "http://test.host/", message: "", email_address: "" }
         expect(flash[:error]).to eq "A message is required"
       end

--- a/spec/controllers/hours_controller_spec.rb
+++ b/spec/controllers/hours_controller_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe HoursController do
   describe "routes" do
-    it "should route to the library action with params" do
+    it "routes to the library action with params" do
       expect(get: "/hours/GREEN").to route_to(controller: 'hours', action: 'show', id: 'GREEN')
     end
   end
 
   describe "GET library" do
-    it "should return correct response" do
+    it "returns correct response" do
       get :show, params: { format: "json", id: "GREEN" }
       expect(response).to have_http_status :ok
     end

--- a/spec/controllers/preview_controller_spec.rb
+++ b/spec/controllers/preview_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe PreviewController do
   describe "#show" do
     doc_id = 1
-    it "should get the document" do
+    it "gets the document" do
       get :show, params: { id: doc_id }
       expect(assigns[:document]).not_to be_nil
     end

--- a/spec/controllers/selected_databases_controller_spec.rb
+++ b/spec/controllers/selected_databases_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SelectedDatabasesController do
   describe "#index" do
-    it "should set the @selected_databases instance variable" do
+    it "sets the @selected_databases instance variable" do
       docs = double('documents')
 
       allow(controller).to receive(:search_service).and_return(double('MockSearchService', fetch: [double('response'), docs]))
@@ -15,7 +15,7 @@ RSpec.describe SelectedDatabasesController do
 
   describe "routes" do
     describe "/selected_databases" do
-      it "should route to the index action" do
+      it "routes to the index action" do
         expect({ get: "/selected_databases" }).to route_to(controller: 'selected_databases', action: 'index')
       end
     end

--- a/spec/features/access_panels/online_books_spec.rb
+++ b/spec/features/access_panels/online_books_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Record view', :js do
-  it 'should have online books panel with Google links' do
+  it 'has online books panel with Google links' do
     skip('Google Books API not working under test')
     visit solr_document_path('44')
 

--- a/spec/features/access_points/digital_collections_spec.rb
+++ b/spec/features/access_points/digital_collections_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Digital Collections Access Point' do
     click_link "Digital collections"
   end
 
-  it 'should include the digital collections masthead' do
+  it 'includes the digital collections masthead' do
     within(".digital-collections-masthead") do
       expect(page).to have_css('h1', text: 'Digital collections')
       expect(page).to have_css('a', text: 'All digital items')

--- a/spec/features/access_points/dissertation_theses_spec.rb
+++ b/spec/features/access_points/dissertation_theses_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe 'Dissertation Theses Access Point' do
     click_link 'Theses & dissertations'
   end
 
-  it 'should have a custom page title' do
+  it 'has a custom page title' do
     expect(page).to have_title('Dissertation theses in SearchWorks catalog')
   end
-  it 'should include the dissertation/theses masthead' do
+  it 'includes the dissertation/theses masthead' do
     within(".dissertation-theses-masthead") do
       expect(page).to have_css('h1', text: 'Theses and dissertations')
     end

--- a/spec/features/all_caps_params_spec.rb
+++ b/spec/features/all_caps_params_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe "Search parameters in all caps" do
-  it "should be downcased" do
+  it "is downcased" do
     visit root_path
     fill_in 'q', with: "HELLO WORLD"
     click_button 'search'

--- a/spec/features/blacklight_customizations/layout_spec.rb
+++ b/spec/features/blacklight_customizations/layout_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Customized Layout' do
     visit root_path
   end
 
-  it 'should include a the application-name in a meta tag' do
+  it 'includes a the application-name in a meta tag' do
     expect(page).to have_css('meta[name="application-name"][value="SearchWorks"]', visible: false)
   end
 
-  it 'should include the google-site-verification code' do
+  it 'includes the google-site-verification code' do
     expect(page).to have_css("meta[name='google-site-verification'][content='#{Settings.GOOGLE_SITE_VERIFICATION}']", visible: false)
   end
 end

--- a/spec/features/blacklight_customizations/search_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/search_toolbar_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Search toolbar", :feature, :js do
   before { visit root_path }
 
   describe "has SearchWorks customizations" do
-    it "should display correct subnavbar elements" do
+    it "displays correct subnavbar elements" do
       within '#search-navbar-container' do
         expect(page).to have_css("button.btn.btn-secondary.search-btn", text: "")
       end
@@ -21,7 +21,7 @@ RSpec.describe "Search toolbar", :feature, :js do
 
   describe "Selections dropdown" do
     describe "show list" do
-      it "should navigate to selections page" do
+      it "navigates to selections page" do
         visit bookmarks_path
         expect(page).to have_css('h2', text: '0 catalog items')
         expect(page).to have_css('a', text: '0 articles+ items')
@@ -30,7 +30,7 @@ RSpec.describe "Search toolbar", :feature, :js do
     end
 
     describe "clear list" do
-      it "should clear selections and update selections count and recently added list" do
+      it "clears selections and update selections count and recently added list" do
         skip 'Not working correctly'
         visit search_catalog_path f: { format: ["Book"] }, view: "default"
         expect(page).to have_css("li a", text: /SELECTIONS \(0\)/i)

--- a/spec/features/collections_search_spec.rb
+++ b/spec/features/collections_search_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe "Searching within collections" do
-  it "should return the zero results page when no items are present" do
+  it "returns the zero results page when no items are present" do
     visit search_catalog_path(f: { collection: ['29'] })
 
     fill_in 'q', with: 'abcde'

--- a/spec/features/fielded_search_spec.rb
+++ b/spec/features/fielded_search_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Fielded Search' do
     let(:query) { 'An object' }
     let(:search_field) { 'Title' }
 
-    it 'works' do
+    it 'shows the matched document' do
       expect(page).to have_css('.document', count: 1)
       expect(page).to have_css('.document h3.index_title a', text: 'An object')
     end
@@ -24,7 +24,7 @@ RSpec.describe 'Fielded Search' do
     let(:query) { 'Doe, Jane' }
     let(:search_field) { 'Author/Contributor' }
 
-    it 'works' do
+    it 'shows the matched document' do
       expect(page).to have_css('.document', count: 1)
       expect(page).to have_css('.document h3.index_title a', text: 'An object')
     end

--- a/spec/features/marc_results_metadata_spec.rb
+++ b/spec/features/marc_results_metadata_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "MARC Metadata in search results" do
       click_button 'search'
     end
 
-    it "should link the uniform title (but not $h)" do
+    it "links the uniform title (but not $h)" do
       within(first('.document')) do
         within('ul.document-metadata') do
           expect(page).to have_css('li', text: 'Instrumental music Selections [print/digital].')
@@ -27,7 +27,7 @@ RSpec.describe "MARC Metadata in search results" do
       click_button 'search'
     end
 
-    it 'should join the characteristics with the physical statement' do
+    it 'joins the characteristics with the physical statement' do
       # this item is the 2nd search result
       within(first('.document')) do
         expect(page).to have_css('dt', text: 'Description')
@@ -44,7 +44,7 @@ RSpec.describe "MARC Metadata in search results" do
       click_button 'search'
     end
 
-    it "should link the author/creator, corporate author, and meeting" do
+    it "links the author/creator, corporate author, and meeting" do
       within(first('.document')) do
         within('ul.document-metadata') do
           expect(page).to have_css('li a', text: 'Arbitrary, Stewart.')

--- a/spec/features/mhld_spec.rb
+++ b/spec/features/mhld_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe "MHLD", :feature do
   describe "record view" do
-    it "should be present in the location access panel" do
+    it "is present in the location access panel" do
       visit solr_document_path('10')
 
       within('[data-hours-route="/hours/ENG"]') do
@@ -27,7 +27,7 @@ RSpec.describe "MHLD", :feature do
       stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
     end
 
-    it "should be present in the accordion section" do
+    it "is present in the accordion section" do
       visit search_catalog_path(q: 'id:10')
 
       within(first('.document')) do

--- a/spec/features/purl_embed_spec.rb
+++ b/spec/features/purl_embed_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'PURL Embed', :js do
-  it 'should be present for images' do
+  it 'is present for images' do
     visit solr_document_path('mf774fs2413')
 
     within('.purl-embed-viewer') do

--- a/spec/features/responsive/record_toolbar_responsive_spec.rb
+++ b/spec/features/responsive/record_toolbar_responsive_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Record toolbar", :feature, :js do
     context 'a citable item' do
       before { page.find('a', text: 'An object').click }
 
-      it 'should display a cite this link toolbar items' do
+      it 'displays a cite this link toolbar items' do
         expect(page).to have_css('div.record-toolbar', visible: true)
         within '#content' do
           within 'div.navbar-collapse' do
@@ -34,7 +34,7 @@ RSpec.describe "Record toolbar", :feature, :js do
         end
       end
 
-      it "should display all toolbar items" do
+      it "displays all toolbar items" do
         within "#content" do
           expect(page).to have_css("div.record-toolbar", visible: true)
 
@@ -83,7 +83,7 @@ RSpec.describe "Record toolbar", :feature, :js do
         end
       end
 
-      it "should display correct toolbar items" do
+      it "displays correct toolbar items" do
         within "#content" do
           expect(page).to have_css("div.record-toolbar", visible: true)
 

--- a/spec/features/responsive/results_view_spec.rb
+++ b/spec/features/responsive/results_view_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Responsive results view Page', :feature, :js do
       visit search_catalog_path f: { access_facet: ['Online'] }
     end
 
-    it 'should show previous/next on large screens' do
+    it 'shows previous/next on large screens' do
       within('ul.pagination') do
         expect(page).to have_css('span', text: 'Previous', visible: true)
       end

--- a/spec/features/sort_and_per_page_dropdown_spec.rb
+++ b/spec/features/sort_and_per_page_dropdown_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe 'Sort and per page toolbar', :feature, :js do
       click_button 'search'
     end
 
-    it 'should display default correctly' do
+    it 'displays default correctly' do
       within '.sort-and-per-page' do
         expect(page).to have_css('button.btn.btn-sul-toolbar', text: 'Sort by relevance', visible: true)
       end
     end
 
-    it 'should change to current sort' do
+    it 'changes to current sort' do
       within '.sort-and-per-page' do
         expect(page).to have_no_css('button.btn.btn-sul-toolbar', text: 'Sort by author', visible: true)
         page.find('button.btn.btn-sul-toolbar', text: 'Sort by relevance').click

--- a/spec/features/special_quotes_spec.rb
+++ b/spec/features/special_quotes_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 
 RSpec.describe "Special Quotes" do
-  it "should replace special quotes in the query" do
+  it "replaces special quotes in the query" do
     visit root_path
     fill_in 'q', with: '『stuff』'
     click_button 'search'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ApplicationHelper do
     let(:temp_doc_vern_array) { { 'key' => 'fudgesicles', 'vern_key' => ['fudgeyzicles1', 'fudgeyzicles2'] } }
 
     describe "get" do
-      it "should return a valid label and fields" do
+      it "returns a valid label and fields" do
         data = get_data_with_label(temp_doc, "Food:", "key")
         expect(data[:label]).to eq "Food:"
         expect(data[:fields]).to eq ["fudgesicles"]
@@ -35,44 +35,44 @@ RSpec.describe ApplicationHelper do
         expect(data[:fields].include?("fudgesicles1")).to be_truthy
         expect(data[:fields].include?("fudgesicles2")).to be_truthy
       end
-      it "should display the vernacular equivalent for a field if one exists" do
+      it "displays the vernacular equivalent for a field if one exists" do
         expect(get_data_with_label(temp_doc_vern, "Food:", "key")[:vernacular]).to eq ["fudgeyzicles"]
       end
-      it "should handle vernacular arrays correctly" do
+      it "handles vernacular arrays correctly" do
         data = get_data_with_label(temp_doc_vern_array, "Food:", "key")[:vernacular]
         expect(data.length).to eq 2
         expect(data.include?("fudgeyzicles1")).to be_truthy
         expect(data.include?("fudgeyzicles2")).to be_truthy
       end
-      it "should return nil for the vernacular if there is none" do
+      it "returns nil for the vernacular if there is none" do
         expect(get_data_with_label(temp_doc, "Food:", "key")[:vernacular]).to be_nil
       end
-      it "should return nil if the field does not exist" do
+      it "returns nil if the field does not exist" do
         expect(get_data_with_label(temp_doc, "Blech:", "not_valid_key")).to be_nil
       end
     end
 
     describe "link_to" do
-      it "should return a valid label and fields" do
+      it "returns a valid label and fields" do
         data = link_to_data_with_label(temp_doc, "Food:", "key", { controller: 'catalog', action: 'index', search_field: 'search_author' })
         expect(data[:label]).to eq("Food:") and
         expect(data[:fields].first).to match(/<a href=.*fudgesicles.*search_field=search_author.*>fudgesicles<\/a>/)
       end
-      it "should handle data from the index in an array" do
+      it "handles data from the index in an array" do
         fields = link_to_data_with_label(temp_doc_array, "Food:", "key", { controller: 'catalog', action: 'index', search_field: 'search_author' })[:fields]
         expect(fields.include?("<a href=\"/?q=%22fudgesicles1%22&amp;search_field=search_author\">fudgesicles1</a>")).to be_truthy and
         expect(fields.include?("<a href=\"/?q=%22fudgesicles2%22&amp;search_field=search_author\">fudgesicles2</a>")).to be_truthy
       end
-      it "should display the linked vernacular equivalent for a field if one exists" do
+      it "displays the linked vernacular equivalent for a field if one exists" do
         actual = link_to_data_with_label(temp_doc_vern, "Food:", "key", { controller: 'catalog', action: 'index', search_field: 'search_author' })
         expect(actual[:vernacular].first).to match(/<a href=.*fudgeyzicles.*search_field=search_author.*>fudgeyzicles<\/a>/)
       end
-      it "should handle vernacular data from the index in an array" do
+      it "handles vernacular data from the index in an array" do
         vern = link_to_data_with_label(temp_doc_vern_array, "Food:", "key", { controller: 'catalog', action: 'index', search_field: 'search_author' })[:vernacular]
         expect(vern.include?("<a href=\"/?q=%22fudgeyzicles1%22&amp;search_field=search_author\">fudgeyzicles1</a>")).to be_truthy and
         expect(vern.include?("<a href=\"/?q=%22fudgeyzicles2%22&amp;search_field=search_author\">fudgeyzicles2</a>")).to be_truthy
       end
-      it "should return nil if the field does not exist" do
+      it "returns nil if the field does not exist" do
         expect(get_data_with_label(temp_doc, "Blech:", "not_valid_key")).to be_nil
       end
     end
@@ -81,11 +81,11 @@ RSpec.describe ApplicationHelper do
   describe "#active_class_for_current_page" do
     let(:advanced_page) { "advanced" }
 
-    it "should be active" do
+    it "is active" do
       helper.request.path = "advanced"
       expect(helper.active_class_for_current_page(advanced_page)).to eq "active"
     end
-    it "should not be active" do
+    it "is not active" do
       helper.request.path = "feedback"
       expect(helper.active_class_for_current_page(advanced_page)).to be_nil
     end
@@ -94,27 +94,27 @@ RSpec.describe ApplicationHelper do
   describe "#disabled_class_for_current_page" do
     let(:selections_page) { "selections" }
 
-    it "should be disabled" do
+    it "is disabled" do
       helper.request.path = "selections"
       expect(helper.disabled_class_for_current_page(selections_page)).to eq "disabled"
     end
-    it "should not be disabled" do
+    it "is not disabled" do
       helper.request.path = "feedback"
       expect(helper.active_class_for_current_page(selections_page)).to be_nil
     end
   end
 
   describe "#disabled_class_for_no_selections" do
-    it "should be disabled" do
+    it "is disabled" do
       expect(helper.disabled_class_for_no_selections(0)).to eq "disabled"
     end
-    it "should not be disabled" do
+    it "is not disabled" do
       expect(helper.disabled_class_for_no_selections(1)).to be_nil
     end
   end
 
   describe "#from_advanced_search" do
-    it "should indicate if we are coming from the advanced search form" do
+    it "indicates if we are coming from the advanced search form" do
       params[:search_field] = 'advanced'
       expect(helper.from_advanced_search?).to be_truthy
     end

--- a/spec/helpers/bookmarks_helper_spec.rb
+++ b/spec/helpers/bookmarks_helper_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe BookmarksHelper do
   end
 
   describe "bookmarks?" do
-    it "should return true if bookmarks controller" do
+    it "returns true if bookmarks controller" do
       params[:controller] = "bookmarks"
       expect(helper.bookmarks?).to be_truthy
     end
 
-    it 'should return true if in the article_selections controller' do
+    it 'returns true if in the article_selections controller' do
       params[:controller] = 'article_selections'
       expect(helper.bookmarks?).to be_truthy
     end
 
-    it "should return false if not bookmarks controller" do
+    it "returns false if not bookmarks controller" do
       params[:controller] = "catalog"
       expect(helper.bookmarks?).to be_falsey
     end

--- a/spec/helpers/browse_helper_spec.rb
+++ b/spec/helpers/browse_helper_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe BrowseHelper do
       Holdings::Spine.new({ lopped_callnumber: 'truncated_callnumber', shelfkey: 'shelfkey', reverse_shelfkey: 'reverse_shelfkey', callnumber: 'callnumber' }, document:)
     }
 
-    it "should link to the callnumber" do
+    it "links to the callnumber" do
       expect(link_to_callnumber_browse(document, spine)).to have_css('button', text: 'callnumber')
     end
-    it "should include correct class" do
+    it "includes correct class" do
       expect(link_to_callnumber_browse(document, spine)).to match(/<button*.*class=\"collapsed\"*/)
     end
-    it "should include correct data attributes" do
+    it "includes correct data attributes" do
       button = Capybara.string(link_to_callnumber_browse(document, spine, 3))
       expect(button).to have_css('button[data-behavior="embed-browse"][data-embed-viewport="#callnumber-3"][data-start="abc123"]')
       # Should add [data-index-path="/browse?start=shelfkey&view=gallery"] to the check,

--- a/spec/helpers/collection_access_point_helper_spec.rb
+++ b/spec/helpers/collection_access_point_helper_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CollectionAccessPointHelper do
   describe "#get_collection" do
     describe "when no document is present" do
-      it "should return parameter values" do
+      it "returns parameter values" do
         params[:f] = { collection: ["29"] }
         expect(response).to receive(:docs).exactly(1).times.and_return([])
         helper.get_collection
@@ -14,7 +14,7 @@ RSpec.describe CollectionAccessPointHelper do
     end
 
     describe "when documents are present" do
-      it "should return 1st doc parent collection values" do
+      it "returns 1st doc parent collection values" do
         params[:f] = { collection: ["29"] }
         expect(response).to receive(:docs).exactly(2).times.and_return([{ collection: ["29"] }])
         helper.get_collection

--- a/spec/helpers/collection_helper_spec.rb
+++ b/spec/helpers/collection_helper_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe CollectionHelper do
   describe "#link_to_collection_members" do
     let(:document) { instance_double(SolrDocument, id: '1234', collection_id: 'a1234') }
 
-    it "should link to the given text" do
+    it "links to the given text" do
       expect(link_to_collection_members("LinkText", document)).to match /<a href.*>LinkText<\/a>/
     end
-    it "should link the collection id with prefix" do
+    it "links the collection id with prefix" do
       expect(link_to_collection_members("LinkText", document)).to match /<a href=\".*collection.*=a1234\".*/
     end
   end
 
   describe "#collections_search_params" do
-    it "should be the collection_type facet value of 'Digital Collection" do
+    it "is the collection_type facet value of 'Digital Collection" do
       expect(collections_search_params).to have_key(:f)
       expect(collections_search_params[:f]).to have_key(:collection_type)
       expect(collections_search_params[:f][:collection_type]).to eq ["Digital Collection"]
@@ -25,7 +25,7 @@ RSpec.describe CollectionHelper do
   describe "#collection_members_path" do
     let(:document) { instance_double(SolrDocument, id: '1234', collection_id: 'a1234') }
 
-    it "should link the collection id with prefix" do
+    it "links the collection id with prefix" do
       expect(collection_members_path(document)).to match /.*collection.*=a1234.*/
     end
   end
@@ -41,10 +41,10 @@ RSpec.describe CollectionHelper do
       allow(no_collection_doc).to receive(:collection_members).and_return([])
     end
 
-    it "should return the correct number of document including the #total" do
+    it "returns the correct number of document including the #total" do
       expect(collection_members_enumeration(document)).to eq "5 items online"
     end
-    it "should not return anything if an document does not have collection members" do
+    it "does not return anything if an document does not have collection members" do
       expect(collection_members_enumeration(no_collection_doc)).to be_nil
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe CollectionHelper do
   end
 
   describe "#collection_breadcrumb_value" do
-    it "should return the collection name when present" do
+    it "returns the collection name when present" do
       allow(helper).to receive(:document_presenter).and_return(
         OpenStruct.new(heading: 'Title2')
       )
@@ -74,11 +74,11 @@ RSpec.describe CollectionHelper do
       assign(:response, OpenStruct.new(documents: document_list))
       expect(helper.send(:collection_breadcrumb_value, 'a54321')).to eq 'Title2'
     end
-    it "should return the ID with the prefix if there is no @document_list" do
+    it "returns the ID with the prefix if there is no @document_list" do
       assign(:response, OpenStruct.new(documents: []))
       expect(helper.send(:collection_breadcrumb_value, 'a54321')).to eq 'a54321'
     end
-    it "should return the ID with the prefix if there are no matching collections" do
+    it "returns the ID with the prefix if there are no matching collections" do
       document_list = [
         SolrDocument.new(collection: ['12345', '54321'], collection_with_title: ['12345 -|- Title1', '54321 -|- Title2'])
       ]

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -4,22 +4,22 @@ require 'rails_helper'
 
 RSpec.describe FacetsHelper do
   describe "#render_resource_icon" do
-    it "should not render anything if format_main_ssim field is not present" do
+    it "does not render anything if format_main_ssim field is not present" do
       expect(helper.render_resource_icon(nil)).to be_nil
     end
-    it "should render a book before a database" do
+    it "renders a book before a database" do
       expect(helper.render_resource_icon(['Database', 'Book'])).to eq '<span class="sul-icon sul-icon-book-1"></span>'
     end
-    it "should render an image before a book" do
+    it "renders an image before a book" do
       expect(helper.render_resource_icon(['Book', 'Image'])).to eq '<span class="sul-icon sul-icon-photos-1"></span>'
     end
-    it "should render the first resource type icon" do
+    it "renders the first resource type icon" do
       expect(helper.render_resource_icon(['Video', 'Image'])).to eq '<span class="sul-icon sul-icon-film-2"></span>'
     end
-    it "should render an icon that is in Constants::SUL_ICON" do
+    it "renders an icon that is in Constants::SUL_ICON" do
       expect(helper.render_resource_icon(['Book'])).to eq '<span class="sul-icon sul-icon-book-1"></span>'
     end
-    it "should not render anything for something not in Constants::SUL_ICON" do
+    it "does not render anything for something not in Constants::SUL_ICON" do
       expect(helper.render_resource_icon(['iPad'])).to be_nil
     end
   end

--- a/spec/helpers/feedback_form_helper_spec.rb
+++ b/spec/helpers/feedback_form_helper_spec.rb
@@ -31,24 +31,24 @@ RSpec.describe FeedbackFormHelper do
       allow(form_controller).to receive(:controller).and_return(form_controller)
     end
 
-    it "should return false when being viewed under the FeedbackFormsController" do
+    it "returns false when being viewed under the FeedbackFormsController" do
       expect(form_controller.show_feedback_form?).to be_falsey
     end
-    it "should return true when not under the FeedbackFormsController" do
+    it "returns true when not under the FeedbackFormsController" do
       expect(helper.show_feedback_form?).to be_truthy
     end
   end
 
   describe 'show_quick_report?' do
-    it 'should be false unless it meets certain criteria' do
+    it 'is false unless it meets certain criteria' do
       expect(helper.show_quick_report?).to be_falsey
     end
-    it 'should return true when coming from a show page' do
+    it 'returns true when coming from a show page' do
       params = { controller: 'catalog', action: 'show' }
       allow(helper).to receive(:params).and_return(params)
       expect(helper.show_quick_report?).to be_truthy
     end
-    it 'should return true when the referrer is a show page and current controller is feedback' do
+    it 'returns true when the referrer is a show page and current controller is feedback' do
       params = { controller: 'feedback_forms', action: 'new' }
       expect(controller.request).to receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/view/12')
       allow(helper).to receive(:params).and_return(params)
@@ -57,19 +57,19 @@ RSpec.describe FeedbackFormHelper do
   end
 
   describe 'refered_from_catalog_show?' do
-    it 'should be true if referer is from view show' do
+    it 'is true if referer is from view show' do
       expect(controller.request).to receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/view/12')
       expect(helper.refered_from_catalog_show?).to be_truthy
     end
-    it 'should be true if referer is from catalog show' do
+    it 'is true if referer is from catalog show' do
       expect(controller.request).to receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/catalog/12')
       expect(helper.refered_from_catalog_show?).to be_truthy
     end
-    it 'should be false if not a show page' do
+    it 'is false if not a show page' do
       expect(controller.request).to receive(:referer).at_least(:once).and_return('http://127.0.0.1:3000/catalog?f%5Baccess_facet%5D%5B%5D=At+the+Library&f%5Baccess_facet%5D%5B%5D=Online')
       expect(helper.refered_from_catalog_show?).to be_falsey
     end
-    it 'should be false if referer is nil' do
+    it 'is false if referer is nil' do
       expect(controller.request).to receive(:referer).at_least(:once).and_return(nil)
       expect(helper.refered_from_catalog_show?).to be_falsey
     end

--- a/spec/helpers/masthead_helper_spec.rb
+++ b/spec/helpers/masthead_helper_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe MastheadHelper do
   end
 
   describe "#facets_prefix_options" do
-    it "should have the correct number of elements" do
+    it "has the correct number of elements" do
       expect(facets_prefix_options.length).to eq 27
     end
-    it "should include the necessary options" do
+    it "includes the necessary options" do
       expect(facets_prefix_options).to include "0-9"
       expect(facets_prefix_options).to include "A"
       expect(facets_prefix_options).to include "X"
@@ -35,11 +35,11 @@ RSpec.describe MastheadHelper do
   end
 
   describe '#digital_collections_params_for' do
-    it 'should always include "Stanford Digital Repository" in the building facet' do
+    it 'alwayses include "Stanford Digital Repository" in the building facet' do
       expect(digital_collections_params_for).to match /building_facet.*Stanford\+Digital\+Repository/
       expect(digital_collections_params_for('something')).to match /building_facet.*Stanford\+Digital\+Repository/
     end
-    it 'should include the given parameter as the format_main_ssim' do
+    it 'includes the given parameter as the format_main_ssim' do
       expect(digital_collections_params_for).not_to match /format_main_ssim/
       expect(digital_collections_params_for('something')).to match /format_main_ssim.*something/
     end

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RecordHelper do
     let(:subjects) { [OpenStruct.new(label: 'Subjects', values: [%w(Subject1a Subject1b), %w(Subject2a Subject2b Subject2c)])] }
 
     describe '#linked_mods_subjects' do
-      it 'should join the subject fields in a dd' do
+      it 'joins the subject fields in a dd' do
         expect(helper.linked_mods_subjects(subjects)).to match /<dd><a href=*.*">Subject1a*.*Subject1b<\/a><\/dd>\s*<dd><a/
       end
     end
@@ -16,7 +16,7 @@ RSpec.describe RecordHelper do
       let(:genres) { [OpenStruct.new(label: 'Genres', values: %w(Genre1 Genre2 Genre3))] }
 
       describe '#linked_mods_genres' do
-        it 'should join the genre fields with a dd' do
+        it 'joins the genre fields with a dd' do
           expect(helper.linked_mods_genres(genres)).to match /<dd><a href=*.*>Genre1*.*<\/a><\/dd>\s*<dd><a*.*Genre2<\/a><\/dd>/
         end
       end

--- a/spec/helpers/results_document_helper_spec.rb
+++ b/spec/helpers/results_document_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ResultsDocumentHelper do
 
   describe "Render metadata" do
     describe '#get_main_title_date' do
-      it "should return date and date ranges" do
+      it "returns date and date ranges" do
         expect(get_main_title_date(@document_01)).to eq "[1999]"
         expect(get_main_title_date(@document_02)).to eq "[1801 ... 1837]"
         expect(get_main_title_date(@document_03)).to eq "[199 B.C.]"
@@ -46,7 +46,7 @@ RSpec.describe ResultsDocumentHelper do
       end
     end
 
-    it "should return book ids with prefixes" do
+    it "returns book ids with prefixes" do
       book_ids = get_book_ids(@document_01)
 
       expect(book_ids['isbn']).to eq ["ISBN0393040801x", "ISBN9780393040807"]

--- a/spec/helpers/thumbnail_helper_spec.rb
+++ b/spec/helpers/thumbnail_helper_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe ThumbnailHelper do
       allow(helper).to receive(:book_ids).and_return(numbers)
     end
 
-    it "should return nothing when the document does not have an associated thumbnail partial" do
+    it "returns nothing when the document does not have an associated thumbnail partial" do
       allow(document).to receive(:display_type).and_return(nil)
       expect(helper.render_cover_image(document)).to be_nil
     end
-    it "should render the appropriate partial for a document's display type" do
+    it "renders the appropriate partial for a document's display type" do
       allow(document).to receive(:display_type).and_return('marc')
       expect(helper).to receive(:render).with({ partial: 'catalog/thumbnails/marc_thumbnail', locals: expected_locals })
       helper.render_cover_image(document)

--- a/spec/integration/record_view_spec.rb
+++ b/spec/integration/record_view_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe "Record view", :feature do
-  it "should display records from the index" do
+  it "displays records from the index" do
     visit solr_document_path("1")
     expect(page).to have_css("h1", text: "An object")
   end
-  it 'should display the correct COinS' do
+  it 'displays the correct COinS' do
     visit solr_document_path("1")
     expect(page).to have_css('span.Z3988[title*="fmt%3Akev%3Amtx%3Abook"]')
   end

--- a/spec/lib/holdings/item_spec.rb
+++ b/spec/lib/holdings/item_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Holdings::Item do
     ]
   end
 
-  it 'should have an attribute for each piece of the item display field' do
+  it 'has an attribute for each piece of the item display field' do
     methods.each do |method|
       expect(item).to respond_to(method)
     end
@@ -29,11 +29,11 @@ RSpec.describe Holdings::Item do
   describe '#suppressed?' do
     let(:no_item_display) { Holdings::Item.new({}) }
 
-    it "should be true when the item_display doesn't exist" do
+    it "is true when the item_display doesn't exist" do
       expect(no_item_display).to be_suppressed
     end
 
-    it 'should return false when the item_display exists' do
+    it 'returns false when the item_display exists' do
       expect(item).not_to be_suppressed
     end
   end
@@ -45,11 +45,11 @@ RSpec.describe Holdings::Item do
   end
 
   describe '#on_order?' do
-    it 'should return true for on-order items' do
+    it 'returns true for on-order items' do
       expect(Holdings::Item.new({ status: 'On order' })).to be_on_order
     end
 
-    it 'should return false for non on-order items' do
+    it 'returns false for non on-order items' do
       expect(item).not_to be_on_order
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe Holdings::Item do
       Holdings::Item.new({ library: 'LANE', effective_permanent_location_code: 'LANE-ECOLL', type: 'ONLINE', shelfkey: 'abc123', reverse_shelfkey: 'xyz987', scheme: 'LC' })
     }
 
-    it "should return '(no call number) if the callnumber is blank" do
+    it "returns '(no call number) if the callnumber is blank" do
       expect(item_without_callnumber.callnumber).to eq '(no call number)'
     end
   end
@@ -71,11 +71,11 @@ RSpec.describe Holdings::Item do
   describe '#status' do
     let(:status) { item.status }
 
-    it 'should return a Holdings::Status object' do
+    it 'returns a Holdings::Status object' do
       expect(status).to be_a Holdings::Status
     end
 
-    it 'should return an availability_class string' do
+    it 'returns an availability_class string' do
       expect(status.availability_class).to eq 'unknown'
     end
   end
@@ -83,18 +83,18 @@ RSpec.describe Holdings::Item do
   describe 'public_note' do
     let(:public_note) { Holdings::Item.new({ note: '.PUBLIC. The Public Note' }) }
 
-    it 'should remove the .PUBLIC. string from the public note field' do
+    it 'removes the .PUBLIC. string from the public note field' do
       expect(public_note.public_note).to eq 'The Public Note'
       expect(public_note.public_note).not_to include 'PUBLIC'
     end
   end
 
   describe '#on_reserve?' do
-    it 'should return true when an item is populated with reserve desks and loan period' do
+    it 'returns true when an item is populated with reserve desks and loan period' do
       expect(item).to be_on_reserve
     end
 
-    it 'should return false when an item is not populated with reserve desk and loan period' do
+    it 'returns false when an item is not populated with reserve desk and loan period' do
       expect(described_class.new({ barcode: '123', library: 'abc' })).not_to be_on_reserve
     end
   end
@@ -102,7 +102,7 @@ RSpec.describe Holdings::Item do
   describe 'zombie libraries' do
     let(:blank) { Holdings::Item.new({ barcode: '123', library: '', effective_permanent_location_code: 'LOCATION' }) }
 
-    it 'should view blank libraries as a zombie library' do
+    it 'views blank libraries as a zombie library' do
       expect(blank.library).to eq 'ZOMBIE'
     end
   end

--- a/spec/lib/holdings/library_spec.rb
+++ b/spec/lib/holdings/library_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe Holdings::Library do
     ] }
     let(:library) { Holdings::Library.new("GREEN", callnumbers) }
 
-    it "should be false when libraries have no item display fields" do
+    it "is false when libraries have no item display fields" do
       expect(library).not_to be_present
     end
   end
 
   describe '#library_instructions' do
-    it 'should return instructions for libraries which have them' do
+    it 'returns instructions for libraries which have them' do
       Constants::LIBRARY_INSTRUCTIONS.each_key do |library|
         expect(Holdings::Library.new(library).library_instructions).to have_key(:heading)
         expect(Holdings::Library.new(library).library_instructions).to have_key(:text)
@@ -124,10 +124,10 @@ RSpec.describe Holdings::Library do
   describe "zombie" do
     let(:zombie) { Holdings::Library.new("ZOMBIE") }
 
-    it "should be #zombie?" do
+    it "is #zombie?" do
       expect(zombie).to be_zombie
     end
-    it "should not be a holding library" do
+    it "is not a holding library" do
       expect(zombie).not_to be_holding_library
     end
   end

--- a/spec/lib/holdings/mhld_spec.rb
+++ b/spec/lib/holdings/mhld_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Holdings::MHLD do
     "SAL3 -|- PAGE-AS -|-  -|- v.1:no.3(1965:Sept.20)-v.1:no.4(1965:Oct.18);v.1:no.6(1965:Nov.17)-v.1:no.11(1966:May9),v.2:no.2(1966:Aug.8)-v.6:no.6(1970:Dec./1971:Jan.) -|- "
   end
 
-  it 'should return the correct elements from the MHLD combined field' do
+  it 'returns the correct elements from the MHLD combined field' do
     mhld = Holdings::MHLD.new(mhld_display)
     expect(mhld.library).to eq 'GREEN'
     expect(mhld.location).to eq 'STACKS'
@@ -19,29 +19,29 @@ RSpec.describe Holdings::MHLD do
     expect(mhld.latest_received).to eq 'mhld latest received'
   end
 
-  it 'should escape HTML enteties in MHLD data' do
+  it 'escapes HTML enteties in MHLD data' do
     library_has = Holdings::MHLD.new(special_mhld).library_has
     expect(library_has).not_to include('<html>')
     expect(library_has).to include('&lt;html&gt;')
   end
 
-  it "should replace '),(' with '), ('" do
+  it "replaces '),(' with '), ('" do
     expect(Holdings::MHLD.new(special_mhld).public_note).to match(/\), \(/)
   end
 
-  it "should replace ',' with ', '" do
+  it "replaces ',' with ', '" do
     expect(Holdings::MHLD.new(special_mhld).public_note).to match(/no\.17, no\.14/)
   end
 
-  it "should replace ';' with '; '" do
+  it "replaces ';' with '; '" do
     expect(Holdings::MHLD.new(long_mhld).library_has).to match(/v.1:no.3\(1965:Sept.20\)-<wbr\/>v.1:no.4\(1965:Oct.18\); v.1:no.6\(1965:Nov.17\)/)
   end
 
-  it 'should append <wbr/> to hyphens' do
+  it 'appends <wbr/> to hyphens' do
     expect(Holdings::MHLD.new(special_mhld).library_has).to include('-<wbr/>')
   end
 
-  it 'should include mhlds from zombie libraries' do
+  it 'includes mhlds from zombie libraries' do
     zombie = Holdings::MHLD.new(zombie_mhld)
     expect(zombie).to be_present
     expect(zombie.library).to eq 'ZOMBIE'
@@ -52,11 +52,11 @@ RSpec.describe Holdings::MHLD do
     let(:no_mhld) { 'GREEN -|- STACKS -|- -|- -|-' }
     let(:mhld) { 'GREEN -|- STACKS -|- -|- -|- something' }
 
-    it 'should be false unless a piece of the mhld statement is available' do
+    it 'is false unless a piece of the mhld statement is available' do
       expect(Holdings::MHLD.new(no_mhld)).not_to be_present
     end
 
-    it 'should be true of any piece of the mhld is available' do
+    it 'is true of any piece of the mhld is available' do
       expect(Holdings::MHLD.new(mhld)).to be_present
     end
   end

--- a/spec/lib/holdings_spec.rb
+++ b/spec/lib/holdings_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe Holdings do
   end
 
   describe "#items" do
-    it "should return an array of Holdings::Items" do
+    it "returns an array of Holdings::Items" do
       holdings.items.each do |item|
         expect(item).to be_a Holdings::Item
       end
     end
-    it "should return an empty array if there are no holdings" do
+    it "returns an empty array if there are no holdings" do
       expect(no_holdings.items).to eq []
     end
-    it "should be sorted by the shelfkey" do
+    it "is sorted by the shelfkey" do
       expect(sortable_holdings.items.map(&:full_shelfkey)).to eq ['111', '999']
     end
   end
@@ -82,13 +82,13 @@ RSpec.describe Holdings do
       )
     }
 
-    it "should group by library" do
+    it "groups by library" do
       expect(libraries.libraries.length).to eq 2
     end
-    it "should sort by library code when there is no translation" do
+    it "sorts by library code when there is no translation" do
       expect(libraries.libraries.map(&:code)).to eq ['library', 'library2']
     end
-    it "should sort Green first then the rest alpha" do
+    it "sorts Green first then the rest alpha" do
       expect(sortable_libraries.libraries.length).to eq 3
       expect(sortable_libraries.libraries.map(&:code)).to eq ['GREEN', 'MARINE-BIO', 'SAL3']
     end
@@ -97,13 +97,13 @@ RSpec.describe Holdings do
   describe "#find_by_barcode" do
     let(:found) { complex_holdings.find_by_barcode('barcode2') }
 
-    it "should return a single Holdings::Item" do
+    it "returns a single Holdings::Item" do
       expect(found).to be_a Holdings::Item
     end
-    it "should be the correct item" do
+    it "is the correct item" do
       expect(found.barcode).to eq 'barcode2'
     end
-    it "should return nil if the barcode is not found" do
+    it "returns nil if the barcode is not found" do
       expect(complex_holdings.find_by_barcode('not-a-barcode')).to be_nil
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe Holdings do
       )
     }
 
-    it "should match up mhlds in locations with existing call numbers" do
+    it "matches up mhlds in locations with existing call numbers" do
       holdings = holdings_doc.holdings
       expect(holdings.libraries.length).to eq 1
       expect(holdings.libraries.first.code).to eq 'GREEN'
@@ -136,7 +136,7 @@ RSpec.describe Holdings do
       expect(location.mhld.length).to eq 1
       expect(location.mhld.first).to be_a Holdings::MHLD
     end
-    it "should include mhlds that don't belong to an existing library or location" do
+    it "includes mhlds that don't belong to an existing library or location" do
       holdings = mhld_only_doc.holdings
       expect(holdings.libraries.length).to eq 1
       expect(holdings.libraries.first.code).to eq 'GREEN'

--- a/spec/lib/page_location_spec.rb
+++ b/spec/lib/page_location_spec.rb
@@ -45,19 +45,19 @@ RSpec.describe PageLocation do
         describe "old format facet" do
           before { params[:f] = { format: ["Database"] } }
 
-          it "should be defined when a facet is selected" do
+          it "is defined when a facet is selected" do
             expect(access_point).to eq :databases
           end
 
-          it "should be defined when an additional format facet is selected" do
+          it "is defined when an additional format facet is selected" do
             params[:f][:format] << "Book"
             expect(access_point).to eq :databases
           end
-          it "should be defined when searching within selected" do
+          it "is defined when searching within selected" do
             params[:q] = "My Query"
             expect(access_point).to eq :databases
           end
-          it "should not be defined when a non-database format facet is selected" do
+          it "is not defined when a non-database format facet is selected" do
             params[:f] = { access: "Online" }
             expect(access_point).to be_nil
           end
@@ -66,18 +66,18 @@ RSpec.describe PageLocation do
         describe "new resource type facet" do
           before { params[:f] = { format_main_ssim: ["Database"] } }
 
-          it "should be defined when a facet is selected" do
+          it "is defined when a facet is selected" do
             expect(access_point).to eq :databases
           end
-          it "should be defined when an additional format facet is selected" do
+          it "is defined when an additional format facet is selected" do
             params[:f][:format_main_ssim] << "Book"
             expect(access_point).to eq :databases
           end
-          it "should be defined when searching within selected" do
+          it "is defined when searching within selected" do
             params[:q] = "My Query"
             expect(access_point).to eq :databases
           end
-          it "should not be defined when a non-database format facet is selected" do
+          it "is not defined when a non-database format facet is selected" do
             params[:f] = { access: "Online" }
             expect(access_point).to be_nil
           end
@@ -140,14 +140,14 @@ RSpec.describe PageLocation do
       describe 'digital_collections' do
         before { params[:f] = { collection_type: ["Digital Collection"] } }
 
-        it 'should be defined when the collection_type is digital collection' do
+        it 'is defined when the collection_type is digital collection' do
           expect(access_point).to eq :digital_collections
         end
-        it "should not be defined when digital_collection is not present" do
+        it "is not defined when digital_collection is not present" do
           params[:f] = {}
           expect(access_point).to be_nil
         end
-        it "should not be defined when digital_collection is a different value" do
+        it "is not defined when digital_collection is a different value" do
           params[:f] = { collection_type: ["Something Else"] }
           expect(access_point).to be_nil
         end
@@ -156,14 +156,14 @@ RSpec.describe PageLocation do
       describe 'sdr' do
         before { params[:f] = { building_facet: ["Stanford Digital Repository"] } }
 
-        it 'should be defined when the building facet is Stanford Digital Repository' do
+        it 'is defined when the building facet is Stanford Digital Repository' do
           expect(access_point).to eq :sdr
         end
-        it "should not be defined when Stanford Digital Repository is not present" do
+        it "is not defined when Stanford Digital Repository is not present" do
           params[:f] = {}
           expect(access_point).to be_nil
         end
-        it "should not be defined when building_facet is a different value" do
+        it "is not defined when building_facet is a different value" do
           params[:f] = { building_facet: ["Green Library"] }
           expect(access_point).to be_nil
         end
@@ -172,14 +172,14 @@ RSpec.describe PageLocation do
       describe 'dissertation_theses' do
         before { params[:f] = { genre_ssim: ['Thesis/Dissertation'] } }
 
-        it 'should be defined when genre facet is "Thesis/Dissertation"' do
+        it 'is defined when genre facet is "Thesis/Dissertation"' do
           expect(access_point).to eq :dissertation_theses
         end
-        it 'should not be defined when Thesis/Dissertation is not present' do
+        it 'is not defined when Thesis/Dissertation is not present' do
           params[:f] = {}
           expect(access_point).to be_nil
         end
-        it 'should not be defined when genre_ssim is another value' do
+        it 'is not defined when genre_ssim is another value' do
           params[:f] = { genre_ssim: ['Cat Tricks'] }
           expect(access_point).to be_nil
         end

--- a/spec/lib/search_query_modifier_spec.rb
+++ b/spec/lib/search_query_modifier_spec.rb
@@ -14,38 +14,38 @@ RSpec.describe SearchQueryModifier do
     let(:default_fielded_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ search_field: "search", q: 'something' }, config)) }
 
     describe "#fielded_search?" do
-      it "should return true when a fielded search is selected" do
+      it "returns true when a fielded search is selected" do
         expect(fielded_search.fielded_search?).to be_truthy
       end
-      it "should return false when no field is selected (e.g. default)" do
+      it "returns false when no field is selected (e.g. default)" do
         expect(no_fielded_search.fielded_search?).to be_falsey
       end
-      it "should return false when there is no query (because no field searches are being done)" do
+      it "returns false when there is no query (because no field searches are being done)" do
         expect(no_query_search.fielded_search?).to be_falsey
       end
-      it "should return false when the default search field is present" do
+      it "returns false when the default search field is present" do
         expect(default_fielded_search.fielded_search?).to be_falsey
       end
     end
 
     describe "#has_query?" do
-      it "should return true when a search has a query" do
+      it "returns true when a search has a query" do
         expect(fielded_search.has_query?).to be_truthy
       end
-      it "should return false when a search does not have a query" do
+      it "returns false when a search does not have a query" do
         expect(no_query_search.has_query?).to be_falsey
       end
     end
 
     describe "#params_without_fielded_search" do
-      it "should return the parameters w/o the search_field param" do
+      it "returns the parameters w/o the search_field param" do
         expect(fielded_search.params_without_fielded_search[:q]).to eq 'something'
         expect(fielded_search.params_without_fielded_search[:search_field]).not_to be_present
       end
     end
 
     describe "#params_without_fielded_search_and_filters" do
-      it "should return the parameters w/o the search_field param or filters" do
+      it "returns the parameters w/o the search_field param or filters" do
         expect(fielded_search.params_without_fielded_search_and_filters[:search_field]).not_to be_present
         # expect(fielded_search.params_without_fielded_search[:f]).to_not be present
       end
@@ -68,23 +68,23 @@ RSpec.describe SearchQueryModifier do
     let(:no_filter_search) { SearchQueryModifier.new(Blacklight::SearchState.new({ q: 'something' }, default_config)) }
 
     describe "#has_filters?" do
-      it "should return true when a search has filters" do
+      it "returns true when a search has filters" do
         expect(filtered_search.has_filters?).to be_truthy
       end
-      it "should return true when there is a range" do
+      it "returns true when there is a range" do
         expect(ranged_search.has_filters?).to be_truthy
       end
-      it "should return false when a search has no filters" do
+      it "returns false when a search has no filters" do
         expect(no_filter_search.has_filters?).to be_falsey
       end
     end
 
     describe "#params_without_filters" do
-      it "should return the parameters hash without an f param" do
+      it "returns the parameters hash without an f param" do
         expect(filtered_search.params_without_fielded_search[:q]).to eq 'something'
         expect(filtered_search.params_without_filters[:f]).not_to be_present
       end
-      it "should return the parameters hash without a range param" do
+      it "returns the parameters hash without a range param" do
         expect(ranged_search.params_without_fielded_search[:q]).to eq 'something'
         expect(ranged_search.params_without_filters[:range]).not_to be_present
       end

--- a/spec/lib/sms_spec.rb
+++ b/spec/lib/sms_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Searchworks::Document::Sms" do
   end
 
   context 'eds document' do
-    it 'should use the eds title' do
+    it 'uses the eds title' do
       expect(eds_doc.to_sms_text).to eq 'holla back'
     end
   end

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe FeedbackMailer do
     let(:params) { { url: 'http://www.example.com/view/1234' } }
     let(:mail) { FeedbackMailer.submit_wrong_book_cover(params, ip) }
 
-    it 'should include the ip address' do
+    it 'includes the ip address' do
       expect(mail.body).to have_content '123.45.67.890'
     end
 
-    it 'should include the referrer url' do
+    it 'includes the referrer url' do
       expect(mail.body).to have_content 'http://www.example.com/view/1234'
     end
   end

--- a/spec/mailers/search_works_record_mailer_spec.rb
+++ b/spec/mailers/search_works_record_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SearchWorksRecordMailer do
       end
       let(:mail) { SearchWorksRecordMailer.article_email_record(documents, params, url_params) }
 
-      it 'should send an HTML email' do
+      it 'sends an HTML email' do
         expect(mail.content_type).to match "text/html; charset=UTF-8"
       end
 
@@ -57,7 +57,7 @@ RSpec.describe SearchWorksRecordMailer do
         expect(mail.body).to include 'Email from: Jane Stanford'
       end
 
-      it 'should include the provided message' do
+      it 'includes the provided message' do
         expect(mail.body).to include "The message"
       end
 
@@ -77,7 +77,7 @@ RSpec.describe SearchWorksRecordMailer do
     context 'catalog' do
       let(:mail) { SearchWorksRecordMailer.email_record(documents, params, url_params) }
 
-      it 'should send an HTML email' do
+      it 'sends an HTML email' do
         expect(mail.content_type).to match "text/html; charset=UTF-8"
       end
 
@@ -95,16 +95,16 @@ RSpec.describe SearchWorksRecordMailer do
         expect(mail.body).to include 'Email from: Jane Stanford'
       end
 
-      it 'should include the provided message' do
+      it 'includes the provided message' do
         expect(mail.body).to include "The message"
       end
 
-      it 'should include the titles of all documents' do
+      it 'includes the titles of all documents' do
         expect(mail.body).to include "Title1"
         expect(mail.body).to include "Title2"
       end
 
-      it 'should include the callnumbers' do
+      it 'includes the callnumbers' do
         expect(mail.body).to include "Green Library - Stacks"
         expect(mail.body).to include "ABC 123"
 
@@ -112,13 +112,13 @@ RSpec.describe SearchWorksRecordMailer do
         expect(mail.body).to include "ABC 321"
       end
 
-      it 'should include the URLs' do
+      it 'includes the URLs' do
         expect(mail.body).to include "Online:"
         expect(mail.body).to include "https://library.stanford.edu"
         expect(mail.body).to include "https://stacks.stanford.edu"
       end
 
-      it 'should include the URL to all the documents' do
+      it 'includes the URL to all the documents' do
         expect(mail.body).to have_link("Title1", href: "http://example.com/view/123")
         expect(mail.body).to have_link("Title2", href: "http://example.com/view/321")
       end
@@ -129,11 +129,11 @@ RSpec.describe SearchWorksRecordMailer do
     context 'catalog' do
       let(:mail) { SearchWorksRecordMailer.full_email_record(documents, params, url_params) }
 
-      it 'should send a html email' do
+      it 'sends a html email' do
         expect(mail.content_type).to match(/text\/html/)
       end
 
-      it 'should include full HTML markup' do
+      it 'includes full HTML markup' do
         expect(mail.body).to have_css('html')
         expect(mail.body).to have_css('body')
       end
@@ -143,27 +143,27 @@ RSpec.describe SearchWorksRecordMailer do
         expect(mail.body).to have_css('dd', text: 'Jane Stanford')
       end
 
-      it 'should include the titles of all documents as links' do
+      it 'includes the titles of all documents as links' do
         expect(mail.body).to have_css('h1 a', text: 'Title1')
         expect(mail.body).to have_css('h1 a', text: 'Title2')
       end
 
-      it 'should include Subjects and Bibliographic information from both MARC and MODS records' do
+      it 'includes Subjects and Bibliographic information from both MARC and MODS records' do
         expect(mail.body).to have_css('h3', text: 'Subjects', count: 2)
         expect(mail.body).to have_css('h3', text: 'Bibliographic information', count: 2)
       end
 
-      it 'should include the HTML markup for MARC records' do
+      it 'includes the HTML markup for MARC records' do
         expect(mail.body).to have_css('dt', text: 'Related Work')
         expect(mail.body).to have_css('dd', text: 'A quartely publication.')
       end
 
-      it 'should include the HTML markup for MODS records' do
+      it 'includes the HTML markup for MODS records' do
         expect(mail.body).to have_css('dt', text: 'Producer')
         expect(mail.body).to have_css('dd', text: 'B. Smith')
       end
 
-      it 'should include holdings of all documents' do
+      it 'includes holdings of all documents' do
         expect(mail.body).to have_css('h2', text: 'At the library', count: documents.length)
         expect(mail.body).to have_css('dt', text: 'Green Library - Stacks')
 
@@ -173,12 +173,12 @@ RSpec.describe SearchWorksRecordMailer do
         expect(mail.body).to have_css('dd', text: 'ABC 321')
       end
 
-      it 'should include links of all the documents' do
+      it 'includes links of all the documents' do
         expect(mail.body).to have_css('h2', text: 'Online')
         expect(mail.body).to have_css('a', text: 'Find full text', count: documents.length)
       end
 
-      it 'should separate records w/ a horizontal rule' do
+      it 'separates records w/ a horizontal rule' do
         expect(mail.body).to have_css('hr', count: documents.length)
       end
 

--- a/spec/models/concerns/cjk_query_spec.rb
+++ b/spec/models/concerns/cjk_query_spec.rb
@@ -42,25 +42,25 @@ RSpec.describe CJKQuery do
                      _query_:\"{!edismax qf=$qf_pub_info pf=$pf_pub_info pf3=$pf3_pub_info pf2=$pf2_pub_info}#{q_str}\" AND
                      _query_:\"{!edismax qf=$qf_number pf=$pf_number pf3=$pf3_number pf2=$pf2_number}#{q_str}\""}
 
-      it "should handle the non-fielded pf/qf" do
+      it "handles the non-fielded pf/qf" do
         expect(solr_params[:q]).to include "{!edismax qf=$qf_cjk pf=$pf_cjk pf3=$pf3_cjk pf2=$pf2_cjk #{local_params} }#{q_str}"
       end
-      it "should handle title pf/qf" do
+      it "handles title pf/qf" do
         expect(solr_params[:q]).to include "{!edismax  qf=$qf_title_cjk pf=$pf_title_cjk pf3=$pf3_title_cjk pf2=$pf2_title_cjk #{local_params} }#{q_str}"
       end
-      it "should handle author pf/qf" do
+      it "handles author pf/qf" do
         expect(solr_params[:q]).to include "{!edismax  qf=$qf_author_cjk pf=$pf_author_cjk pf3=$pf3_author_cjk pf2=$pf2_author_cjk #{local_params} }#{q_str}"
       end
-      it "should handle subject pf/qf" do
+      it "handles subject pf/qf" do
         expect(solr_params[:q]).to include "{!edismax  qf=$qf_subject_cjk pf=$pf_subject_cjk pf3=$pf3_subject_cjk pf2=$pf2_subject_cjk #{local_params} }#{q_str}"
       end
-      it "should handle series pf/qf" do
+      it "handles series pf/qf" do
         expect(solr_params[:q]).to include "{!edismax  qf=$qf_series_cjk pf=$pf_series_cjk pf3=$pf3_series_cjk pf2=$pf2_series_cjk #{local_params} }#{q_str}"
       end
-      it "should handle pub_info pf/qf" do
+      it "handles pub_info pf/qf" do
         expect(solr_params[:q]).to include "{!edismax  qf=$qf_pub_info_cjk pf=$pf_pub_info_cjk pf3=$pf3_pub_info_cjk pf2=$pf2_pub_info_cjk #{local_params} }#{q_str}"
       end
-      it "should not do anything w/ the number qf/pf" do
+      it "does not do anything w/ the number qf/pf" do
         expect(solr_params[:q]).to include "{!edismax qf=$qf_number pf=$pf_number pf3=$pf3_number pf2=$pf2_number}#{q_str}"
       end
 
@@ -76,7 +76,7 @@ RSpec.describe CJKQuery do
     describe "pre-processed" do
       let(:solr_q) { "_query_:\"{!edismax  qf=$qf_title_cjk pf=$pf_title_cjk pf3=$pf3_title_cjk pf2=$pf2_title_cjk #{local_params} }#{q_str}\"" }
 
-      it "should not try to append _cjk onto already processed solr params logic" do
+      it "does not try to append _cjk onto already processed solr params logic" do
         expect(solr_params[:q]).to include "{!edismax  qf=$qf_title_cjk pf=$pf_title_cjk pf3=$pf3_title_cjk pf2=$pf2_title_cjk #{local_params} }#{q_str}"
         expect(solr_params[:q]).not_to include "_cjk_cjk"
       end
@@ -84,7 +84,7 @@ RSpec.describe CJKQuery do
   end
 
   describe "cjk_query_addl_params" do
-    it "should leave unrelated solr params alone" do
+    it "leaves unrelated solr params alone" do
       blacklight_params.merge!(q: '舊小說', search_field: 'search_title')
       my_solr_params = { 'key1' => 'val1', 'key2' => 'val2' }
       solr_params = my_solr_params
@@ -106,42 +106,42 @@ RSpec.describe CJKQuery do
         expect(solr_params).not_to have_key("mm")
         expect(solr_params).not_to have_key("qs")
       end
-      it "should detect Han - Traditional and add mm and qs to Solr params" do
+      it "detects Han - Traditional and add mm and qs to Solr params" do
         blacklight_params[:q] = '舊小說'
         solr_params = {}
         search_builder.modify_params_for_cjk(solr_params)
         expect(solr_params['mm']).to eq cjk_mm
         expect(solr_params['qs']).to eq 0
       end
-      it "should detect Han - Simplified and add mm and qs to Solr params" do
+      it "detects Han - Simplified and add mm and qs to Solr params" do
         blacklight_params[:q] = '旧小说'
         solr_params = {}
         search_builder.modify_params_for_cjk(solr_params)
         expect(solr_params['mm']).to eq cjk_mm
         expect(solr_params['qs']).to eq 0
       end
-      it "should detect Hiragana and add mm and qs to Solr params" do
+      it "detects Hiragana and add mm and qs to Solr params" do
         blacklight_params[:q] = 'まんが'
         solr_params = {}
         search_builder.modify_params_for_cjk(solr_params)
         expect(solr_params['mm']).to eq cjk_mm
         expect(solr_params['qs']).to eq 0
       end
-      it "should detect Katakana and add mm and qs to Solr params" do
+      it "detects Katakana and add mm and qs to Solr params" do
         blacklight_params[:q] = 'マンガ'
         solr_params = {}
         search_builder.modify_params_for_cjk(solr_params)
         expect(solr_params['mm']).to eq cjk_mm
         expect(solr_params['qs']).to eq 0
       end
-      it "should detect Hangul and add mm and qs to Solr params" do
+      it "detects Hangul and add mm and qs to Solr params" do
         blacklight_params[:q] = '한국경제'
         solr_params = {}
         search_builder.modify_params_for_cjk(solr_params)
         expect(solr_params['mm']).to eq cjk_mm
         expect(solr_params['qs']).to eq 0
       end
-      it "should detect CJK mixed with other alphabets and add mm and qs to Solr params" do
+      it "detects CJK mixed with other alphabets and add mm and qs to Solr params" do
         blacklight_params[:q] = 'abcけいちゅうabc'
         solr_params = {}
         search_builder.modify_params_for_cjk(solr_params)
@@ -165,7 +165,7 @@ RSpec.describe CJKQuery do
         )
       end
 
-      it 'should exhibit the same behavior without a search_field' do
+      it 'exhibits the same behavior without a search_field' do
         blacklight_params[:q] = q_str
         solr_params = { q: q_str }
         search_builder.modify_params_for_cjk(solr_params)
@@ -178,7 +178,7 @@ RSpec.describe CJKQuery do
         )
       end
 
-      it 'should add cjk local params to q if it is a CJK unigram' do
+      it 'adds cjk local params to q if it is a CJK unigram' do
         q_uni = '飘'
         blacklight_params.merge!(q: q_uni, search_field: 'search')
         solr_params = { q: q_uni }
@@ -267,7 +267,7 @@ RSpec.describe CJKQuery do
       end
     end
 
-    it 'should add mm, qs and CJK local params to q if CJK detected' do
+    it 'adds mm, qs and CJK local params to q if CJK detected' do
       blacklight_params.merge!(q: q_str, search_field: 'search')
       solr_params = { q: q_str }
       search_builder.modify_params_for_cjk(solr_params)
@@ -280,50 +280,50 @@ RSpec.describe CJKQuery do
   end
 
   describe "#cjk_unigrams_size" do
-    it "should detect hangul" do
+    it "detects hangul" do
       expect(search_builder.send(:cjk_unigrams_size, '한국주택은행')).to eq 6
     end
-    it "should detect Han - Traditional" do
+    it "detects Han - Traditional" do
       expect(search_builder.send(:cjk_unigrams_size, '舊小說')).to eq 3
     end
-    it "should detect Han - Simplified" do
+    it "detects Han - Simplified" do
       expect(search_builder.send(:cjk_unigrams_size, '旧小说')).to eq 3
     end
-    it "should detect Modern Kanji" do
+    it "detects Modern Kanji" do
       expect(search_builder.send(:cjk_unigrams_size, '漫画')).to eq 2
     end
-    it "should detect Traditional Kanji" do
+    it "detects Traditional Kanji" do
       expect(search_builder.send(:cjk_unigrams_size, '漫畫')).to eq 2
     end
-    it "should detect Hiragana" do
+    it "detects Hiragana" do
       expect(search_builder.send(:cjk_unigrams_size, "まんが")).to eq 3
     end
-    it "should detect Katakana" do
+    it "detects Katakana" do
       expect(search_builder.send(:cjk_unigrams_size, "マンガ")).to eq 3
     end
-    it "should detect Hancha traditional" do
+    it "detects Hancha traditional" do
       expect(search_builder.send(:cjk_unigrams_size, "廣州")).to eq 2
     end
-    it "should detect Hancha simplified" do
+    it "detects Hancha simplified" do
       expect(search_builder.send(:cjk_unigrams_size, "光州")).to eq 2
     end
-    it "should detect Hangul" do
+    it "detects Hangul" do
       expect(search_builder.send(:cjk_unigrams_size, "한국경제")).to eq 4
     end
-    it "should detect mixed scripts" do
+    it "detects mixed scripts" do
       expect(search_builder.send(:cjk_unigrams_size, "近世仮名遣い")).to eq 6
     end
-    it "should detect first character CJK" do
+    it "detects first character CJK" do
       expect(search_builder.send(:cjk_unigrams_size, "舊小說abc")).to eq 3
       expect(search_builder.send(:cjk_unigrams_size, "旧小说 abc")).to eq 3
       expect(search_builder.send(:cjk_unigrams_size, " 漫画 abc")).to eq 2
     end
-    it "should detect last character CJK" do
+    it "detects last character CJK" do
       expect(search_builder.send(:cjk_unigrams_size, "abc漫畫")).to eq 2
       expect(search_builder.send(:cjk_unigrams_size, "abc まんが")).to eq 3
       expect(search_builder.send(:cjk_unigrams_size, "abc マンガ ")).to eq 3
     end
-    it "should detect (latin)(CJK)(latin)" do
+    it "detects (latin)(CJK)(latin)" do
       expect(search_builder.send(:cjk_unigrams_size, "abc廣州abc")).to eq 2
       expect(search_builder.send(:cjk_unigrams_size, "abc 한국경제abc")).to eq 4
       expect(search_builder.send(:cjk_unigrams_size, "abc近世仮名遣い abc")).to eq 6

--- a/spec/models/concerns/collection_member_spec.rb
+++ b/spec/models/concerns/collection_member_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe CollectionMember do
   let(:merged_sirsi) { SolrDocument.new(collection: ['sirsi', '12345']) }
 
   describe "#is_a_collection_member?" do
-    it "should return true for collection members" do
+    it "returns true for collection members" do
       expect(member.is_a_collection_member?).to be_truthy
     end
-    it "should return false for non collection members" do
+    it "returns false for non collection members" do
       expect(non_member.is_a_collection_member?).to be_falsey
     end
-    it "should return false for sirsi records" do
+    it "returns false for sirsi records" do
       expect(sirsi.is_a_collection_member?).to be_falsey
     end
-    it "should return true for sirsi records that identify as being in another collection" do
+    it "returns true for sirsi records that identify as being in another collection" do
       expect(merged_sirsi.is_a_collection_member?).to be_truthy
     end
   end
@@ -38,11 +38,11 @@ RSpec.describe CollectionMember do
       allow(Blacklight.default_index).to receive(:connection).and_return(stub_solr)
     end
 
-    it "should search solr for ids in the collection" do
+    it "searches solr for ids in the collection" do
       expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
       expect(member.parent_collections).to be_present
     end
-    it "should return a solr document" do
+    it "returns a solr document" do
       expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
       member.parent_collections.each do |parent|
         expect(parent).to be_a SolrDocument
@@ -51,10 +51,10 @@ RSpec.describe CollectionMember do
     it "#parent_collection_params should return all IDs joined w/ OR" do
       expect(multi_collection.send(:parent_collection_params)).to eq "id:12345 OR id:54321"
     end
-    it 'should strip leading "a" from collection ids' do
+    it 'strips leading "a" from collection ids' do
       expect(catkey_prefix.send(:parent_collection_params)).to eq "id:12345"
     end
-    it "should return nil for non collection members" do
+    it "returns nil for non collection members" do
       expect(non_member.parent_collections).to be_nil
     end
   end
@@ -71,7 +71,7 @@ RSpec.describe CollectionMember do
     }
     let(:document_without_parent) { SolrDocument.new() }
 
-    it "should return the parent collections from the index" do
+    it "returns the parent collections from the index" do
       collections = document_with_parent.index_parent_collections
       expect(collections.length).to eq 2
       expect(collections.first).to be_a SolrDocument
@@ -82,7 +82,7 @@ RSpec.describe CollectionMember do
       expect(collections.last[:id]).to eq '54321'
       expect(collections.last[:title_display]).to eq 'Collection2 Title'
     end
-    it "should return nil if the document is not a collection member" do
+    it "returns nil if the document is not a collection member" do
       expect(document_without_parent.index_parent_collections).to be_nil
     end
   end

--- a/spec/models/concerns/eds_document_spec.rb
+++ b/spec/models/concerns/eds_document_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EdsDocument do
   end
 
   describe '#html_fulltext_available' do
-    it 'should return true when fulltext is present' do
+    it 'returns true when fulltext is present' do
       expect(document.html_fulltext?).to be true
     end
 

--- a/spec/models/concerns/extent_spec.rb
+++ b/spec/models/concerns/extent_spec.rb
@@ -44,43 +44,43 @@ RSpec.describe Extent do
       )
     }
 
-    it "should not be present if the appropriate metadata is not available" do
+    it "is not present if the appropriate metadata is not available" do
       expect(no_extent.extent).not_to be_present
       expect(no_extent.extent_sans_format).not_to be_present
     end
-    it "should include a single extent statement" do
+    it "includes a single extent statement" do
       expect(single_extent.extent).to eq 'an extent statement'
       expect(single_extent.extent_sans_format).to eq 'an extent statement'
     end
-    it "should join multiple extent statements" do
+    it "joins multiple extent statements" do
       expect(multi_extent.extent).to eq 'Extent1, Extent2'
       expect(multi_extent.extent_sans_format).to eq 'Extent1, Extent2'
     end
-    it "should join physical and characteristics statements" do
+    it "joins physical and characteristics statements" do
       expect(marc_extent.extent).to eq 'Extent Sound: digital; optical; surround; stereo; Dolby. Video: NTSC. Digital: video file; DVD video; Region 1.'
       expect(marc_extent.extent_sans_format).to eq 'Extent Sound: digital; optical; surround; stereo; Dolby. Video: NTSC. Digital: video file; DVD video; Region 1.'
     end
 
     describe 'including format' do
-      it 'should upcase the given format' do
+      it 'upcases the given format' do
         expect(single_format.extent).to start_with 'Book'
       end
 
-      it "should select the non-database format (even if it's the first one)" do
+      it "selects the non-database format (even if it's the first one)" do
         expect(multi_format.extent).to start_with 'Book'
       end
 
-      it 'should select the first format when multiple non-Database formats are present' do
+      it 'selects the first format when multiple non-Database formats are present' do
         expect(bad_format.extent).to start_with 'Book'
       end
     end
 
     describe 'not including format' do
-      it 'should not append the format' do
+      it 'does not append the format' do
         expect(single_extent.extent_sans_format).to start_with 'an extent statement'
       end
 
-      it 'should use both fields in marc_extent' do
+      it 'uses both fields in marc_extent' do
         expect(marc_extent.extent_sans_format).to start_with 'Extent'
       end
     end

--- a/spec/models/concerns/index_authors_spec.rb
+++ b/spec/models/concerns/index_authors_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe IndexAuthors do
     vern_author_meeting_display: ["Vern Author Meeting"]
   ) }
 
-  it "should not return anything for a document without authors" do
+  it "does not return anything for a document without authors" do
     expect(no_authors_document.authors_from_index).not_to be_present
   end
-  it "should return authors for all supplied types" do
+  it "returns authors for all supplied types" do
     expect(document.authors_from_index.length).to eq 6
   end
-  it "should not have duplicate authors" do
+  it "does not have duplicate authors" do
     meeting_text = "Author Meeting"
     author_meeting_display = document[:author_meeting_display]
     meetings = document.authors_from_index.select do |author|

--- a/spec/models/concerns/index_links_spec.rb
+++ b/spec/models/concerns/index_links_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe IndexLinks do
   end
 
   describe 'mixin' do
-    it 'should add the #index_links method' do
+    it 'adds the #index_links method' do
       expect(document).to respond_to(:index_links)
     end
     it '#index_links should return Links' do

--- a/spec/models/concerns/marc_instrumentation_spec.rb
+++ b/spec/models/concerns/marc_instrumentation_spec.rb
@@ -4,17 +4,17 @@ require 'rails_helper'
 
 RSpec.describe 'MarcInstrumentation' do
   include MarcMetadataFixtures
-  it 'should return nil for non marc object' do
+  it 'returns nil for non marc object' do
     document = SolrDocument.new
     expect(document.marc_instrumentation).to be_nil
   end
 
-  it 'should return empty marc_record for marc doc without 382 field' do
+  it 'returns empty marc_record for marc doc without 382 field' do
     document = SolrDocument.new(marc_json_struct: metadata1)
     expect(document.marc_instrumentation.values.length).to eq 0
   end
 
-  it 'should return Instrumentation for document with 382 field' do
+  it 'returns Instrumentation for document with 382 field' do
     document = SolrDocument.new(marc_json_struct: marc_382_instrumentation)
     expect(document.marc_instrumentation.class).to eq Instrumentation
   end

--- a/spec/models/concerns/marc_links_spec.rb
+++ b/spec/models/concerns/marc_links_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MarcLinks do
-  it "should return an empty array for non marc records" do
+  it "returns an empty array for non marc records" do
     expect(SolrDocument.new.marc_links.all).to eq []
   end
 

--- a/spec/models/concerns/mods_data_spec.rb
+++ b/spec/models/concerns/mods_data_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe ModsData do
   let(:document) { SolrDocument.new(modsxml: mods_everything) }
 
   describe "#mods" do
-    it "should be nil if no modsxml" do
+    it "is nil if no modsxml" do
       expect(SolrDocument.new().mods).to be_nil
     end
 
-    it "should be a ModsDisplay" do
+    it "is a ModsDisplay" do
       expect(document.mods).to be_a ModsDisplay::HTML
     end
   end
 
   describe "#prettified_mods" do
-    it "should be nil if no modsxml" do
+    it "is nil if no modsxml" do
       expect(SolrDocument.new().prettified_mods).to be_nil
     end
 
-    it "should return prettified mods" do
+    it "returns prettified mods" do
       expect(document.prettified_mods).to be_a String
       expect(document.prettified_mods).to match /<div class="CodeRay">/
       expect(document.prettified_mods).to match />A record with everything</

--- a/spec/models/concerns/selected_database_spec.rb
+++ b/spec/models/concerns/selected_database_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SelectedDatabase do
   describe "SelectedDatabase" do
     let(:selected_database) { SolrDocument.new(id: "6494821") }
 
-    it "should match configured databases with the matching documents" do
+    it "matches configured databases with the matching documents" do
       expect(selected_database.selected_database_description).to start_with 'Bibliographic database on art and related disciplines'
       expect(selected_database.selected_database_subjects).to eq ["Art"]
       expect(selected_database.selected_database_see_also.id).to eq "6666306"

--- a/spec/models/concerns/solr_bookplates_spec.rb
+++ b/spec/models/concerns/solr_bookplates_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SolrBookplates do
   let(:subject) { SolrDocument.new(bookplates_display: ['ABC -|- 123']) }
 
-  it 'should provide a bookplates method that returns an array of Bookplate objects' do
+  it 'provides a bookplates method that returns an array of Bookplate objects' do
     expect(subject).to respond_to(:bookplates)
     expect(subject.bookplates).to be_a Array
     expect(subject.bookplates).to be_present

--- a/spec/models/concerns/solr_holdings_spec.rb
+++ b/spec/models/concerns/solr_holdings_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SolrHoldings do
   let(:document) { SolrDocument.new }
 
-  it "should provide a holdings method" do
+  it "provides a holdings method" do
     expect(document).to respond_to(:holdings)
     expect(document.holdings).to be_a Holdings
   end
@@ -38,13 +38,13 @@ RSpec.describe SolrHoldings do
       )
     }
 
-    it 'should return the item based on preferred barcode' do
+    it 'returns the item based on preferred barcode' do
       expect(preferred.preferred_item.barcode).to eq '12345'
     end
-    it 'should return the first item when the preferred barcode does not exist in the holdings' do
+    it 'returns the first item when the preferred barcode does not exist in the holdings' do
       expect(bad_preferred.preferred_item.barcode).to eq '54321'
     end
-    it 'should return the first item if there is no preferred barcode available' do
+    it 'returns the first item if there is no preferred barcode available' do
       expect(no_preferred.preferred_item.barcode).to eq '54321'
     end
   end

--- a/spec/models/hoover_open_url_request_spec.rb
+++ b/spec/models/hoover_open_url_request_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe HooverOpenUrlRequest do
     describe '#item_publisher' do
       let(:marc_json_struct) { hoover_request_fixture }
 
-      it 'it returns subfields $a, $b, $c 260/264' do
+      it 'returns subfields $a, $b, $c 260/264' do
         expect(url.item_publisher).to eq '260 Subfield $a 260 Subfield $b 260 Subfield $c 264 Subfield $c'
       end
     end

--- a/spec/models/links/link_spec.rb
+++ b/spec/models/links/link_spec.rb
@@ -23,27 +23,27 @@ RSpec.describe 'Link' do
     expect(link.text).to be_html_safe
   end
 
-  it 'should parse the href option' do
+  it 'parses the href option' do
     expect(link.href).to eq 'http://link.edu'
   end
 
-  it 'should parse the fulltext option' do
+  it 'parses the fulltext option' do
     expect(link).to be_fulltext
   end
 
-  it 'should parse the stanford only option' do
+  it 'parses the stanford only option' do
     expect(link).to be_stanford_only
   end
 
-  it 'should parse the finding_aid option' do
+  it 'parses the finding_aid option' do
     expect(link).to be_finding_aid
   end
 
-  it 'should parse the sfx option' do
+  it 'parses the sfx option' do
     expect(link).to be_sfx
   end
 
-  it 'should parse the managed_purl option' do
+  it 'parses the managed_purl option' do
     expect(link).to be_managed_purl
   end
 end

--- a/spec/models/links_spec.rb
+++ b/spec/models/links_spec.rb
@@ -15,23 +15,23 @@ RSpec.describe Links do
     ]
   end
 
-  it 'should identify fulltext links' do
+  it 'identifies fulltext links' do
     expect(links.fulltext.length).to eq 1
     expect(links.fulltext.first.html).to eq 'fulltext link'
   end
 
-  it 'should identify supplemental links' do
+  it 'identifies supplemental links' do
     expect(links.supplemental.length).to eq 1
     expect(links.supplemental.first.html).to eq 'non-fulltext link'
   end
 
-  it 'should identify finding aid links' do
+  it 'identifies finding aid links' do
     expect(links.finding_aid.length).to eq 2
     expect(links.finding_aid.first.html).to eq '1st finding aid link'
     expect(links.finding_aid.last.html).to eq '2nd finding aid link'
   end
 
-  it 'should identify the managed_purl links' do
+  it 'identifies the managed_purl links' do
     expect(links.managed_purls.length).to eq 1
     expect(links.managed_purls.first.html).to eq 'Managed purl link'
   end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe SearchBuilder do
       allow(search_builder).to receive(:page_location).and_return(instance_double(PageLocation, databases?: true))
     end
 
-    it "should handle 0-9 filters properly" do
+    it "handles 0-9 filters properly" do
       search_builder.with(prefix: '0-9').database_prefix_search(solr_params)
       expect(solr_params[:fq]).to include("title_sort:/[0-9].*/")
     end
-    it "should handle alpha filters properly" do
+    it "handles alpha filters properly" do
       search_builder.with(prefix: 'b').database_prefix_search(solr_params)
       expect(solr_params[:fq]).to include("title_sort:/[b].*/")
     end
-    it "should do nothing if prefix param is invalid" do
+    it "does nothing if prefix param is invalid" do
       search_builder.with(prefix: '*').database_prefix_search(solr_params)
       expect(solr_params[:fq]).to be_nil
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -7,57 +7,57 @@ RSpec.describe SolrDocument do
   describe "marc field" do
     let(:marcjson) { SolrDocument.new(marc_json_struct: metadata1) }
 
-    it "should respond to #to_marc for marcjson" do
+    it "responds to #to_marc for marcjson" do
       expect(marcjson).to respond_to(:to_marc)
       expect(marcjson.to_marc).to be_a MARC::Record
     end
   end
 
   describe "MarcLinks" do
-    it "should include marc links" do
+    it "includes marc links" do
       expect(subject).to be_a MarcLinks
     end
   end
 
   describe "DatabaseDocument" do
-    it "should include database document" do
+    it "includes database document" do
       expect(subject).to be_a DatabaseDocument
     end
   end
 
   describe "DisplayType" do
-    it "should include display type" do
+    it "includes display type" do
       expect(subject).to be_a DisplayType
       expect(subject).to respond_to(:display_type)
     end
   end
 
   describe "DigitalCollection" do
-    it "should include digital collection" do
+    it "includes digital collection" do
       expect(subject).to be_a DigitalCollection
     end
   end
 
   describe "CollectionMember" do
-    it "should include collection member" do
+    it "includes collection member" do
       expect(subject).to be_a CollectionMember
     end
   end
 
   describe "Extent" do
-    it "should include the extent" do
+    it "includes the extent" do
       expect(subject).to be_a Extent
     end
   end
 
   describe "IndexAuthors" do
-    it "should include index authors" do
+    it "includes index authors" do
       expect(subject).to be_a IndexAuthors
     end
   end
 
   describe "Druid" do
-    it "should include druid" do
+    it "includes druid" do
       expect(subject).to be_a Druid
     end
   end
@@ -75,13 +75,13 @@ RSpec.describe SolrDocument do
   end
 
   describe "SolrHoldings" do
-    it "should include SolrHoldings" do
+    it "includes SolrHoldings" do
       expect(subject).to be_a SolrHoldings
     end
   end
 
   describe 'SolrSet' do
-    it 'should be included' do
+    it 'is included' do
       expect(subject).to be_a SolrSet
     end
   end

--- a/spec/presenters/facet_options_presenter_spec.rb
+++ b/spec/presenters/facet_options_presenter_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe FacetOptionsPresenter do
       context 'when the limiter is selected' do
         let!(:params) { { f: { 'eds_search_limiters_facet' => %w[SelectedValue1 SelectedValue2] } } }
 
-        it 'it removes the limiter from the URL (and retains other values)' do
+        it 'removes the limiter from the URL (and retains other values)' do
           expect(limiter.search_url).not_to include('SelectedValue1')
           expect(limiter.search_url).to include('SelectedValue2')
         end

--- a/spec/routing/article_routes_spec.rb
+++ b/spec/routing/article_routes_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Article Routing' do
     context 'rejects unknown identifiers' do
       let(:id) { 'eds__1 2/3' }
 
-      it 'should not route to show page' do
+      it 'does not route to show page' do
         expect(result).not_to be_routable
       end
     end

--- a/spec/tasks/fixtures_indexer_spec.rb
+++ b/spec/tasks/fixtures_indexer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FixturesIndexer do
   end
 
   describe "run" do
-    it "should index the fixtures and commit them" do
+    it "indexes the fixtures and commit them" do
       expect(stub_solr).to receive(:add).twice.and_return(true)
       expect(stub_solr).to receive(:commit).twice.and_return(true)
       FixturesIndexer.run
@@ -20,7 +20,7 @@ RSpec.describe FixturesIndexer do
   end
 
   describe "#new" do
-    it "should set the solr client" do
+    it "sets the solr client" do
       expect(FixturesIndexer.new.instance_variable_get(:@solr)).to eq stub_solr
     end
   end
@@ -38,10 +38,10 @@ RSpec.describe FixturesIndexer do
   end
 
   describe "#file_list" do
-    it "should be an array" do
+    it "is an array" do
       expect(subject.file_list).to be_an Array
     end
-    it "should be an array of fixture file references" do
+    it "is an array of fixture file references" do
       subject.file_list.each do |file|
         expect(file).to match /\/fixtures\/solr_documents\/.*.yml$/
       end

--- a/spec/views/browse/index.html.erb_spec.rb
+++ b/spec/views/browse/index.html.erb_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe "browse/index" do
     expect(view).to receive(:document_presenter).with(original_doc).and_return(presenter)
   end
 
-  it "should link to the document" do
+  it "links to the document" do
     render
     expect(rendered).to have_css('a', text: 'Title')
   end
   describe "without barcode" do
-    it "should select the first callnumber in the heading when no barcode is present" do
+    it "selects the first callnumber in the heading when no barcode is present" do
       render
       expect(rendered).to have_css('h1', text: "Browse related items")
       expect(rendered).to have_css('p', text: /Starting at call number:.*callnumber123/m)
@@ -52,7 +52,7 @@ RSpec.describe "browse/index" do
       allow(view).to receive(:params).and_return(start: '123', barcode: '321')
     end
 
-    it "should use the callnumber based on the provided barcode in the heading" do
+    it "uses the callnumber based on the provided barcode in the heading" do
       render
       expect(rendered).to have_css('h1', text: "Browse related items")
       expect(rendered).to have_css('p', text: /Starting at call number:.*callnumber321/m)

--- a/spec/views/catalog/_accordion_section_library.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_library.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "catalog/_accordion_section_library" do
       render
     end
 
-    it "should include the library accordion and text" do
+    it "includes the library accordion and text" do
       expect(rendered).to have_css('.accordion-section.location')
       expect(rendered).to have_css('.accordion-section.location button.header[aria-expanded="false"]', text: "Check availability")
       expect(rendered).to have_css('.accordion-section.location span.snippet', text: "Green Library")

--- a/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
+++ b/spec/views/catalog/_accordion_section_online.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "catalog/_index_online_section" do
         render
       end
 
-      it 'should include the online dl' do
+      it 'includes the online dl' do
         expect(rendered).to have_css('dt', text: 'Online')
         expect(rendered).to have_css('dd li', count: 4)
         expect(rendered).to have_css('dd li', count: 5, visible: false) # 4 links and a Google Books link

--- a/spec/views/catalog/librarian_view.html.erb_spec.rb
+++ b/spec/views/catalog/librarian_view.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "catalog/librarian_view" do
       render
     end
 
-    it "should render the mods_view" do
+    it "renders the mods_view" do
       expect(rendered).to have_content('August  2, 2022  4:01pm')
       expect(rendered).to have_css('.mods-view')
     end
@@ -46,7 +46,7 @@ RSpec.describe "catalog/librarian_view" do
       render
     end
 
-    it "should indicate there is no librarian view" do
+    it "indicates there is no librarian view" do
       expect(rendered).to have_content('No librarian view available')
     end
   end

--- a/spec/views/catalog/record/_callnumber_browse.html.erb_spec.rb
+++ b/spec/views/catalog/record/_callnumber_browse.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "catalog/record/_callnumber_browse" do
     render 'catalog/record/callnumber_browse', document:
   end
 
-  it "should render a panel" do
+  it "renders a panel" do
     expect(rendered).to have_css('div.record-browse-nearby')
     expect(rendered).to have_css(".section#browse-nearby")
   end
@@ -32,10 +32,10 @@ RSpec.describe "catalog/record/_callnumber_browse" do
     expect(rendered).to have_link('Continue to full page', href: '/browse?start=full_shelfkey&view=gallery')
     # Somehow we need to send in a fixture that will invoke the right ckey
   end
-  it "should render a heading" do
+  it "renders a heading" do
     expect(rendered).to have_css('h2', text: /Browse related items/)
   end
-  it "should include links to all unique callnumbers" do
+  it "includes links to all unique callnumbers" do
     expect(rendered).to have_css('.callnumber button', text: "callnumber")
     expect(rendered).to have_css('.callnumber button', text: "callnumber2")
   end

--- a/spec/views/catalog/record/_marc_bibliographic.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_bibliographic.html.erb_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe "catalog/record/_marc_bibliographic" do
       assign(:document, document)
     end
 
-    it "should display for databases" do
+    it "displays for databases" do
       allow(document).to receive(:is_a_database?).and_return(true)
       render
       expect(rendered).to have_css("dt", text: "Note")
       expect(rendered).to have_css("dd", text: "A local note added to subjects only")
     end
-    it "should not display for non-databases" do
+    it "does not display for non-databases" do
       allow(document).to receive(:is_a_database?).and_return(false)
       render
       expect(rendered).to have_no_css("dt", text: "Note")
@@ -32,7 +32,7 @@ RSpec.describe "catalog/record/_marc_bibliographic" do
       render
     end
 
-    it "should include dates from solr" do
+    it "includes dates from solr" do
       expect(rendered).to have_css('dt', text: 'Publication date')
       expect(rendered).to have_css('dd', text: '1234')
 
@@ -50,7 +50,7 @@ RSpec.describe "catalog/record/_marc_bibliographic" do
       render
     end
 
-    it 'should include the related works section' do
+    it 'includes the related works section' do
       expect(rendered).to have_css('dt', text: 'Related Work')
       expect(rendered).to have_css('dd a', text: '700 with t 700 $e Title.')
       expect(rendered).to have_no_css('dt', text: 'Included Work')

--- a/spec/views/catalog/record/_marc_contents_summary.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_contents_summary.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "catalog/record/_marc_contents_summary" do
       assign(:document, SolrDocument.new(marc_json_struct: finding_aid_856, marc_links_struct: [{ finding_aid: true, href: '...', link_text: 'FINDING AID: Link text' }]))
     end
 
-    it "should be displayed when present" do
+    it "is displayed when present" do
       render
       expect(rendered).to have_css("dt", text: "Finding aid")
       expect(rendered).to have_css("dd", text: "FINDING AID:")
@@ -44,7 +44,7 @@ RSpec.describe "catalog/record/_marc_contents_summary" do
     end
   end
 
-  it "should be blank if the document has not fields" do
+  it "is blank if the document has not fields" do
     assign(:document, SolrDocument.new(marc_json_struct: no_fields_fixture))
     render
     expect(rendered).to be_blank
@@ -55,7 +55,7 @@ RSpec.describe "catalog/record/_marc_contents_summary" do
       render
     end
 
-    it 'should include the included works section' do
+    it 'includes the included works section' do
       expect(rendered).to have_css('dt', text: 'Included work')
       expect(rendered).to have_css('dd a', count: 2)
       expect(rendered).to have_css('dd a', text: '710 with t ind2 Title! sub n after t')

--- a/spec/views/catalog/record/_marc_contributors.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_contributors.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "catalog/record/_marc_contributors" do
       render
     end
 
-    it "should display secondary authors" do
+    it "displays secondary authors" do
       expect(rendered).to have_css("dt", text: "Contributor")
       expect(rendered).to have_css('dd', count: 3)
 

--- a/spec/views/catalog/record/_marc_metadata_sections.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_metadata_sections.html.erb_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe "catalog/record/_marc_metadata_sections" do
       render 'catalog/record/marc_metadata_sections', document:
     end
 
-    it "should display correct sections" do
+    it "displays correct sections" do
       expect(rendered).to have_css('h3', text: "Contributors")
       expect(rendered).to have_css('h3', text: "Contents/Summary")
       expect(rendered).to have_css('h3', text: "Bibliographic information")
     end
 
-    it "should have side nav content handles" do
+    it "has side nav content handles" do
       expect(rendered).to have_css(".section#contributors")
       expect(rendered).to have_css(".section#contents-summary")
       expect(rendered).to have_css(".section#bibliography-info")
     end
 
-    it "should render side nav content" do
+    it "renders side nav content" do
       expect(rendered).to have_css("ul.side-nav-minimap")
 
       expect(rendered).to have_css(".side-nav-minimap button i.fa.fa-arrow-up")

--- a/spec/views/catalog/record/_marc_subjects.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_subjects.html.erb_spec.rb
@@ -13,21 +13,21 @@ RSpec.describe "catalog/record/_marc_subjects" do
       render
     end
 
-    it "should render non-marc 655 subjects under 'Subject'" do
+    it "renders non-marc 655 subjects under 'Subject'" do
       expect(rendered).to have_css('dt', text: "Subject")
       expect(rendered).to have_css('dd a', text: "Subject A1")
     end
 
-    it "should include an aria-label attribute" do
+    it "includes an aria-label attribute" do
       expect(rendered).to have_css('dd a[aria-label="Subject A1"]')
     end
 
-    it "should render non-marc 655 subjects under 'Genre'" do
+    it "renders non-marc 655 subjects under 'Genre'" do
       expect(rendered).to have_css('dt', text: "Genre")
       expect(rendered).to have_css('dd a', text: "Subject A1")
     end
 
-    it 'should render the MARC 690 as local subjects' do
+    it 'renders the MARC 690 as local subjects' do
       expect(rendered).to have_css('dt', text: 'Local subject')
       expect(rendered).to have_css('dd', text: 'Local Subject A1')
     end
@@ -62,13 +62,13 @@ RSpec.describe "catalog/record/_marc_subjects" do
       assign(:document, document)
     end
 
-    it "should display for databases" do
+    it "displays for databases" do
       allow(document).to receive(:is_a_database?).and_return(true)
       render
       expect(rendered).to have_css("dd a", text: "DB Subject1")
       expect(rendered).to have_css("dd a", text: "DB Subject2")
     end
-    it "should not display for non-databases" do
+    it "does not display for non-databases" do
       allow(document).to receive(:is_a_database?).and_return(false)
       render
       expect(rendered).to have_no_css("dd a", text: "DB Subject1")

--- a/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
+++ b/spec/views/catalog/record/_marc_upper_metadata_items.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       assign(:document, SolrDocument.new(marc_json_struct: metadata1))
     end
 
-    it 'should display for for 245C field' do
+    it 'displays for for 245C field' do
       render
       expect(rendered).to have_css('dt', text: 'Responsibility')
       expect(rendered).to have_css('dd', text: 'Most responsible person ever')
@@ -23,7 +23,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       render
     end
 
-    it "should display the characteristics with labels" do
+    it "displays the characteristics with labels" do
       expect(rendered).to have_css('dt', text: 'Sound')
       expect(rendered).to have_css('dd', text: 'digital; optical; surround; stereo; Dolby')
       expect(rendered).to have_css('dt', text: 'Video')
@@ -52,7 +52,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       render
     end
 
-    it "should include the imprint statement" do
+    it "includes the imprint statement" do
       expect(rendered).to have_css('dt', text: "Imprint")
       expect(rendered).to have_css('dd', text: "SubA SubB SubC SubG")
     end
@@ -64,7 +64,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       render
     end
 
-    it "should include the edition statement" do
+    it "includes the edition statement" do
       expect(rendered).to have_css('dt', text: "Edition")
       expect(rendered).to have_css('dd', text: "SubA SubB")
     end
@@ -76,7 +76,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       render
     end
 
-    it "should be rendered" do
+    it "is rendered" do
       expect(rendered).to have_css('dt', text: 'Production')
       expect(rendered).to have_css('dd', text: 'SubfieldA SubfieldB')
     end
@@ -88,7 +88,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       render
     end
 
-    it "should be rendered and include specific dts/dds" do
+    it "is rendered and include specific dts/dds" do
       expect(rendered).to have_css('dt', text: 'Instrumentation')
       expect(rendered).to have_css('dd', text: 'singer (1) or bass guitar (2), percussion (1) (4 hands), guitar (1) / electronics (1), solo flute (1) (total=8)')
       expect(rendered).to have_css('dd', text: 'singer (3)')
@@ -105,7 +105,7 @@ RSpec.describe "catalog/record/_marc_upper_metadata_items" do
       render
     end
 
-    it 'should render the collection titles as links' do
+    it 'renders the collection titles as links' do
       expect(rendered).to have_css('dt', text: 'Collection')
       expect(rendered).to have_css('dd', text: 'Bruce & Rachel Jeffer Collection of WPA/Federal Writers Project and related New Deal material')
     end

--- a/spec/views/catalog/record/_mods_abstract_contents.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_abstract_contents.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "catalog/record/_mods_abstract_contents" do
       assign(:document, document)
     end
 
-    it "should display abstract" do
+    it "displays abstract" do
       render
       expect(rendered).to have_css("dd", text: "Topographical and street map of the")
       expect(rendered).to have_css("dd", text: "This is an amazing table of contents!")

--- a/spec/views/catalog/record/_mods_access.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_access.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "catalog/record/_mods_access" do
       assign(:document, document)
     end
 
-    it "should display access" do
+    it "displays access" do
       render
       expect(rendered).to have_css("dt", text: "Use and reproduction")
       expect(rendered).to have_css("dd", text: "Copyright © Stanford University.")

--- a/spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_bibliographic.html.erb_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe "catalog/record/_mods_bibliographic" do
       assign(:document, document)
     end
 
-    it "should display titles" do
+    it "displays titles" do
       render
       expect(rendered).to have_css("dt", text: "Alternative title")
       expect(rendered).to have_css("dd", text: "A record")
     end
-    it "should display audience" do
+    it "displays audience" do
       render
       expect(rendered).to have_css("dt", text: "Who?")
       expect(rendered).to have_css("dd", text: "Cat loverz")
     end
-    it "should display notes" do
+    it "displays notes" do
       render
       expect(rendered).to have_css("dt", text: "Note")
       expect(rendered).to have_css("dd", text: "Pick up milk")
@@ -35,12 +35,12 @@ RSpec.describe "catalog/record/_mods_bibliographic" do
       # expect(rendered).to have_css("dt", text: "Related")
       # expect(rendered).to have_css("dd", text: "Cat loverz")
     end
-    it "should display identifier" do
+    it "displays identifier" do
       render
       expect(rendered).to have_css("dt", text: "uri")
       expect(rendered).to have_css("dd", text: "http://www.myspace.com/myband")
     end
-    it "should display location" do
+    it "displays location" do
       render
       expect(rendered).to have_css("dt", text: "Secret Location")
       expect(rendered).to have_css("dd", text: "NorCal")

--- a/spec/views/catalog/record/_mods_contributors.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_contributors.html.erb_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "catalog/record/_mods_contributors" do
       render
     end
 
-    it 'should display primary authors' do
+    it 'displays primary authors' do
       expect(rendered).to have_css('dt', text: 'Author')
       expect(rendered).to have_css('dd', text: 'J. Smith')
     end
 
-    it "should display secondary authors" do
+    it "displays secondary authors" do
       expect(rendered).to have_css("dt", text: "Producer")
       expect(rendered).to have_css("dd a", text: "B. Smith")
     end

--- a/spec/views/catalog/record/_mods_subjects.html.erb_spec.rb
+++ b/spec/views/catalog/record/_mods_subjects.html.erb_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe "catalog/record/_mods_subjects" do
       assign(:document, document)
     end
 
-    it "should display subjects if available" do
+    it "displays subjects if available" do
       render
       expect(rendered).to have_css("dt", text: "Subject")
       expect(rendered).to have_css("a", text: '1906 Earthquake')
     end
-    it "should should not render anything when a document has no subjects" do
+    it "shoulds not render anything when a document has no subjects" do
       assign(:document, no_subjects_doc)
       render
       expect(rendered).not_to be_present
@@ -34,12 +34,12 @@ RSpec.describe "catalog/record/_mods_subjects" do
       assign(:document, document)
     end
 
-    it "should display genres if available" do
+    it "displays genres if available" do
       render
       expect(rendered).to have_css("dt", text: "Genre")
       expect(rendered).to have_css("a", text: 'Photographs')
     end
-    it "should should not render anything when a document has no genres" do
+    it "shoulds not render anything when a document has no genres" do
       assign(:document, no_genres_doc)
       render
       expect(rendered).not_to be_present

--- a/spec/views/shared/feedback_forms/_chat_with_librarian.html.erb_spec.rb
+++ b/spec/views/shared/feedback_forms/_chat_with_librarian.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'shared/feedback_forms/_chat_with_librarian' do
     render
   end
 
-  it 'should have correct data attributes' do
+  it 'has correct data attributes' do
     expect(rendered).to have_css('[data-jid="ic@chat.libraryh3lp.com"]')
     expect(rendered).to have_css('[data-library-h3lp]')
   end


### PR DESCRIPTION
For consistency across projects.  Should is wishy-washy, and we ought to be clear about what it does do.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
