### PR TITLE
Fix the bookmark checkboxes alignment.

### DIFF
--- a/app/components/articles/document_list_component.rb
+++ b/app/components/articles/document_list_component.rb
@@ -6,7 +6,7 @@ module Articles
     attr_reader :document, :counter
 
     def actions
-      helpers.render_index_doc_actions document, wrapping_class: 'index-document-functions'
+      helpers.render_index_doc_actions document, wrapping_class: 'index-document-functions col'
     end
 
     delegate :eds_restricted?, to: :document

--- a/app/components/search_result/document_component.rb
+++ b/app/components/search_result/document_component.rb
@@ -10,7 +10,7 @@ module SearchResult
     end
 
     def actions
-      helpers.render_index_doc_actions document, wrapping_class: 'index-document-functions'
+      helpers.render_index_doc_actions document, wrapping_class: 'index-document-functions col'
     end
 
     # NOTE: ideally this would override the metadata slot in Blacklight, but I'm not sure how to do that.


### PR DESCRIPTION
After:
<img width="833" alt="Screenshot 2025-04-30 at 14 11 05" src="https://github.com/user-attachments/assets/f63fa60a-9192-4cfb-94fd-d293788f0866" />

Before:
<img width="821" alt="Screenshot 2025-04-30 at 14 11 14" src="https://github.com/user-attachments/assets/210d982e-27ec-4def-92a6-3237a4815df2" />
