### PR TITLE
Remove unnecessary override of Blacklight style

### DIFF
--- a/app/assets/stylesheets/searchworks4/masthead.css
+++ b/app/assets/stylesheets/searchworks4/masthead.css
@@ -1,9 +1,3 @@
-/* Override blacklight 9. We may want to move this to the component library: */
-.navbar-logo {
-  --bl-logo-image: none;
-  --bl-logo-width: 250px;
-  background-color: black;
-}
 .masthead {
   .nav-link {
     --sul-link-font-weight: 600;


### PR DESCRIPTION
We don't need it now that we don't have blacklight

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
