### PR TITLE
Remove custom IIIF link click tracking

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -18,16 +18,6 @@ Blacklight.onLoad(function() {
 
   // Track engagement with IIIF icon
   document.querySelectorAll('.iiif-dnd').forEach(function(el) {
-    el.addEventListener('click', function(e) {
-      sendAnalyticsEvent({
-        category: 'IIIF DnD',
-        action: 'SW/clicked',
-        label: (e.currentTarget).data().manifest
-      })
-    })
-  })
-
-  document.querySelectorAll('.iiif-dnd').forEach(function(el) {
     el.addEventListener('dragstart', function(e) {
       sendAnalyticsEvent({
         category: 'IIIF DnD',


### PR DESCRIPTION
Part of #5085.

External link clicks are tracked by default in GA4.

<img width="224" alt="Screenshot 2025-06-11 at 9 38 19 AM" src="https://github.com/user-attachments/assets/0f62d765-c4ce-49ca-a352-014f80ae9cb6" />


<img width="603" alt="Screenshot 2025-06-11 at 9 37 16 AM" src="https://github.com/user-attachments/assets/b701c9c9-4d17-4df4-9e89-43578882474f" />
