### PR TITLE
Restore the hamburger menu icon and clean up vertical alignments for facets

### DIFF
--- a/app/assets/stylesheets/modules/results-documents.scss
+++ b/app/assets/stylesheets/modules/results-documents.scss
@@ -76,7 +76,7 @@
 
 .search_num_of_results {
   text-align: left;
-  margin-top: $h2-font-size * 0.5;
+  margin-top: 0.5rem;
 
   .results-heading a {
     border-bottom: 0;

--- a/app/components/articles/response/facet_group_component.html.erb
+++ b/app/components/articles/response/facet_group_component.html.erb
@@ -1,5 +1,5 @@
 <% # main container for facets/limits menu -%>
-<%= content_tag :div, id: @id,  class: 'facets sidenav facets-toggleable-sm' do %>
+<%= content_tag :div, id: @id, class: 'facets sidenav facets-toggleable-sm mt-1 border-0 px-0' do %>
   <% if limiters.present? %>
     <div class="top-panel-heading">
       <h2>
@@ -31,10 +31,10 @@
   <% end %>
 
   <div class="facets-header">
-    <%= content_tag :h2, @title, class: 'facets-heading' if @title %>
+    <%= content_tag :h2, @title, class: 'facets-heading my-0' if @title %>
 
     <%= content_tag :button,
-      class:'btn btn-outline-secondary facet-toggle-button d-block d-md-none',
+      class:'btn btn-outline-secondary facet-toggle-button fs-2 d-block d-md-none',
       type: 'button',
       data: {
         'bs-toggle': 'collapse',
@@ -42,11 +42,10 @@
       },
       aria: {
         controls: @panel_id,
-        expanded: 'false',
-        label: t('blacklight.search.facets.group.toggle'),
+        expanded: 'false'
       } do %>
-      <span data-show-label><%= t('blacklight.search.facets.group.open') %></span>
-      <span data-hide-label><%= t('blacklight.search.facets.group.close') %></span>
+        <span class="visually-hidden">Toggle facets</span>
+        <span class="fa fa-bars"></span>
     <% end %>
   </div>
 

--- a/app/components/searchworks/response/facet_group_component.html.erb
+++ b/app/components/searchworks/response/facet_group_component.html.erb
@@ -1,12 +1,12 @@
 <% # This is a copy of the Blacklight 8 version of this component.
    # We should be able to delete this local copy after we migrate to Blacklight 8 %>
 <% # main container for facets/limits menu -%>
-<%= content_tag :div, id: @id,  class: 'facets sidenav facets-toggleable-sm' do %>
-  <div class="facets-header">
-    <%= content_tag :h2, @title, class: 'facets-heading' if @title %>
+<%= content_tag :div, id: @id,  class: 'facets sidenav facets-toggleable-sm mt-1 border-0 px-0' do %>
+  <div class="facets-header align-items-baseline">
+    <%= content_tag :h2, @title, class: 'facets-heading my-0' if @title %>
 
     <%= content_tag :button,
-      class:'btn btn-outline-secondary facet-toggle-button d-block d-md-none',
+      class:'btn btn-outline-secondary facet-toggle-button fs-2 d-block d-md-none',
       type: 'button',
       data: {
         'bs-toggle': 'collapse',
@@ -14,11 +14,10 @@
       },
       aria: {
         controls: @panel_id,
-        expanded: 'false',
-        label: t('blacklight.search.facets.group.toggle'),
+        expanded: 'false'
       } do %>
-        <span data-show-label><%= t('blacklight.search.facets.group.open') %></span>
-        <span data-hide-label><%= t('blacklight.search.facets.group.close') %></span>
+        <span class="visually-hidden">Toggle facets</span>
+        <span class="fa fa-bars"></span>
     <% end %>
   </div>
 


### PR DESCRIPTION
After:
<img width="573" alt="Screenshot 2025-05-07 at 08 00 52" src="https://github.com/user-attachments/assets/50982ea2-43be-4087-921c-313cb23e3fd5" />

<img width="402" alt="Screenshot 2025-05-07 at 08 01 01" src="https://github.com/user-attachments/assets/559b1d31-1a58-484a-ad5f-5653e05650c8" />
