### PR TITLE
fix mini bento close button on safari

### DIFF
--- a/app/components/search_result/mini_bento/layout_component.html.erb
+++ b/app/components/search_result/mini_bento/layout_component.html.erb
@@ -1,10 +1,10 @@
 <div class='alternate-catalog' data-alternate-catalog="<%= url %>">
-  <% if close? %>
-    <button type='button' class='alternate-catalog-close btn-close close' aria-label="Close">
-    </button>
-  <% end %>
   <div class="row">
     <h3 class="alternate-catalog-title col"></h3>
+    <% if close? %>
+      <button type='button' class='alternate-catalog-close btn-close close col-2 me-2' aria-label="Close">
+      </button>
+    <% end %>
   </div>
   <div class="alternate-catalog-body row d-none">
     <div class="col-md-5">


### PR DESCRIPTION
closes #5003 

Mobile in Firefox
<img width="458" alt="Screenshot 2025-05-22 at 3 32 42 PM" src="https://github.com/user-attachments/assets/c72026f2-6f40-4795-ad53-bafbf0b3220d" />


In safari
<img width="643" alt="Screenshot 2025-05-22 at 3 43 23 PM" src="https://github.com/user-attachments/assets/ec070318-bb27-4f41-ba63-0b22e2925177" />
