### PR TITLE
Add `blacklight-search-storage` meta tag from upstream

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:head) do %>
+  <meta name="blacklight-search-storage" content="<%= blacklight_config.track_search_session.storage %>">
+<% end %>
+
 <% if has_search_parameters? %>
   <%= render_masthead_partial %>
   <%= render partial: "search_results" %>


### PR DESCRIPTION
I'm not sure what this does, but it's present in the upstream partial and maybe we want/need it?