### PR TITLE
Add basic page level accessibility testing with axe-core-spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :deployment do
 end
 
 group :development, :test do
+  gem "axe-core-rspec"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'capybara', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,19 @@ GEM
     airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.3)
+    axe-core-api (4.10.3)
+      dumb_delegator
+      ostruct
+      virtus
+    axe-core-rspec (4.10.3)
+      axe-core-api (= 4.10.3)
+      dumb_delegator
+      ostruct
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.3.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -173,6 +186,8 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 1.6)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.5)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -199,6 +214,8 @@ GEM
     deep_merge (1.2.2)
     deprecation (1.1.0)
       activesupport
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -222,6 +239,7 @@ GEM
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
     drb (2.2.3)
+    dumb_delegator (1.1.0)
     ebsco-eds (1.1.7)
       activesupport (>= 5.2)
       bibtex-ruby (>= 5.1.0, < 7.0)
@@ -278,6 +296,7 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -606,6 +625,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.7)
     thor (1.3.2)
+    thread_safe (0.3.6)
     time (0.4.1)
       date
     timeout (0.4.3)
@@ -637,6 +657,10 @@ GEM
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -671,6 +695,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  axe-core-rspec
   blacklight (~> 9.0.0.beta1)
   blacklight-hierarchy (~> 6.0)
   blacklight-marc (~> 8.0)

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Site Accessibility', :js do
+  it 'has an accessible home page, including the header and footer' do
+    visit root_path
+    expect(page).to be_accessible
+  end
+
+  context 'with the catalog', skip: "Pending SearchWorks 4.0 designs" do
+    before { stub_article_service(docs: StubArticleService::SAMPLE_RESULTS) }
+
+    it 'has an accessible index page' do
+      visit search_catalog_path
+      expect(page).to be_accessible.within('main')
+    end
+
+    it 'has an accessible search results page' do
+      visit search_catalog_path f: { access_facet: ['Online'] }
+      expect(page).to be_accessible.within('main')
+    end
+
+    it 'has an accessible zero results page' do
+      visit search_catalog_path(q: 'sdfsda', search_field: 'search_author')
+      expect(page).to be_accessible.within('main')
+    end
+  end
+
+  context 'with articles', skip: "Pending SearchWorks 4.0 designs" do
+    before { stub_article_service(docs: StubArticleService::SAMPLE_RESULTS) }
+
+    it 'has an accessible index page' do
+      visit articles_path
+      expect(page).to be_accessible.within('main')
+    end
+
+    it 'has an accessible search results page' do
+      visit articles_path q: 'frog'
+      expect(page).to be_accessible.within('main')
+    end
+
+    it 'has an accessible "more facets" modal' do
+      visit articles_path q: 'frog'
+      click_button 'Language'
+      within '.blacklight-eds_language_facet' do
+        click_link 'more'
+      end
+      expect(page).to have_field 'A-Z Sort'
+      expect(page).to be_accessible.within('dialog')
+    end
+
+    it 'has an accessible zero results page' do
+      visit articles_path(q: 'Kittens', f: { 'eds_subject_topic_facet' => ['Abc'] }, search_field: 'search')
+      expect(page).to be_accessible.within('main')
+    end
+  end
+
+  context 'with a record', skip: "Pending SearchWorks 4.0 designs" do
+    it 'has an accessible view' do
+      visit solr_document_path('28')
+      expect(page).to be_accessible.within('main')
+    end
+
+    it 'has an accessible view with filmstrips' do
+      visit solr_document_path('34')
+      expect(page).to be_accessible.within('main')
+    end
+  end
+
+  it 'has an accessible bookmarks page', skip: "Pending SearchWorks 4.0 designs" do
+    visit bookmarks_path
+    expect(page).to be_accessible.within('main')
+  end
+
+  it 'has an accessible selections page', skip: "Pending SearchWorks 4.0 designs" do
+    visit '/selections'
+    expect(page).to be_accessible.within('main')
+  end
+
+  it 'has an accessible advanced search page', skip: "Pending SearchWorks 4.0 designs" do
+    visit blacklight_advanced_search_engine.advanced_search_path
+    expect(page).to be_accessible.within('main')
+  end
+
+  it 'has an accessible course reserves page', skip: "Pending SearchWorks 4.0 designs" do
+    before do
+      create(:reg_course)
+      visit course_reserves_path
+    end
+
+    expect(page).to be_accessible.within('main')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'selenium-webdriver'
 require 'webmock/rspec'
+require 'axe-rspec'
 
 WebMock.disable_net_connect!(allow_localhost: true, allow: [
   'eds-api.ebscohost.com',

--- a/spec/support/accessibility_helpers.rb
+++ b/spec/support/accessibility_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AccessibilityHelpers
+  # An alias so our tests are less coupled to the aXe implementation
+  def be_accessible(...)
+    be_axe_clean(...).according_to(
+      :'best-practice',
+      :wcag2a,
+      :wcag2aa,
+      :wcag21a,
+      :wcag21aa
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include AccessibilityHelpers, type: :feature
+end


### PR DESCRIPTION
A start for #5056

Rule descriptions are found [here](https://github.com/dequelabs/axe-core/blob/f49c1c49b5eafe1f8065e07c314f75968dd91333/doc/rule-descriptions.md#best-practices-rules).