### PR TITLE
Add the full page links in the backend

### DIFF
--- a/app/javascript/embedded-call-number-browse.js
+++ b/app/javascript/embedded-call-number-browse.js
@@ -58,14 +58,6 @@ import PreviewContent from './preview-content'
         .querySelector(`.gallery-document[data-doc-id="${this.currentDoc}"]`)
     };
 
-    // Add the first and last item in the list, that goes to full page browse
-    GalleryDocs.prototype.addBrowseLinkDivs = function() {
-      let html = `<div class="gallery-document"><div class="browse-link">` +
-                 `<a href="${this.browseUrl}" class="text-center"> Continue to full page</a></div></div>`
-      this.embedContainer.append(html);
-      this.embedContainer.prepend(html);
-    }
-
     return this.each(function() {
       var $item = $(this)
       const $galleryDoc = new GalleryDocs($item)
@@ -84,7 +76,6 @@ import PreviewContent from './preview-content'
           PreviewContent.append($galleryDoc.url, $galleryDoc.embedContainer)
             .done(function (data) {
               reorderPreviewElements();
-              $galleryDoc.addBrowseLinkDivs();
               scrollOver($galleryDoc.currentDocumentTarget(), $galleryDoc.galleryTarget)
             })
         }

--- a/app/views/catalog/_document_gallery.html.erb
+++ b/app/views/catalog/_document_gallery.html.erb
@@ -3,7 +3,25 @@
 
 <% # container for all documents in index view -%>
 <% if params[:controller] == "browse" && params[:action] == "nearby" %>
+  <div class="gallery-document">
+    <div class="browse-link">
+      <%= link_to 'Continue to full page', browse_index_path(
+        start: params[:start],
+        call_number: params[:call_number],
+        view: :gallery
+      ), class: 'text-center' %>
+    </div>
+  </div>
   <%= render view_config.document_component.with_collection(document_presenters, partials: view_config.partials, counter_offset: @response&.start || 0) %>
+  <div class="gallery-document">
+    <div class="browse-link">
+      <%= link_to 'Continue to full page', browse_index_path(
+        start: params[:start],
+        call_number: params[:call_number],
+        view: :gallery
+      ), class: 'text-center' %>
+    </div>
+  </div>
 <% elsif %>
   <% # container for all documents in brief index view -%>
   <div id="documents" class="row gallery">


### PR DESCRIPTION
Since, we're adding HTML to the page which was generated by the backend, we may as well be consistent and not have the front end also generate some of the HTML.