### PR TITLE
Enable citeproc citations by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,7 +81,7 @@ folio:
 live_lookup_service: LiveLookup::Folio
 
 citeproc_citations:
-  enabled: false
+  enabled: true
 
 oclc_discovery:
   citations:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,6 +9,3 @@ LIB_GUIDES:
   MINI_BENTO_ENABLED: true
 
 live_lookup_service: LiveLookup::Testing
-
-citeproc_citations:
-  enabled: true


### PR DESCRIPTION
Currently explicitly disabled in -prod:
https://github.com/sul-dlss/shared_configs/pull/2343