### PR TITLE
Show the StanfordOnlySpanComonent on Article results

### DIFF
--- a/app/presenters/article_fulltext_link_presenter.rb
+++ b/app/presenters/article_fulltext_link_presenter.rb
@@ -20,12 +20,21 @@ class ArticleFulltextLinkPresenter
 
   attr_reader :document, :context
 
+  delegate :request, to: :context
+  delegate :format, to: :request
+  delegate :html?, to: :format
+
   def online_label
     "<span class='online-label'>Full text</span>"
   end
 
   def stanford_only_icon
-    "<span class='stanford-only'></span>"
+    if html?
+      context.render StanfordOnlySpanComponent.new
+    else
+      # JSON result for bento
+      "<span class='stanford-only'></span>"
+    end
   end
 
   def online_access_panel?

--- a/app/views/articles/index.json.jbuilder
+++ b/app/views/articles/index.json.jbuilder
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+# This is consumed by Bento
 docs = @presenter.documents.collect do |document|
-  link = ArticleFulltextLinkPresenter.new(document:, context: self).links.try(:first) # top priority one only
+  link = ArticleFulltextLinkPresenter.new(document:, context: self).links.first # top priority one only
   composed_title = document['eds_composed_title']
   data = document.to_h # avoids deprecation warning
   data['fulltext_link_html'] = link if link.present?

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Overridden from Blacklight to inject content into documents
+# This is consumed by Bento
 json.response do
   json.docs augment_solr_document_json_response(@presenter.documents)
   json.facets do


### PR DESCRIPTION
Fixes #4923

Before:
<img width="296" alt="Screenshot 2025-05-13 at 10 37 46 AM" src="https://github.com/user-attachments/assets/7a5cb87b-4dd5-4f50-83df-64222fe0120b" />

After
<img width="309" alt="Screenshot 2025-05-13 at 10 37 34 AM" src="https://github.com/user-attachments/assets/5233abc8-f8ad-40fc-9280-7c3a51428900" />



<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
