### PR TITLE
convert index_brief.html.erb to ViewComponent

### DIFF
--- a/app/components/articles/index_brief_component.html.erb
+++ b/app/components/articles/index_brief_component.html.erb
@@ -1,4 +1,3 @@
-<% doc_presenter = document_presenter(document) %>
 <% # header bar for doc items in index view %>
 <div class="brief-document container-fluid">
   <div class="row row-eq-height brief-container">
@@ -6,8 +5,7 @@
 
       <div class="documentHeader">
         <h3 class="index_title">
-          <% counter = document_counter_with_offset(document_counter) %>
-          <%= render_resource_icon doc_presenter.formats %>
+          <%= render_resource_icon doc_formats %>
           <%= document.online_label %>
           <span class="document-counter">
             <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
@@ -43,4 +41,3 @@
 
   </div>
 </div>
-

--- a/app/components/articles/index_brief_component.rb
+++ b/app/components/articles/index_brief_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Articles
+  class IndexBriefComponent < ViewComponent::Base
+    with_collection_parameter :document
+
+    def initialize(document:, document_counter:)
+      super
+      @document = document
+      @document_counter = document_counter
+    end
+
+    def counter
+      document_counter_with_offset(document_counter)
+    end
+
+    def doc_formats
+      document_presenter(document).formats
+    end
+
+    attr_reader :document, :document_counter
+
+    delegate :document_presenter, :render_resource_icon, :document_counter_with_offset,
+             :link_to_document, :get_main_title_date, :render_index_doc_actions, to: :helpers
+  end
+end

--- a/app/views/catalog/_document_brief.html.erb
+++ b/app/views/catalog/_document_brief.html.erb
@@ -1,4 +1,8 @@
 <% # container for all documents in index view -%>
 <div id="documents">
-  <%= render :collection => documents, :as => :document, :partial => 'index_brief' %>
+  <% if controller_path == 'articles' %>
+    <%= render Articles::IndexBriefComponent.with_collection(documents) %>
+  <% else %>
+    <%= render :collection => documents, :as => :document, :partial => 'index_brief' %>
+  <% end %>
 </div>


### PR DESCRIPTION
This is to make things easier for a bug fix I found for https://github.com/sul-dlss/SearchWorks/issues/2090. This displays correctly on the default view but if you switch to the brief view we are displaying the old content. This partial is where the change needs to get made to fix this issue. I have split the fix into two PRs to make things easier to review. 