### PR TITLE
Stop using .navbar-dark

### DIFF
--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -47,10 +47,6 @@ $gray-light: #737373;
 // Alerts
 $alert-link-font-weight: 500;
 
-// Navbar
-$navbar-dark-color: $white;
-$navbar-dark-toggler-border-color: transparent;
-
 // Pagination
 $pagination-color: black;
 $pagination-hover-color: black;

--- a/app/assets/stylesheets/modules/record-toolbar.scss
+++ b/app/assets/stylesheets/modules/record-toolbar.scss
@@ -1,8 +1,11 @@
 .record-toolbar {
+  --bs-navbar-color: white;
+  --bs-navbar-toggler-border-color: transparent;
   font-size: 15px;
 
   .navbar-nav > li {
-    div.toggle-bookmark, .btn-sul-toolbar {
+    div.toggle-bookmark,
+    .btn-sul-toolbar {
       padding-bottom: 0.5rem;
       padding-top: 0.5rem;
     }
@@ -48,5 +51,4 @@
       }
     }
   }
-
 }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -6,6 +6,11 @@
   box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.2);
   color: $white;
 
+  #search-subnavbar {
+    --bs-navbar-color: white;
+    --bs-navbar-toggler-border-color: transparent;
+  }
+
   .navbar-collapse {
     padding: 0;
   }

--- a/app/components/record_toolbar_component.html.erb
+++ b/app/components/record_toolbar_component.html.erb
@@ -1,4 +1,4 @@
-<div class="record-toolbar sul-toolbar navbar navbar-expand-md navbar-dark px-3 my-4" role="navigation">
+<div class="record-toolbar sul-toolbar navbar navbar-expand-md px-3 my-4" role="navigation">
   <div>
     <%= helpers.link_back_to_catalog class: 'btn btn-link btn-sul-toolbar back-to-results', label: t('blacklight.back_to_search').html_safe %>
     <%= render ToolbarSearchContextInfoComponent.new(search_context: @search_context, search_session: search_session, current_document: document) %>

--- a/app/views/shared/_search_subnavbar.html.erb
+++ b/app/views/shared/_search_subnavbar.html.erb
@@ -1,5 +1,5 @@
 <div id="search-subnavbar-container">
-  <nav id="search-subnavbar" class="navbar navbar-dark navbar-expand-md" aria-label="<%= t('searchworks.navigation.search_sub_bar') %>">
+  <nav id="search-subnavbar" class="navbar navbar-expand-md" aria-label="<%= t('searchworks.navigation.search_sub_bar') %>">
     <button type="button" class="navbar-toggler pull-left" data-bs-toggle="collapse" data-bs-target="#search-subnavbar-collapse">
       <span class="visually-hidden">Toggle navigation</span>
       <span class="fa fa-bars"></span>


### PR DESCRIPTION
It is deprecated in Bootstrap https://getbootstrap.com/docs/5.3/migration/\#color-modes-1

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
