### PR TITLE
Also render unmatched vernacular in the content advice component

### DIFF
--- a/app/components/record/marc_content_advice_component.rb
+++ b/app/components/record/marc_content_advice_component.rb
@@ -15,7 +15,9 @@ module Record
     end
 
     def content_advice_values
-      content_advice.flat_map { |h| h[:fields].map { |field| field[:field] } }
+      content_advice.flat_map do |h|
+        h[:fields].presence&.map { |field| field[:field].presence } || h[:unmatched_vernacular]
+      end.compact
     end
 
     def call

--- a/spec/components/record/marc_content_advice_component_spec.rb
+++ b/spec/components/record/marc_content_advice_component_spec.rb
@@ -35,4 +35,19 @@ RSpec.describe Record::MarcContentAdviceComponent, type: :component do
       expect(page.to_html).to be_empty
     end
   end
+
+  context 'the summary_struct has a content advice field with unmatched vernacular' do
+    let(:summary_struct) do
+      [
+        { label: 'Summary', fields: [{ field: 'Summary of content' }] },
+        { label: 'Content advice', fields: [], unmatched_vernacular: 'Warning about the content in some other language' }
+      ]
+    end
+
+    it 'creates a content warning' do
+      expect(page).to have_css('.content-advice')
+      expect(page).to have_content('Warning about the content in some other language')
+      expect(page).to have_css('strong', text: 'Content advice: ')
+    end
+  end
 end


### PR DESCRIPTION
fixes SW-4435

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
