### PR TITLE
Add padding to the toast icon

### DIFF
--- a/app/javascript/controllers/copy_link_controller.js
+++ b/app/javascript/controllers/copy_link_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
         await navigator.clipboard.writeText(this.urlValue)
         const toast = document.getElementById('toast')
         const toastText = toast.querySelector('.toast-text')
-        toastText.innerHTML = '<i class="bi bi-check-circle-fill" aria-hidden="true"></i> Link copied to clipboard'
+        toastText.innerHTML = '<i class="bi bi-check-circle-fill pe-1" aria-hidden="true"></i> Link copied to clipboard'
         bootstrap.Toast.getOrCreateInstance(toast).show()
     } catch (err) {
         console.error('Failed to copy text: ', err);


### PR DESCRIPTION
I missed this on review. The designs have a bit of padding here.

Before:
<img width="363" alt="Screenshot 2025-06-25 at 1 43 34 PM" src="https://github.com/user-attachments/assets/32a64447-b766-486a-a1ba-c454aed37681" />

After:
<img width="360" alt="Screenshot 2025-06-25 at 1 44 08 PM" src="https://github.com/user-attachments/assets/b2b849b9-8b4c-49c5-9741-36ea2a5aa576" />

