### PR TITLE
fix filtering on bound_with_items, fix call number for items without …

### DIFF
--- a/app/components/record/bound_with_children_component.html.erb
+++ b/app/components/record/bound_with_children_component.html.erb
@@ -1,11 +1,9 @@
 <div class="bound-with-type">Bound with:</div>
 <ul class="list-unstyled mb-0">
   <% bound_with_children.each do |child| %>
-      <% child.items.each do |item| %>
-        <li class="pb-2">
-          <div class="bound-with-title"><%= bound_with_title(child) %></div>
-          <div class="bound-with-callnumber"><%= item.callnumber %></div>
-        </li>
-      <% end %>
+    <li class="pb-2">
+      <div class="bound-with-title"><%= bound_with_title(child.document) %></div>
+      <div class="bound-with-callnumber"><%= child.callnumber %></div>
+    </li>
   <% end %>
 </ul>

--- a/app/components/record/bound_with_children_component.rb
+++ b/app/components/record/bound_with_children_component.rb
@@ -11,8 +11,8 @@ module Record
 
     attr_reader :bound_with_children, :item_id, :instance_id
 
-    def bound_with_title(child)
-      (instance_id == child.id ? tag.em('Same title') : link_to(child['title_full_display'], solr_document_path(child.id), data: { turbo: false }))
+    def bound_with_title(document)
+      (instance_id == document.id ? tag.em('Same title') : link_to(document['title_full_display'], solr_document_path(document.id), data: { turbo: false }))
     end
   end
 end

--- a/app/components/record/bound_with_children_table_component.html.erb
+++ b/app/components/record/bound_with_children_table_component.html.erb
@@ -3,11 +3,9 @@
   <th class="sr-only">Title</th>
   <th class="sr-only">Call Number</th>
   <% bound_with_children.each do |child| %>
-      <% child.items.each do |item| %>
-        <tr class="bound-with-item">
-          <td class="bound-with-title align-top py-2"><%= bound_with_title(child) %></td>
-          <td class="bound-with-callnumber align-top py-2"><%= item.callnumber %></td>
-        </tr>
-      <% end %>
+      <tr class="bound-with-item">
+        <td class="bound-with-title align-top py-2"><%= bound_with_title(child.document) %></td>
+        <td class="bound-with-callnumber align-top py-2"><%= child.callnumber %></td>
+      </tr>
   <% end %>
 </table>

--- a/app/controllers/bound_with_children_controller.rb
+++ b/app/controllers/bound_with_children_controller.rb
@@ -22,6 +22,7 @@ class BoundWithChildrenController < ApplicationController
     builder = Builder.new(@item_id, 100)
     search = search_service.repository.search(builder)
     @bound_with_children = filtered_children(search.docs)
+    @bound_with_parent = @bound_with_children.first.bound_with_parent
   end
 
   def index
@@ -32,11 +33,11 @@ class BoundWithChildrenController < ApplicationController
     search = search_service.repository.search(builder)
     @number_of_results = search.response['numFound']
     @bound_with_children = filtered_children(search.docs)
-    @instance_call_number = @bound_with_children.present? ? @bound_with_children.first.items.first.bound_with_parent[:call_number] : ''
+    @bound_with_parent = @bound_with_children.first.bound_with_parent
   end
 
   def filtered_children(bound_with_children)
-    @filtered_children = bound_with_children.each do |child|
+    @filtered_children = bound_with_children.flat_map do |child|
       child.items.select { |item| item.id == @item_id && !item.bound_with_principal? }
     end
   end

--- a/app/views/bound_with_children/index.html.erb
+++ b/app/views/bound_with_children/index.html.erb
@@ -3,7 +3,7 @@
     <div class="bound-with p-2 mt-2">
       <%= render Record::BoundWithChildrenComponent.new(bound_with_children: @bound_with_children, item_id: @item_id, instance_id: @id) %>
       <% if @number_of_results > @limit %>
-        <%= link_to "See all items bound with #{@instance_call_number}", bound_with_children_modal_solr_document_path(item_id: @item_id), data: { turbo_frame: "blacklight-modal", blacklight_modal: "trigger" }, class: 'btn btn-outline-primary p-1 text-left' %>
+        <%= link_to "See all items bound with #{@bound_with_parent['call_number']}", bound_with_children_modal_solr_document_path(item_id: @item_id), data: { turbo_frame: "blacklight-modal", blacklight_modal: "trigger" }, class: 'btn btn-outline-primary p-1 text-left' %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/bound_with_children/modal.html.erb
+++ b/app/views/bound_with_children/modal.html.erb
@@ -2,9 +2,9 @@
   <% component.with_header do %>
     <span class="d-flex flex-column">
       <h2 class="modal-title">
-        <%= @bound_with_children.first.items.first.bound_with_parent[:title] %>
+        <%= @bound_with_parent['title'] %>
       </h2>
-      <%= @bound_with_children.first.items.first.bound_with_parent[:call_number] %>
+      <%= @bound_with_parent['call_number'] %>
     </span>
   <% end %>
   <div class="bound-with-modal">

--- a/spec/components/record/bound_with_children_component_spec.rb
+++ b/spec/components/record/bound_with_children_component_spec.rb
@@ -5,18 +5,18 @@ require "rails_helper"
 RSpec.describe Record::BoundWithChildrenComponent, type: :component do
   let(:bound_with_children) {
     [
-      instance_double(SolrDocument, id: 123456,
-                                    items: [instance_double(Holdings::Item, id: '12356-789010-13da',
-                                                                            callnumber: 'call number 1234')]),
-      instance_double(SolrDocument, id: 987654,
-                                    items: [instance_double(Holdings::Item, id: '12356-789010-13d2',
-                                                                            callnumber: 'call number 9876')])
+      instance_double(Holdings::Item, id: '12356-789010-13da',
+                                      document: instance_double(SolrDocument, id: 123456),
+                                      callnumber: 'call number 1234'),
+      instance_double(Holdings::Item, id: '12356-789010-13d2',
+                                      document: instance_double(SolrDocument, id: 987654),
+                                      callnumber: 'call number 9876')
     ]
   }
   let(:component) { described_class.new(bound_with_children:, item_id: '12356-789010-13da', instance_id: 123456) }
 
   before do
-    allow(bound_with_children.last).to receive(:[]).with("title_full_display").and_return("987654 title")
+    allow(bound_with_children.last.document).to receive(:[]).with("title_full_display").and_return("987654 title")
     render_inline(component)
   end
 


### PR DESCRIPTION
…bound_with_parent

closes #4836

This PR fixes two related issues. First is the honeybadger error in the issue. The second is filtered_children wasn't actually filtering the bound withs. It was returning the bound withs after looping. This was also causing the error with honeybadger. 

Originally we kept the structure because the bound_with_children component needed the SolrDocument to construct links however Chris pointed out that Holdings:Item has access to the SolrDocument. This meant we were able to change the loop to just grab all the items that matched the item_id and aren't principle records and loop over a flat list instead of a list of SolrDocumnets and then their items.
