### PR TITLE
remove redundant lines and replace with existing function

### DIFF
--- a/app/policies/item_request_link_policy.rb
+++ b/app/policies/item_request_link_policy.rb
@@ -29,7 +29,6 @@ class ItemRequestLinkPolicy
   def folio_holdable?
     return false unless Settings.folio_hold_recall_statuses.include?(item.folio_status)
 
-    item.allowed_request_types.include?('Hold') ||
-      item.allowed_request_types.include?('Recall')
+    item_allows_hold_recall?
   end
 end


### PR DESCRIPTION
item_allows_hold_recall? is doing the exact same check and is a public function so we should use that instead of re-creating it.