### PR TITLE
Tweak home page column borders.

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -40,7 +40,7 @@
       </div>
     </div>
     <div class="col-lg-6 col-xl-8 d-flex flex-column flex-xl-row align-items-baseline">
-      <section class="px-2 py-3 tips w-100">
+      <section class="px-lg-3 py-1 tips">
         <header class="d-flex justify-content-between flex-wrap align-items-center h3"><span class="text-nowrap">Search tips</span>
           <a href="https://guides.library.stanford.edu/searchworks" class="btn btn-sm btn-outline-primary text-nowrap align-self-start">Visit SearchWorks Guide</a>
         </header>
@@ -69,7 +69,7 @@
           </li>
         </ul>
       </section>
-      <section class="px-2 py-3 w-100 features">
+      <section class="px-lg-3 py-xl-1 py-3 features">
         <header class="h3">Featured resources</header>
 
         <ul class="list-unstyled">


### PR DESCRIPTION
At various breakpoints:
lg:
<img width="182" alt="Screenshot 2025-06-20 at 11 00 34" src="https://github.com/user-attachments/assets/bf9b2cf6-4622-43e3-b99b-0b5b78b4c117" />

xl:
<img width="657" alt="Screenshot 2025-06-20 at 11 00 50" src="https://github.com/user-attachments/assets/7a30cb00-d6b8-4dd0-8788-1246be8c1931" />

md:
<img width="182" alt="Screenshot 2025-06-20 at 11 01 37" src="https://github.com/user-attachments/assets/569028ec-5b64-4572-94b7-48efa52bb283" />
