### PR TITLE
add toast, bookmarks count badge

### DIFF
--- a/app/assets/stylesheets/searchworks4/masthead.css
+++ b/app/assets/stylesheets/searchworks4/masthead.css
@@ -10,3 +10,11 @@
     --bs-link-color-rgb: var(--stanford-cardinal-rgb);
   }
 }
+
+.navbar {
+  .badge {
+    --bs-badge-color: var(--stanford-black);
+
+    background-color: var(--stanford-fog-light);
+  }
+}

--- a/app/components/document/tracking_bookmark_component.html.erb
+++ b/app/components/document/tracking_bookmark_component.html.erb
@@ -4,6 +4,8 @@
              method:  bookmarked? ? :delete : :put,
              class: "bookmark-toggle",
              data: {
+               controller: 'bookmark-toast',
+               action: 'bookmark.blacklight@window->bookmark-toast#bookmarkUpdated',
                present: t('blacklight.search.bookmarks.present'),
                absent: t('blacklight.search.bookmarks.absent'),
                inprogress: t('blacklight.search.bookmarks.inprogress')

--- a/app/javascript/controllers/bookmark_toast_controller.js
+++ b/app/javascript/controllers/bookmark_toast_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="bookmark-toast"
+export default class extends Controller {
+  bookmarkUpdated(e) {
+    let toastHTML = '<i class="bi bi-trash-fill pe-1" aria-hidden="true"></i> Removed from bookmarks'
+    if (e.detail.checked){
+      toastHTML = '<i class="bi bi-check-circle-fill pe-1" aria-hidden="true"></i> Saved to bookmarks'
+    } 
+    const toast = document.getElementById('toast')
+    const toastText = toast.querySelector('.toast-text')
+    toastText.innerHTML = toastHTML
+    bootstrap.Toast.getOrCreateInstance(toast).show()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -57,3 +57,6 @@ application.register("preview-embed-browse", PreviewEmbedBrowseController)
 
 import PreviewFilmstripController from "./preview_filmstrip_controller"
 application.register("preview-filmstrip", PreviewFilmstripController)
+
+import BookmarkToastController from "./bookmark_toast_controller"
+application.register("bookmark-toast", BookmarkToastController)

--- a/app/views/shared/searchworks4/_user_util_links.html.erb
+++ b/app/views/shared/searchworks4/_user_util_links.html.erb
@@ -2,6 +2,7 @@
               <li class="nav-item">
                 <a class="nav-link" href="/selections">
                   Bookmarks
+                  <span class="badge rounded-pill" data-role="bookmark-counter"><%= current_or_guest_user.bookmarks.count %></span>
                 </a>
               </li>
               <li class="nav-item">


### PR DESCRIPTION
closes #5204 

We need to wait for a new release of Bl9 to be cut for this to work but it should be able to go in right now without having to wait. https://github.com/projectblacklight/blacklight/commit/32fc74c910e260d15ba4b33246d43f3cb23358ed

You can test this works by putting the following into the console ```var e = new CustomEvent('bookmark.blacklight', { detail: { checked: true}}); window.dispatchEvent(e)```


![Screenshot 2025-06-26 at 2 38 43 PM](https://github.com/user-attachments/assets/9a70883e-fd51-459c-932d-9d3baa2d653e)
![Screenshot 2025-06-26 at 2 38 18 PM](https://github.com/user-attachments/assets/eb22a8cc-2290-4883-9741-d8a9fbccea52)

The only thing I did not get to in this PR is the `the bookmark icon turns to an active/saved status` because I am going to add it to an existing PR that styles the bookmark icon and this keeps us from having merge conflicts. 