### PR TITLE
Remove custom external link tracking event

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -37,17 +37,6 @@ Blacklight.onLoad(function() {
     })
   })
 
-  // Track external link clicks
-  document.querySelectorAll('a[href*="://"]').forEach(function(el) {
-    el.addEventListener('click', function(e) {
-      sendAnalyticsEvent({
-        category: 'External link',
-        action: 'SW/clicked',
-        label: this.href
-      })
-    })
-  })
-
   // Track an action when the user clicks on an accordion
   document.querySelectorAll('[data-action="accordion-section#toggle"]').forEach(function (el) {
     el.addEventListener('click', function (e) {


### PR DESCRIPTION
Part of #5085.

If the category name of this custom event, "External link", is accurate I don't believe we need this. GA4 tracks this natively.

See: https://support.google.com/analytics/answer/13566436?hl=en&ref_topic=13367860#zippy=%2Cin-this-article

We have "Outbound clicks" enabled in Enhanced measurement:
<img width="808" alt="Screenshot 2025-06-10 at 5 08 47 PM" src="https://github.com/user-attachments/assets/f52d374b-4a84-46e6-bde0-dbc2be11652b" />

The outgoing links dimensions can be accessed in explorations reports:
<img width="456" alt="Screenshot 2025-06-10 at 5 23 04 PM" src="https://github.com/user-attachments/assets/cffb57ac-1376-4e66-8908-33a0c5d3242a" />

We *do* currently get counts for `SW/clicked`, so this would be an inflection point, although we should have outgoing link data from GA4 for as long as we've had the tracking enabled.

<img width="224" alt="Screenshot 2025-06-10 at 5 34 37 PM" src="https://github.com/user-attachments/assets/f8268341-266b-49f2-9936-fe684c6d5b9a" />

I don't think `SW/clicked` is very useful as we're using the same event name for other click events, depending on the `event_category` parameter to disambiguate. My understanding is that we should use the common parameters where possible and split these overlapping events into their own custom events.
