### PR TITLE
have article bookmarks use eds search service

### DIFF
--- a/app/controllers/article_selections_controller.rb
+++ b/app/controllers/article_selections_controller.rb
@@ -80,4 +80,12 @@ class ArticleSelectionsController < ApplicationController
       flash[:notice] = I18n.t('blacklight.bookmarks.need_login') and raise Blacklight::Exceptions::AccessDenied
     end
   end
+
+  def search_service
+    eds_params = {
+      guest: session['eds_guest'],
+      session_token: session['eds_session_token']
+    }
+    Eds::SearchService.new(blacklight_config, params, eds_params)
+  end
 end


### PR DESCRIPTION
closes #4862 

search_service = Blacklight::SearchService in app/controllers/article_selections_controller.rb
Somehow it ends up getting into the Eds::SearchService but it doesn't have the eds_params set so it won't work.