### PR TITLE
Search additional fields for call number search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -362,9 +362,9 @@ class CatalogController < ApplicationController
       field.label = "Call number"
       field.include_in_advanced_search = false
       field.advanced_parse = false
-      field.solr_parameters = { defType: 'lucene' }
-      field.solr_local_parameters = {
-        df: 'callnum_search'
+      field.solr_parameters = {
+        qf: 'callnum_search alphanum_callnum_search spec_callnum_search sudoc_callnum_search undoc_callnum_search',
+        pf: 'callnum_search alphanum_callnum_search spec_callnum_search sudoc_callnum_search undoc_callnum_search'
       }
     end
 

--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -205,6 +205,10 @@
     <!-- Item Info Fields (derived from 999) -->
     <!-- Call Number Fields -->
     <field name="callnum_search" type="callnum_ws" indexed="true" stored="true" multiValued="true"/>
+    <field name="alphanum_callnum_search" type="callnumAlphanum" indexed="true" stored="true" multiValued="true"/>
+    <field name="spec_callnum_search" type="callnumSpec" indexed="true" stored="true" multiValued="true"/>
+    <field name="sudoc_callnum_search" type="callnumSudoc" indexed="true" stored="true" multiValued="true"/>
+    <field name="undoc_callnum_search" type="callnumUndoc" indexed="true" stored="true" multiValued="true"/>
 
     <!-- for nearby on shelf:  term lookups to get next X alpha sorted terms -->
     <field name="shelfkey" type="alphaSort" indexed="true" stored="true" multiValued="true" />
@@ -747,6 +751,67 @@
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(\S{1})" replacement="yyyy$1"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
 	      <filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- field designed for ALPHANUM (and CALDOC) call number searching -->
+    <fieldType name="callnumAlphanum" class="solr.TextField" omitNorms="true" omitTermFreqAndPositions="true">
+      <analyzer>
+        <!-- Remove space between the first two terms, we want two or more terms to match -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^(\w+)\s+(\w+)" replacement="$1$2"/>
+        <!-- Replace punctuation with a space -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{Punct}])" replacement=" "/>
+        <!-- Normalize whitespace -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s{2,}" replacement=" "/>
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter=" " />
+	<filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- field designed for SPEC call number searching -->
+    <fieldType name="callnumSpec" class="solr.TextField" omitNorms="true" omitTermFreqAndPositions="true">
+      <analyzer>
+        <!-- Normalize whitespace -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s{2,}" replacement=" "/>
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter=" " />
+	<filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- field designed for SUDOC call number searching -->
+    <fieldType name="callnumSudoc" class="solr.TextField" omitNorms="true" omitTermFreqAndPositions="true">
+      <analyzer>
+        <!-- Remove space between letters and numbers -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([A-Za-z])\s+?(\d)" replacement="$1$2"/>
+        <!-- Replace punctuation with a space -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{Punct}])" replacement=" "/>
+        <!-- Normalize whitespace -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s{2,}" replacement=" "/>
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter=" " />
+	<filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <fieldType name="callnumUndoc" class="solr.TextField" omitNorms="true" omitTermFreqAndPositions="true">
+      <analyzer>
+        <!-- Normalize punctuation (except /) to a space -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory"
+                    pattern="([!\#$%&amp;'()*+,\-.:;&lt;=&gt;?@\[\\\]^_`{|}~])"
+                    replacement=" "/>
+        <!-- Normalize whitespace -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s{2,}" replacement=" "/>
+        <!-- Remove whitespace after a slash -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="/\s+" replacement="/"/>
+        <!-- Remove whitespace before a slash -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+/" replacement="/"/>
+        <!-- Remove trailing whitespace -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+$" replacement=""/>
+        <!-- Remove the first slash in the string, to require at least two leading terms to match -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([^/]*)/(.*)$" replacement="$1$2"/>
+        <!-- Add a slash after the first term if there are no slashes at all (some UNDOCs like ICAO are abbreviated, e.g., ICAO DOC 9161) -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([^\s/]+?)\s+([^/]+)$" replacement="$1/$2"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
       </analyzer>
     </fieldType>
 

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -293,7 +293,7 @@
         isbn_search^1.6
         issn_search^1.6
         id_search
-        callnum_search
+        callnum_search alphanum_callnum_search spec_callnum_search sudoc_callnum_search undoc_callnum_search
         druid
         oclc
         item_barcodes_search
@@ -365,7 +365,7 @@
         pub_date_search^2
         isbn_search^1.6
         issn_search^1.6
-        callnum_search
+        callnum_search alphanum_callnum_search spec_callnum_search sudoc_callnum_search undoc_callnum_search
         id_search
         druid
         oclc
@@ -437,7 +437,7 @@
         bib_search^7
         pub_date_search^10
         issn_search^7.5
