### PR TITLE
change border color on articles login alert

### DIFF
--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -46,8 +46,12 @@
   }
 }
 
-.eds-restricted {
-  border-left: 4px solid var(--stanford-cardinal)!important;
+.alert.eds-restricted {
+  border: 1px solid var(--stanford-cardinal);
+}
+
+#documents .document.eds-restricted, .alert.eds-restricted {
+  border-left: 4px solid var(--stanford-cardinal);
   .stanford-only {
     margin-left: 0;
   }

--- a/app/components/search_result/login_banner_component.rb
+++ b/app/components/search_result/login_banner_component.rb
@@ -5,7 +5,7 @@ module SearchResult
     delegate :new_user_session_path, to: :helpers
 
     def classes
-      'alert px-3 py-3 border-end border-top border-bottom alert-dismissible rounded-0 fade show eds-restricted'
+      'alert px-3 py-3 alert-dismissible rounded-0 fade show eds-restricted'
     end
   end
 end


### PR DESCRIPTION
The figma has a border of stanford red, we currently have a gray border. This fixes that.

**Figma**

<img width="493" alt="Screenshot 2025-05-02 at 1 49 48 PM" src="https://github.com/user-attachments/assets/abe122b4-bf89-4a7b-8449-54053dc69b0e" />

**Current**

<img width="697" alt="Screenshot 2025-05-02 at 1 49 52 PM" src="https://github.com/user-attachments/assets/34c7fc6c-bbf3-44b0-adcc-fef3c025bb40" />

**This PR**

<img width="681" alt="Screenshot 2025-05-02 at 1 49 56 PM" src="https://github.com/user-attachments/assets/8dd7877c-8a9f-402b-836e-25f332641354" />
