### PR TITLE
Use the default search builder to construct the bound-with query.

### DIFF
--- a/app/controllers/bound_with_children_controller.rb
+++ b/app/controllers/bound_with_children_controller.rb
@@ -5,35 +5,35 @@ class BoundWithChildrenController < ApplicationController
   include Blacklight::Searchable
   copy_blacklight_config_from(CatalogController)
 
-  class Builder
-    def initialize(item_id, limit)
-      @item_id = item_id
-      @limit = limit
-    end
-
-    def reverse_merge(extra)
-      extra.merge(q: "bound_with_parent_item_ids_ssim:#{@item_id}", facet: false, rows: @limit)
-    end
+  configure_blacklight do |config|
+    config.default_solr_params = { facet: false, rows: 100, qt: 'search' }
+    config.search_state_fields = %i[id item_id]
+    config.facet_fields.clear
   end
 
   def modal
     @id = params.require(:id)
     @item_id = params.require(:item_id)
-    builder = Builder.new(@item_id, 100)
-    search = search_service.repository.search(builder)
-    @bound_with_children = filtered_children(search.docs)
-    @bound_with_parent = @bound_with_children.first.bound_with_parent
+    @response = search_results(@item_id)
+    @bound_with_children = filtered_children(@response.docs)
+    @bound_with_parent = @bound_with_children.first&.bound_with_parent
   end
 
   def index
     @id = params.require(:id)
     @item_id = params.require(:item_id)
-    @limit = params[:limit] ? params[:limit].to_i : 3
-    builder = Builder.new(@item_id, @limit)
-    search = search_service.repository.search(builder)
-    @number_of_results = search.response['numFound']
-    @bound_with_children = filtered_children(search.docs)
-    @bound_with_parent = @bound_with_children.first.bound_with_parent
+    limit = params[:limit] ? params[:limit].to_i : 3
+    @response = search_results(@item_id, limit: limit)
+    @bound_with_children = filtered_children(@response.docs)
+    @bound_with_parent = @bound_with_children.first&.bound_with_parent
+  end
+
+  private
+
+  def search_results(item_id, limit: 100)
+    search_service.search_results do |builder|
+      builder.where(bound_with_parent_item_ids_ssim: item_id).rows(limit)
+    end
   end
 
   def filtered_children(bound_with_children)

--- a/app/controllers/bound_with_children_controller.rb
+++ b/app/controllers/bound_with_children_controller.rb
@@ -37,8 +37,8 @@ class BoundWithChildrenController < ApplicationController
   end
 
   def filtered_children(bound_with_children)
-    @filtered_children = bound_with_children.flat_map do |child|
+    bound_with_children.flat_map do |child|
       child.items.select { |item| item.id == @item_id && !item.bound_with_principal? }
-    end
+    end.sort_by(&:full_shelfkey)
   end
 end

--- a/app/views/bound_with_children/index.html.erb
+++ b/app/views/bound_with_children/index.html.erb
@@ -2,7 +2,7 @@
   <% if @bound_with_children.present? %>
     <div class="bound-with p-2 mt-2">
       <%= render Record::BoundWithChildrenComponent.new(bound_with_children: @bound_with_children, item_id: @item_id, instance_id: @id) %>
-      <% if @number_of_results > @limit %>
+      <% if @response.total_pages > 1 %>
         <%= link_to "See all items bound with #{@bound_with_parent['call_number']}", bound_with_children_modal_solr_document_path(item_id: @item_id), data: { turbo_frame: "blacklight-modal", blacklight_modal: "trigger" }, class: 'btn btn-outline-primary p-1 text-left' %>
       <% end %>
     <% end %>


### PR DESCRIPTION
With the stub search builder, we're bypassing some of the things blacklight will do for us (including properly quoting and escaping the item id value, setting the `qt`, etc). If we ever decide to paginate the long bound-with lists, we'll be able to use the default machinery too.