### PR TITLE
Remove mistargeted css.

### DIFF
--- a/app/assets/stylesheets/modules/browse-toolbar.scss
+++ b/app/assets/stylesheets/modules/browse-toolbar.scss
@@ -15,17 +15,4 @@
       margin-right: 5px;
     }
   }
-  .callnumber {
-    margin-left: 10px;
-    line-height: 3em;
-  }
-}
-
-@include media-breakpoint-down(sm) {
-  .record-browse-nearby {
-    .callnumber {
-      display: block;
-      margin: 10px 10px 0 0;
-    }
-  }
 }


### PR DESCRIPTION
This CSS can't be what was originally intended. It ends up targeting the callnumber in the availability panel of the preview only when it is in browse nearby:

<img width="826" alt="Screenshot 2025-05-01 at 09 42 58" src="https://github.com/user-attachments/assets/387a290a-97ba-455c-90f0-a70403e2d1c6" />

After:
<img width="867" alt="Screenshot 2025-05-01 at 09 43 32" src="https://github.com/user-attachments/assets/2e12086d-161e-4947-8090-2a0ee40694c9" />
