### PR TITLE
Remove unnecessary class btn-link from StanfordOnlyPopupComonent

### DIFF
--- a/app/components/stanford_only_popover_component.rb
+++ b/app/components/stanford_only_popover_component.rb
@@ -2,7 +2,7 @@
 
 class StanfordOnlyPopoverComponent < ViewComponent::Base
   def call
-    tag.button(class: 'stanford-only btn btn-link p-0 align-baseline', style: 'height: 24px; width: 24px',
+    tag.button(class: 'stanford-only btn p-0 align-baseline', style: 'height: 24px; width: 24px',
                data: { turbo: false, toggle: 'popover', placement: 'right', content: 'Available to Stanford-affiliated users only. Log in to access.' },
                aria: { label: 'Stanford-only' }) do
       render StanfordOnlyIconComponent.new


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
