### PR TITLE
update stanford_only_icon to be a popover

### DIFF
--- a/app/presenters/article_fulltext_link_presenter.rb
+++ b/app/presenters/article_fulltext_link_presenter.rb
@@ -30,7 +30,7 @@ class ArticleFulltextLinkPresenter
 
   def stanford_only_icon
     if html?
-      context.render StanfordOnlySpanComponent.new
+      context.render StanfordOnlyPopoverComponent.new
     else
       # JSON result for bento
       "<span class='stanford-only'></span>"

--- a/spec/presenters/article_fulltext_link_presenter_spec.rb
+++ b/spec/presenters/article_fulltext_link_presenter_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe ArticleFulltextLinkPresenter do
       context 'when format is html' do
         let(:format) { :html }
 
-        it 'includes the svg icon' do
+        it 'includes the svg popover' do
           expect(page).to have_css 'span.online-label', text: 'Full text'
           expect(page).to have_link 'View/download PDF'
-          expect(page).to have_css 'span[aria-label="Stanford-only"] svg'
+          expect(page).to have_css 'button[aria-label="Stanford-only"] svg'
         end
       end
     end


### PR DESCRIPTION
Right now the stanford only icon next to an article is static. It should be a popover

Before:
![Screenshot 2025-06-13 at 2 58 55 PM](https://github.com/user-attachments/assets/04e9ffea-1d39-4ae6-878d-1e953f9eca92)

After:
![Screenshot 2025-06-13 at 2 58 45 PM](https://github.com/user-attachments/assets/ce47ebe6-241a-4035-b592-54c1343ded08)
