### PR TITLE
Remove the blacklight CSS

### DIFF
--- a/app/assets/stylesheets/searchworks4.scss
+++ b/app/assets/stylesheets/searchworks4.scss
@@ -15,3 +15,7 @@
 @import url("searchworks4/homepage.css");
 @import url("searchworks4/availability-icons.css");
 @import url("modules/chat.css");
+
+#pre-footer {
+  margin-top: 1rem;
+}

--- a/app/assets/stylesheets/searchworks4/blacklight.scss
+++ b/app/assets/stylesheets/searchworks4/blacklight.scss
@@ -1,5 +1,4 @@
 @import "bootstrap/scss/bootstrap.scss";
-@import "blacklight-frontend/app/assets/stylesheets/blacklight/blacklight.scss";
 
 // the default bootstrap font-family list includes "Segoe UI Emoji", which, on windows
 // renders our remove icon as an emoji-sized x instead of what we see on all other platforms...
@@ -20,4 +19,54 @@ $remove-icon-font-family:
   --bl-logo-image: none;
   --bl-logo-width: 250px;
   background-color: black;
+}
+
+.input-group > .search-q {
+  flex-grow: 4;
+}
+
+
+.facet-limit {
+  --bs-accordion-btn-bg: var(--bs-gray-100);
+  --bs-btn-hover-bg: var(--bs-gray-200);
+  --bs-accordion-active-bg: var(--bs-accordion-btn-bg);
+}
+
+.facet-values {
+  --bl-facet-active-item-color: var(--bs-success);
+  --bl-facet-remove-color: var(--bs-secondary-color);
+  --bl-facet-remove-hover-color: var(--bs-danger);
+
+  margin-bottom: 0;
+
+  li {
+    display: flex;
+    justify-content: flex-start;
+    padding: 3px 0;
+
+    .selected {
+      color: var(--bl-facet-active-item-color);
+    }
+  }
+
+  .facet-count {
+    margin-inline-start: auto;
+  }
+
+  .remove {
+    color: var(--bl-facet-remove-color);
+    font-weight: bold;
+    padding-left: $spacer * 0.5;
+    text-decoration: none;
+
+    &:hover {
+      color: var(--bl-facet-remove-hover-color);
+      text-decoration: none;
+    }
+  }
+
+  .facet-label {
+    hyphens: auto;
+    overflow-wrap: break-word;
+  }
 }

--- a/app/assets/stylesheets/searchworks4/facets.css
+++ b/app/assets/stylesheets/searchworks4/facets.css
@@ -1,3 +1,8 @@
+.facet-limit {
+  --bs-accordion-btn-padding-x: 0.5rem;
+  --bs-accordion-body-padding-x: 0.5rem;
+}
+
 .facet-values .sul-icon {
   font-size: 1.5em;
   width: 30px;

--- a/app/assets/stylesheets/searchworks4/facets.css
+++ b/app/assets/stylesheets/searchworks4/facets.css
@@ -1,10 +1,6 @@
 .facet-values .sul-icon {
-  align-items: center;
-  color: $black;
-  display: table-cell;
   font-size: 1.5em;
   width: 30px;
-  vertical-align: middle;
   &::before,
   svg {
     height: 21px;


### PR DESCRIPTION
The blacklight CSS seemingly mostly gives us some facet styling that can be trivially recreated here.

<img width="628" alt="Screenshot 2025-06-11 at 11 08 01" src="https://github.com/user-attachments/assets/4f5caa23-cc8d-48cc-af58-33b9a8637840" />
