### PR TITLE
fixing bootstrap filename

### DIFF
--- a/app/assets/stylesheets/searchworks4.scss
+++ b/app/assets/stylesheets/searchworks4.scss
@@ -1,7 +1,7 @@
 @layer framework, components, local;
 @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css)
 layer(framework);
-@import url("bootstrap-icons") layer(framework);
+@import url("bootstrap-icons.css") layer(framework);
 @import url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-04-17/styles/sul.css")
 layer(components);
 


### PR DESCRIPTION
The searchworks4.scss file needs to add ".css" to the url for bootstrap icons to allow for this file to be brought in correctly.

Fixes #5175 