### PR TITLE
Get rid of unnecessary alert-error class

### DIFF
--- a/app/assets/stylesheets/modules/alert.scss
+++ b/app/assets/stylesheets/modules/alert.scss
@@ -1,5 +1,0 @@
-.alert-error{
-  background-color: $state-danger-bg;
-  border-color: $state-danger-border;
-  color: $state-danger-text;
-}

--- a/app/assets/stylesheets/searchworks.scss
+++ b/app/assets/stylesheets/searchworks.scss
@@ -12,7 +12,6 @@
 @import "modules/alternate-catalog";
 @import "modules/availability-icons";
 @import "modules/advanced-search";
-@import "modules/alert";
 @import "modules/article";
 @import "modules/availability";
 @import "modules/bookmarks";

--- a/app/javascript/feedback_form.js
+++ b/app/javascript/feedback_form.js
@@ -72,10 +72,11 @@ Blacklight.onLoad(function(){
 
     function renderFlashMessages(response){
       $.each(response, function(i,val){
-        var flashHtml = "<div class='alert alert-" + val[0] + "'><button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button>" + val[1] + "</div>";
+        const alertType = val[0] == 'error' ? 'danger' : val[0]
+        const flashHtml = `<div class="alert alert-${alertType}"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>${val[1]}</div>`
 
         // Show the flash message
-        $('div.flash_messages').html(flashHtml);
+        document.querySelector('div.flash_messages').innerHTML = flashHtml
       });
     }
 


### PR DESCRIPTION
We should just use alert-danger

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
