### PR TITLE
Restore button hover color for sul-toolbar

### DIFF
--- a/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
+++ b/app/assets/stylesheets/modules/sort-and-per-page-toolbar.scss
@@ -1,3 +1,11 @@
+.page_links .btn-sul-toolbar {
+  --bs-btn-hover-bg: #{$sul-toolbar-bg};
+
+  &:hover {
+    text-decoration: var(--link-hover-decoration-line) var(--link-hover-decoration-style);
+  }
+}
+
 .sul-toolbar.sort-and-per-page { 
   padding: 4px 0;
   margin-top: .8em;


### PR DESCRIPTION
Closes #5066 (after backport to `release`)

This is what it was in a recent "working" release:
<img width="65" alt="Screenshot 2025-06-05 at 4 16 31 PM" src="https://github.com/user-attachments/assets/7f929059-1e9a-4f95-8cbd-5e2d26b9fa07" />

Now:
<img width="68" alt="Screenshot 2025-06-05 at 4 29 28 PM" src="https://github.com/user-attachments/assets/1872280b-f907-4828-a00e-32d7104d4edb" />

This also impacts the same controls that are present at the top of the catalog results page.