### PR TITLE
Update callnumber button styling.

### DIFF
--- a/app/assets/stylesheets/modules/browse-toolbar.scss
+++ b/app/assets/stylesheets/modules/browse-toolbar.scss
@@ -15,4 +15,9 @@
       margin-right: 5px;
     }
   }
+
+  .btn-callnumber {
+    line-height: 3em;
+    margin-left: 10px;
+  }
 }

--- a/app/views/catalog/record/_callnumber_browse.html.erb
+++ b/app/views/catalog/record/_callnumber_browse.html.erb
@@ -7,7 +7,7 @@
     <div class="col-md-9 col-sm-12">
       Start at call number:
       <% spines.each_with_index do |spine, index| %>
-        <span class="callnumber">
+        <span class="btn-callnumber">
           <%= link_to_callnumber_browse(document, spine, index) %>
         </span>
       <% end %>

--- a/spec/views/catalog/record/_callnumber_browse.html.erb_spec.rb
+++ b/spec/views/catalog/record/_callnumber_browse.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "catalog/record/_callnumber_browse" do
     expect(rendered).to have_css('h2', text: /Browse related items/)
   end
   it "includes links to all unique callnumbers" do
-    expect(rendered).to have_css('.callnumber button', text: "callnumber")
-    expect(rendered).to have_css('.callnumber button', text: "callnumber2")
+    expect(rendered).to have_css('.btn-callnumber', text: "callnumber")
+    expect(rendered).to have_css('.btn-callnumber', text: "callnumber2")
   end
 end


### PR DESCRIPTION
I figured out what #4830 was supposed to target. 

After (and how it used to be):
<img width="329" alt="Screenshot 2025-05-01 at 14 16 56" src="https://github.com/user-attachments/assets/c5b99ed1-448a-4fcf-b4f7-14380065fd44" />

Before:
<img width="295" alt="Screenshot 2025-05-01 at 14 17 06" src="https://github.com/user-attachments/assets/bbf62bf0-1b5c-4e1a-ba29-677db5d695ee" />

