### PR TITLE
Fix hompage search bar style

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -16,6 +16,7 @@
         </div>
       </div>
       <%= render HomepageSearchComponent.new url: search_action_url,
+                                             classes: [],
                                              advanced_search_url: search_action_url(action: 'advanced_search'),
                                              params: search_state.params_for_search.except(:qt),
                                              autocomplete_path: suggest_index_catalog_path %>


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before:
<img width="682" alt="Screenshot 2025-06-16 at 10 44 44 AM" src="https://github.com/user-attachments/assets/6aff0d04-bd70-4481-bf0e-7e7f8a0fe381" />

After:
<img width="673" alt="Screenshot 2025-06-16 at 10 47 57 AM" src="https://github.com/user-attachments/assets/6bee5900-fe70-4744-9a8c-f5845172ba55" />