### PR TITLE
Remove unnecessary function

### DIFF
--- a/app/javascript/controllers/preview_brief_controller.js
+++ b/app/javascript/controllers/preview_brief_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import PreviewContent from '../preview-content'
 
+// Shows previews on the brief results view
 export default class extends Controller {
   static values = {
     url: String
@@ -10,14 +11,9 @@ export default class extends Controller {
 
   showPreview() {
     this.previewTarget.classList.add('preview')
-    this.appendPointer()
     PreviewContent.append(this.urlValue, $(this.previewTarget));
     this.showButtonTarget.hidden = true
     this.hideButtonTarget.hidden = false
-  }
-
-  appendPointer() {
-    this.previewTarget.innerHTML = '<div class="preview-arrow"></div>'
   }
 
   closePreview() {


### PR DESCRIPTION
The arrow is already present on the markup in the backend

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
