### PR TITLE
Simplify select all code

### DIFF
--- a/app/javascript/select-all.js
+++ b/app/javascript/select-all.js
@@ -19,65 +19,27 @@
       init();
 
       function init() {
-        $element.on('click', function() {
-          const state = $selectAll.is(':visible');
-          bookmarkSelectors = $(selectorSelectBookmarks);
-          let first = true;
-          const checkFirstBox = new Promise((resolve) => {
-            const observer = new MutationObserver(function(mutationList) {
-              for (const mutation of mutationList) {
+        $element.on('click', toggleAll)
+      }
 
-                mutation.addedNodes.forEach(function(node) {
-                  console.log("Mutation", node)
-                  if (node.data != 'Saving...') {
-                    console.log("starting the rest", node.data)
-
-                    resolve()
-                  }
-                })
-              }
+      function toggleAll() {
+        const state = $selectAll.is(':visible')
+        document.querySelectorAll(selectorSelectBookmarks).forEach(async (checkbox, index) => {
+          if (checkbox.checked !== state) {
+            const event = new MouseEvent("click", {
+              view: window,
+              bubbles: true,
+              cancelable: true,
             })
-
-            bookmarkSelectors.each(function(i, checkbox) {
-              if (first) {
-                if (checkbox.checked !== state) {
-                  console.log("first box checked")
-                  first = false;
-                  const span = checkbox.closest('form').querySelector('[data-checkboxsubmit-target="span"]')
-                  observer.observe(span, { childList: true, subtree: true });
-                  const event = new MouseEvent("click", {
-                    view: window,
-                    bubbles: true,
-                    cancelable: true,
-                  })
-                  checkbox.dispatchEvent(event)
-                }
-              }
-            })
-          })
-
-          checkFirstBox.then(() => {
-            // Check the rest of the boxes
-            bookmarkSelectors.each(async function(i, checkbox) {
-              if (checkbox.checked !== state) {
-                console.log("subsequent box checked")
-
-                const event = new MouseEvent("click", {
-                  view: window,
-                  bubbles: true,
-                  cancelable: true,
-                })
-                checkbox.dispatchEvent(event)
-                if (i > 20) {
-                  // Avoid trigging DOS protection in the loadbalancer.
-                  await new Promise(r => setTimeout(r, 500))
-                }
-              }
-            })
-          })
-
-          toggleActions()
+            checkbox.dispatchEvent(event)
+          }
+          if (index > 20) {
+            // Avoid trigging DOS protection in the loadbalancer.
+            await new Promise(r => setTimeout(r, 500))
+          }
         })
+
+        toggleActions()
       }
 
       function setInitialAction() {


### PR DESCRIPTION
I believe that 78af604192ac1c93161d5d42f4664b1cd68f0c83 introduced a bug, where the deferred code was immediately resolved in all instances, which means it wasn't working as desgined in 9d1a31e52a04d58780d4d73d5d9723bf53f09fdc. However, since we haven't been using the deferred code, the original bug has not resurfaced, which means we can get rid of the deferred code, so that it's all a bit simpler.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
