### PR TITLE
Remove the zero results page loaded analytics event

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -70,14 +70,6 @@ Blacklight.onLoad(function() {
     })
   })
 
-  // Just track when a zero results page gets loaded, no need for event handler
-  document.querySelectorAll('.zero-results').forEach(function(el) {
-    sendAnalyticsEvent({
-      category: 'Zero results',
-      action: 'SW/loaded'
-    })
-  });
-
   // Featured resources on home page
   document.querySelectorAll('.catalog-home-page .features a').forEach(function(el) {
     el.addEventListener('click', function(e) {


### PR DESCRIPTION
Part of #5085 

I think in GA4 this could be better explored via page views, rather than a specific event.

<img width="215" alt="Screenshot 2025-06-11 at 3 24 12 PM" src="https://github.com/user-attachments/assets/74393ff9-4bfb-43f6-a45c-c4b0de4e0492" />
<img width="588" alt="Screenshot 2025-06-11 at 3 24 18 PM" src="https://github.com/user-attachments/assets/072782c1-fb84-478a-a9d1-88c40ee5428f" />

https://analytics.google.com/analytics/web/#/analysis/p342534663/edit/PhaoN7HxSlapy2LeEzwgQQ