### PR TITLE
Update stanford only icon for better alignment

### DIFF
--- a/app/assets/stylesheets/modules/availability-icons.scss
+++ b/app/assets/stylesheets/modules/availability-icons.scss
@@ -1,6 +1,15 @@
 $available-color: green;
 $noncirc-color: darkorange;
 
+.stanford-only {
+  height: 1rem;
+  margin-left: 0.5rem;
+  padding: 0;
+  svg {
+    vertical-align: top;
+  }
+}
+
 .availability {
   .availability-icon {
     @extend .fa;

--- a/app/assets/stylesheets/modules/results-online-section.scss
+++ b/app/assets/stylesheets/modules/results-online-section.scss
@@ -19,5 +19,4 @@
 
 ul.online-links {
   padding-left: 0;
-  line-height: 1.5rem;
 }

--- a/app/components/stanford_only_icon_component.rb
+++ b/app/components/stanford_only_icon_component.rb
@@ -13,7 +13,7 @@ class StanfordOnlyIconComponent < ViewComponent::Base
   end
 
   def svg
-    tag.svg(width: '13px', height: '13px', viewBox: '0 0 13 13', aria: { hidden: true }) do
+    tag.svg(width: font_size, height: font_size, viewBox: '0 0 14 14', aria: { hidden: true }) do
       tag.g(stroke: 'none', stroke_width: 1, fill: 'none', fill_rule: 'evenodd') do
         tag.g(transform: 'translate(-1.000000, -1.000000)') do
           tag.g(id: 'stanford-only', transform: 'translate(1.000000, -3.000000)') do
@@ -27,5 +27,9 @@ class StanfordOnlyIconComponent < ViewComponent::Base
 
   def call
     svg
+  end
+
+  def font_size
+    '14px' # TODO: This will change in Bootstrap 5
   end
 end

--- a/app/components/stanford_only_popover_component.rb
+++ b/app/components/stanford_only_popover_component.rb
@@ -2,7 +2,7 @@
 
 class StanfordOnlyPopoverComponent < ViewComponent::Base
   def call
-    tag.button(class: 'stanford-only btn p-0 align-baseline', style: 'height: 24px; width: 24px',
+    tag.button(class: 'stanford-only btn',
                data: { turbo: false, toggle: 'popover', placement: 'right', content: 'Available to Stanford-affiliated users only. Log in to access.' },
                aria: { label: 'Stanford-only' }) do
       render StanfordOnlyIconComponent.new


### PR DESCRIPTION
This works in the existing places and will also work with larger fonts (for chat)

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->

<img width="863" alt="Screenshot 2025-04-11 at 1 08 28 PM" src="https://github.com/user-attachments/assets/ed4abc03-1dd4-4e03-8756-aa6c339578ca" />