-        callnum_search^7
+        callnum_search^7 alphanum_callnum_search^7 spec_callnum_search^7 sudoc_callnum_search^7 undoc_callnum_search^7
         physical^5                     vern_physical^5
         award_search^5
         collection_search^5

--- a/spec/features/callnum_search_spec.rb
+++ b/spec/features/callnum_search_spec.rb
@@ -42,4 +42,118 @@ RSpec.describe 'Call num search', :js do
       expect(page).to have_css('h1', text: object_title)
     end
   end
+
+  context 'with SUDOC call numbers' do
+    it 'matches the full call number even with whitespace differences' do
+      visit search_catalog_path
+      fill_in 'q', with: 'Y4 .AP 6/2:S.HRG.98-413'
+      select 'Call number', from: 'search_field'
+      click_button 'search'
+      expect(page).to have_text 'An object'
+    end
+
+    it 'matches leading terms of the call number' do
+      visit search_catalog_path
+      fill_in 'q', with: 'Y4.AP'
+      select 'Call number', from: 'search_field'
+      click_button 'search'
+      expect(page).to have_text 'An object'
+    end
+  end
+
+  context 'with ALPHANUM call numbers' do
+    context 'when the item is from SPEC' do
+      it 'matches exact call numbers' do
+        visit search_catalog_path
+        fill_in 'q', with: 'SC1003A BOX 1'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'An object'
+      end
+
+      it 'matches full call number terms' do
+        visit search_catalog_path
+        fill_in 'q', with: 'SC1003A'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'An object'
+      end
+
+      it 'does not match a partial call number term' do
+        visit search_catalog_path
+        fill_in 'q', with: 'SC1003'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'No results found'
+      end
+    end
+
+    context 'when the item is not from SPEC' do
+      it 'matches searches with at least the first two terms' do
+        visit search_catalog_path
+        fill_in 'q', with: 'ZVC 12345'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'An object'
+      end
+
+      it 'does not match a search with only the first term' do
+        visit search_catalog_path
+        fill_in 'q', with: 'ZVC'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'No results found'
+      end
+
+      it 'matches call numbers that look like ETDs' do
+        visit search_catalog_path
+        fill_in 'q', with: '3781 2009 K'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'An object'
+      end
+
+      it 'matches call numbers that look like CalDocs' do
+        visit search_catalog_path
+        fill_in 'q', with: 'CALIF E3000  S26 L3 2025'
+        select 'Call number', from: 'search_field'
+        click_button 'search'
+        expect(page).to have_text 'An object'
+      end
+    end
+  end
+
+  context 'with UNDOC call numbers' do
+    it 'matches the full call number even with whitespace differences' do
+      visit search_catalog_path
+      fill_in 'q', with: 'E/ ESCWA/ED/SER. Z/2/2005/2006-2007/2008'
+      select 'Call number', from: 'search_field'
+      click_button 'search'
+      expect(page).to have_text 'An object'
+    end
+
+    it 'matches leading terms of the call number' do
+      visit search_catalog_path
+      fill_in 'q', with: 'E/ESCWA'
+      select 'Call number', from: 'search_field'
+      click_button 'search'
+      expect(page).to have_text 'An object'
+    end
+
+    it 'matches call numbers without slashes' do
+      visit search_catalog_path
+      fill_in 'q', with: 'ICAO'
+      select 'Call number', from: 'search_field'
+      click_button 'search'
+      expect(page).to have_text 'An object'
+    end
+
+    it 'does not match only one leading term prior to a slash' do
+      visit search_catalog_path
+      fill_in 'q', with: 'E'
+      select 'Call number', from: 'search_field'
+      click_button 'search'
+      expect(page).to have_text 'No results found'
+    end
+  end
 end

--- a/spec/fixtures/solr_documents/1.yml
+++ b/spec/fixtures/solr_documents/1.yml
@@ -13,6 +13,16 @@ marc_json_struct: |
 <%= simple_856 %>
 pub_date: 2014
 callnum_search: G70.212 .A426 2011:test
+alphanum_callnum_search:
+  - ZVC 12345
+  - 3781 2009 K
+  - 3781 S78 M
+  - CALIF E3000.S26 L3 2025
+spec_callnum_search: SC1003A BOX 1
+sudoc_callnum_search: Y 4.AP 6/2:S.HRG.98-413
+undoc_callnum_search:
+  - E/ESCWA /ED/SER.Z/2/2005/2006-2007/2008
+  - ICAO DOC 8071 V.2
 pub_year_tisim: 2014
 beginning_year_isi: 2000
 imprint_display: 1990


### PR DESCRIPTION
SearchWorks side of https://github.com/sul-dlss/searchworks_traject_indexer/issues/1620

The fields are already in solr and indexed via: https://github.com/sul-dlss/searchworks_traject_indexer/pull/1626. The impactful change here is the call number search config modification.
