### PR TITLE
update blacklight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/blacklight.git
-  revision: 92db30a265b7d344f83cd9704c2f197b60b83f10
+  revision: 27bab9e7419dbd8b0fcd68ca4b03a121ae6c24af
   specs:
     blacklight (9.0.0.beta2)
       globalid


### PR DESCRIPTION
sort of closes #5159 
I think it needs a release to work because the JS isn't being installed so you can't actually check from keyboard.
<img width="515" alt="Screenshot 2025-06-24 at 2 07 35 PM" src="https://github.com/user-attachments/assets/7fe2033d-b715-4c20-8a69-5d3f48738224" />
