### PR TITLE
Deploy release branch instead of main

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - release
 
 jobs:
   tests:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
       }
 
       when {
-        branch 'main'
+        branch 'release'
       }
 
       steps {
@@ -234,11 +234,11 @@ pipeline {
     stage('folio-dev deploy') {
       environment {
         DEPLOY_ENVIRONMENT = 'preview_folio'
-        BRANCH = 'main'
+        BRANCH = 'release'
       }
 
       when {
-        branch 'main'
+        branch 'release'
       }
 
       steps {
@@ -276,7 +276,7 @@ pipeline {
       }
     }
 
-    stage('Prod deploy (on release)') {
+    stage('Prod deploy (on tagged release)') {
       environment {
         DEPLOY_ENVIRONMENT = 'prod'
       }

--- a/Jenkinsfile-Folio-Update
+++ b/Jenkinsfile-Folio-Update
@@ -33,7 +33,7 @@ pipeline {
           git add config/folio
           git commit -m "Update FOLIO types" &&
           git push git@github.com:sul-dlss/SearchWorks.git folio-policies-update-prod &&
-          hub pull-request -f -m "Update FOLIO types" --base main
+          hub pull-request -f -m "Update FOLIO types" --base release
           echo 'Done!'
           '''
         }
@@ -67,7 +67,7 @@ pipeline {
           git add config/folio
           git commit -m "Update FOLIO types" &&
           git push git@github.com:sul-dlss/SearchWorks.git folio-policies-update-test &&
-          hub pull-request -f -m "Update FOLIO types" --base main
+          hub pull-request -f -m "Update FOLIO types" --base release
           echo 'Done!'
           '''
         }

--- a/Jenkinsfile-Lane-Update
+++ b/Jenkinsfile-Lane-Update
@@ -25,7 +25,7 @@ pipeline {
           git add config/ezproxy/lane_proxy_file.txt
           git commit -m "Update Lane Library EZProxy config" &&
           git push git@github.com:sul-dlss/SearchWorks.git lane-ezproxy-update &&
-          hub pull-request -f -m "Update Lane Library EZProxy config" --base main
+          hub pull-request -f -m "Update Lane Library EZProxy config" --base release
           echo 'Done!'
           '''
         }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,9 +3,9 @@
 set :application, 'SearchWorks'
 set :repo_url, 'https://github.com/sul-dlss/SearchWorks.git'
 
-# Default branch is :master so we need to update to main
+# Default branch is :master so we need to update to release
 if ENV['DEPLOY']
-  set :branch, ENV.fetch('BRANCH', 'main')
+  set :branch, ENV.fetch('BRANCH', 'release')
 else
   ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 end


### PR DESCRIPTION
Fixes #5057
Fixes #5058

We need to remember to cut our release tags on the `release` branch rather than `main`.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
