### PR TITLE
don't allow call number browser ribbon to initialize twice

### DIFF
--- a/app/javascript/embedded-call-number-browse.js
+++ b/app/javascript/embedded-call-number-browse.js
@@ -143,5 +143,7 @@ import PreviewContent from './preview-content'
 
 
 Blacklight.onLoad(function() {
+  if ($('*[data-behavior="embed-browse"]').hasClass('active')) return;
+
   $('*[data-behavior="embed-browse"]').embedBrowse();
 });


### PR DESCRIPTION
closes #4942 

We probably still want to convert this to a stimulus controller but this is a quick patch that will fix the issue for now.