### PR TITLE
don't display filter bullet when no filters

### DIFF
--- a/app/components/search_result/no_result/filters_component.rb
+++ b/app/components/search_result/no_result/filters_component.rb
@@ -3,7 +3,9 @@
 module SearchResult
   module NoResult
     class FiltersComponent < Blacklight::ConstraintsComponent
-      def query_constraints; end
+      def render?
+        !(@search_state.filters.blank? && @search_state.clause_params.blank?)
+      end
     end
   end
 end

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -4,9 +4,12 @@
     <div class="border-before">
       <h2 class="ps-3"><%= t 'blacklight.search.zero_results.modify_your_search', search_type: search_type_name %></h2>
       <ul>
-        <li>Remove filters <%= link_to 'Clear all', search_action_path(q: params[:q]), class: "text-primary ms-2" %>
-          <%= render SearchResult::NoResult::FiltersComponent.new(search_state:) %>
-        </li>
+        <% filters = SearchResult::NoResult::FiltersComponent.new(search_state:) %>
+        <% if filters.render? %>
+          <li>Remove filters <%= link_to 'Clear all', search_action_path(q: params[:q]), class: "text-primary ms-2" %>
+            <%= render filters %>
+          </li>
+        <% end %>
         <li>Check spelling.</li>
         <li>Use fewer keywords or try different keywords that are broader in meaning.</li>
         <% if from_advanced_search? %>


### PR DESCRIPTION
closes #4906 

Before:
![](https://private-user-images.githubusercontent.com/6816624/442156285-4fe74838-e1c2-4bc7-86f3-e6a0592af484.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDY4MDYyMDEsIm5iZiI6MTc0NjgwNTkwMSwicGF0aCI6Ii82ODE2NjI0LzQ0MjE1NjI4NS00ZmU3NDgzOC1lMWMyLTRiYzctODZmMy1lNmEwNTkyYWY0ODQucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDUwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA1MDlUMTU1MTQxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NWJiZTYyMGMyNGEyODU0MmNlMzczYTc3ZGZlNGU5OGViYjYyZDViZTI2MDY4YTBkZGFhNzQ2NGMxMjIzMzk3MyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.wCxQSWaqhRymf_UNk4RcRFY2PRZ2aEX8tP1NMQB-BjE)

After:
![Screenshot 2025-05-09 at 11 51 08 AM](https://github.com/user-attachments/assets/bdc8557c-7db4-402e-8766-91df67db6bdc)
