### PR TITLE
Set json_solr_path

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -87,6 +87,7 @@ class CatalogController < ApplicationController
     ## parameters included in the Blacklight-jetty document requestHandler.
     #
     config.document_solr_path = 'select'
+    config.json_solr_path = 'select'
     config.default_document_solr_params = {
      :qt => 'document',
     #  ## These are hard-coded in the blacklight 'document' requestHandler


### PR DESCRIPTION
Upstream set `json_solr_path` to `/advanced` by default:

https://github.com/projectblacklight/blacklight/pull/3066

I'm not sure we need it here, and setting it back to `/select` seems to fix #4768  🤷‍♂️ 