### PR TITLE
Remove the extra halo around the Stanford-only button

### DIFF
--- a/app/assets/stylesheets/modules/availability-icons.scss
+++ b/app/assets/stylesheets/modules/availability-icons.scss
@@ -2,6 +2,8 @@ $available-color: green;
 $noncirc-color: darkorange;
 
 .stanford-only {
+  --bs-btn-focus-box-shadow: 192, 12, 12;
+
   height: 1rem;
   margin-left: 0.5rem;
   padding: 0;

--- a/app/components/stanford_only_popover_component.rb
+++ b/app/components/stanford_only_popover_component.rb
@@ -2,7 +2,7 @@
 
 class StanfordOnlyPopoverComponent < ViewComponent::Base
   def call
-    tag.button(class: 'stanford-only btn btn-primary',
+    tag.button(class: 'stanford-only btn',
                data: { 'bs-toggle': 'popover', 'bs-placement': 'right', 'bs-content': 'Available to Stanford-affiliated users only. Log in to access.' },
                aria: { label: 'Stanford-only' }) do
       render StanfordOnlyIconComponent.new


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
before
<img width="203" alt="Screenshot 2025-06-04 at 1 18 53 PM" src="https://github.com/user-attachments/assets/63c68084-3e83-448f-881d-2e2fd1d7e7bb" />

after
<img width="205" alt="Screenshot 2025-06-04 at 1 18 37 PM" src="https://github.com/user-attachments/assets/ece6c6a8-aa27-4028-a87a-c732a40fdb59" />
