### PR TITLE
Also guard against solr documents without #to_marc (e.g. SDR MODS documents)

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -64,7 +64,7 @@ class Citation
   end
 
   def citations_from_marc
-    return unless Settings.citeproc_citations.enabled && document.to_marc && citeproc_item
+    return unless Settings.citeproc_citations.enabled && document.respond_to?(:to_marc) && document.to_marc && citeproc_item
 
     @citations_from_marc ||= Citations::MarcCitation.new(citeproc_item:).all_citations
   end


### PR DESCRIPTION
I'm not sure I'm loving `SolrDocument` sometimes responding to `to_marc` and sometimes not... `#to_marc` just returning `nil` seems like it'd be better 🤷‍♂️ 