### PR TITLE
Add a recaptcha login link component

### DIFF
--- a/app/assets/stylesheets/modules/recaptcha.css
+++ b/app/assets/stylesheets/modules/recaptcha.css
@@ -1,0 +1,12 @@
+.recaptcha {
+  a {
+    --link-text-decoration-color: var(--stanford-digital-red);
+    --bs-link-decoration: underline dotted var(--underline-color) 1px;
+    color: var(--stanford-digital-red);
+
+    &:hover {
+      color: rgb(var(--stanford-digital-red-dark-rgb));
+      font-weight: 500;
+    }
+  }
+}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -28,6 +28,7 @@
 @import "modules/course_reserve_browse";
 @import "modules/eds_range_slider";
 @import "modules/feedback-form";
+@import "modules/recaptcha";
 @import "modules/facets";
 @import "modules/file-collection-members";
 @import "modules/file-list-table";

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -2,6 +2,7 @@
   --stanford-illuminating-dark: #fec51d1a;
 
   /* From component library */
+  --stanford-digital-red: #b1040e;
   --stanford-digital-red-dark-rgb: 130, 0, 0;
   --stanford-digital-blue-rgb: 0, 108, 184;
   --stanford-digital-green: #008566;

--- a/app/components/recaptcha_with_login_link_component.html.erb
+++ b/app/components/recaptcha_with_login_link_component.html.erb
@@ -1,0 +1,5 @@
+<div class="recaptcha <%= classes %>">
+  <p class="mb-1">Stanford affiliates: <%= link_to 'Log in', new_user_session_path(referrer: request.original_url), data: { turbo: false } %>
+ to skip Captcha.</p>
+  <%= recaptcha_tags id: recaptcha_id, noscript: %>
+</div>

--- a/app/components/recaptcha_with_login_link_component.rb
+++ b/app/components/recaptcha_with_login_link_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RecaptchaWithLoginLinkComponent < ViewComponent::Base
+  attr_reader :recaptcha_id, :classes, :noscript
+
+  # You likely want to default to noscript for recaptcha. See https://github.com/sul-dlss/SearchWorks/issues/3873
+  def initialize(recaptcha_id:, classes: 'col-sm-9 offset-sm-3', noscript: false)
+    @recaptcha_id = recaptcha_id
+    @classes = classes
+    @noscript = noscript
+    super
+  end
+end

--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -47,12 +47,6 @@
 
   <% if current_user.blank? %>
     <div class="form-group row">
-      <div class="col-sm-10 offset-sm-2">
-        <%# Remove noscript for recaptcha when used in a modal. %>
-        <%# Otherwise the modal builder will insert unprocessed noscript tags, resulting in an empty g-recaptcha-response. %>
-        <%= recaptcha_tags id: 'connection-form-recaptcha', noscript: false %>
-
-        <p>(Stanford users can avoid this Captcha by logging in.)</p>
-      </div>
+      <%= render RecaptchaWithLoginLinkComponent.new(recaptcha_id: 'connection-form-recaptcha', classes: 'col-sm-10 offset-sm-2') %>
     </div>
   <% end %>

--- a/app/views/shared/feedback_forms/_form_fields.html.erb
+++ b/app/views/shared/feedback_forms/_form_fields.html.erb
@@ -47,12 +47,7 @@
 
     <% if current_user.blank? %>
       <div class="form-group row">
-        <div class="col-sm-9 offset-sm-3">
-          <%# Remove noscript for recaptcha. See https://github.com/sul-dlss/SearchWorks/issues/3873 %>
-          <%= recaptcha_tags id: "#{type}-recaptcha", noscript: false %>
-
-          <p>(Stanford users can avoid this Captcha by logging in.)</p>
-        </div>
+        <%= render RecaptchaWithLoginLinkComponent.new(recaptcha_id: "#{type}-recaptcha") %>
       </div>
     <% end %>
 

--- a/spec/components/recaptcha_with_login_link_component_spec.rb
+++ b/spec/components/recaptcha_with_login_link_component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecaptchaWithLoginLinkComponent, type: :component do
+  before do
+    render_inline(described_class.new(recaptcha_id: 'my-recaptcha-id'))
+  end
+
+  it 'renders the component' do
+    expect(page).to have_link 'Log in'
+    expect(page).to have_css '#my-recaptcha-id'
+  end
+end

--- a/spec/features/blacklight_customizations/emailing_records_spec.rb
+++ b/spec/features/blacklight_customizations/emailing_records_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Emailing Records", :js do
       expect(page).to have_css('h1', text: 'Email This', visible: true)
 
       within('.modal-dialog') do
-        expect(page).to have_css('p', text: '(Stanford users can avoid this Captcha by logging in.)')
+        expect(page).to have_css('p', text: 'Stanford affiliates: Log in to skip Captcha.')
       end
     end
   end


### PR DESCRIPTION
Closes #3868

500 vs 600 font weight on hover still in discussion with @dbranchini (600 visually shifts the text).
<img width="312" alt="Screenshot 2025-04-14 at 11 17 17 AM" src="https://github.com/user-attachments/assets/03fc9d70-5e58-411d-9238-cdda270e6c39" />
