### PR TITLE
Add an anchor tag on the all reference hours link

### DIFF
--- a/app/components/chat_with_librarian_component.html.erb
+++ b/app/components/chat_with_librarian_component.html.erb
@@ -7,5 +7,5 @@
   <span class="ml-1 ms-1" data-controller="chat-hours" data-chat-hours-url-value="https://library-hours.stanford.edu/api/v1/library/green/location/reference/hours/for/today">
     <span class="placeholder"></span>
   </span>
-  <%= link_to 'All reference hours', 'https://library.stanford.edu/libraries/cecil-h-green-library', class: "ml-1 ms-1" %>
+  <%= link_to 'All reference hours', 'https://library.stanford.edu/libraries/cecil-h-green-library#additional-hours', class: "ml-1 ms-1" %>
 <% end %>


### PR DESCRIPTION
This brings the user to the part of the page with the hours.  This was a suggestion from Niqui and confirmed by Darcy

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
