### PR TITLE
Remove special handling for Education (at SAL1&2)

### DIFF
--- a/app/controllers/concerns/location_facet.rb
+++ b/app/controllers/concerns/location_facet.rb
@@ -3,9 +3,7 @@
 ##
 # A mixin to add dynamic libary specific location facet support
 module LocationFacet
-  SUBLOCATION_LIBRARIES = ['Art & Architecture (Bowes)',
-                           'Education (at SAL1&2)',
-                           'Education (Cubberley)'].freeze
+  SUBLOCATION_LIBRARIES = ['Art & Architecture (Bowes)', 'Education (Cubberley)'].freeze
 
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
This value is no longer used

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
