### PR TITLE
update eds restricted item view to show message and popover

### DIFF
--- a/app/assets/stylesheets/modules/availability-icons.scss
+++ b/app/assets/stylesheets/modules/availability-icons.scss
@@ -10,6 +10,15 @@ $noncirc-color: darkorange;
   }
 }
 
+h1 .stanford-only {
+  height: 1.5rem;
+  margin-left: 0;
+  svg {
+    height: 1.5rem;
+    width: 1.5rem;
+  }
+}
+
 .availability {
   .availability-icon {
     @extend .fa;

--- a/app/components/articles/document_component.html.erb
+++ b/app/components/articles/document_component.html.erb
@@ -9,8 +9,13 @@
   class: classes.flatten.join(' ') do %>
   <%= header %>
   <div class="document-main-section">
-    <%= title %>
-    <%= document_metadata %>
+    <% if @document.eds_restricted? %>
+      <h1><%= I18n.t('searchworks.guest_message') %>
+      <%= render StanfordOnlyPopoverComponent.new %></h1>
+    <% else %>
+      <%= title %>
+      <%= document_metadata %>
+    <% end %>
   </div>
   <%= footer %>
 <% end %>

--- a/app/components/articles/eds_restricted_component.html.erb
+++ b/app/components/articles/eds_restricted_component.html.erb
@@ -1,7 +1,7 @@
 <header class="documentHeader row">
   <h3 class="<%= @classes %>">
     <%= counter %>
-    This title cannot be displayed for guests.
+    <%= I18n.t('searchworks.guest_message') %>
     <%= render StanfordOnlyPopoverComponent.new %>
   </h3>
 </header>

--- a/app/views/articles/_show_main_content.html.erb
+++ b/app/views/articles/_show_main_content.html.erb
@@ -1,12 +1,18 @@
-    <%= render RecordToolbarComponent.new(presenter: document_presenter(@document), search_context: @search_context, search_session: search_session) %>
-    <% @page_title = t 'blacklight.search.show.title_html', :document_title => document_presenter(@document).html_title, :application_name => "#{I18n.t('blacklight.application_name')} catalog" -%>
-    <%# content_for(:head) { render_link_rel_alternates } -%>
- 
-    <%= render (blacklight_config.view_config(:show).document_component || Blacklight::DocumentComponent).new(document: document_presenter(@document), component: :div, title_component: :h1, show: true) do |component| %>
-      <% component.with_footer do %>
-        <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
-          <!-- COinS, for Zotero among others. -->
-          <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(@document[@document.format_key]) %>"></span>
-        <% end %>
-      <%  end %>
+<% if @document.eds_restricted? %>
+  <div class="mt-4">
+    <%= render SearchResult::LoginBannerComponent.new %>
+  </div>
+<% end %>
+
+<%= render RecordToolbarComponent.new(presenter: document_presenter(@document), search_context: @search_context, search_session: search_session) %>
+<% @page_title = t 'blacklight.search.show.title_html', :document_title => document_presenter(@document).html_title, :application_name => "#{I18n.t('blacklight.application_name')} catalog" -%>
+<%# content_for(:head) { render_link_rel_alternates } -%>
+
+<%= render (blacklight_config.view_config(:show).document_component || Blacklight::DocumentComponent).new(document: document_presenter(@document), component: :div, title_component: :h1, show: true) do |component| %>
+  <% component.with_footer do %>
+    <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+      <!-- COinS, for Zotero among others. -->
+      <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(@document[@document.format_key]) %>"></span>
     <% end %>
+  <%  end %>
+<% end %>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -275,6 +275,7 @@ en:
       request_on_site: Request on-site access
       finding_aid: Request via Finding Aid
       aeon: Request via Aeon
+    guest_message: This title cannot be displayed for guests.
   blacklight:
     advanced_search:
       page_title: 'Advanced search in SearchWorks catalog'


### PR DESCRIPTION
closes #1452. Would use `hide_whitespace` because app/views/articles/_show_main_content.html.erb is a small change but looks large due to tabbing fixes.
<img width="1022" alt="Screenshot 2025-05-02 at 3 34 25 PM" src="https://github.com/user-attachments/assets/94f49db9-ec2e-4eb1-b803-2ed5d85b2609" />
