### PR TITLE
Remove unnecessary css rule

### DIFF
--- a/app/assets/stylesheets/modules/access-panel.scss
+++ b/app/assets/stylesheets/modules/access-panel.scss
@@ -14,7 +14,6 @@
   .card-body {
     h4 {
       color: $cardinal-red;
-      font-size: $h4-font-size;
       line-height: 1.4em;
       margin-bottom: 5px;
 


### PR DESCRIPTION
`$h4-font-size` is a bootstrap variable that already sets h4 font size. See https://github.com/twbs/bootstrap/blob/f849680d16a9695c9a6c9c062d6cff55ddcf071e/scss/_reboot.scss#L110

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
