### PR TITLE
Add additional style elements to the cite modal

### DIFF
--- a/app/assets/stylesheets/searchworks4/modal.css
+++ b/app/assets/stylesheets/searchworks4/modal.css
@@ -1,6 +1,7 @@
 .modal-content:has(.record-summary) {
   --bs-modal-header-border-width: 0;
   --bs-modal-padding: 0;
+  --bs-border-color: var(--stanford-30-black);
 
   .modal-title {
     font-size: 1.5rem;

--- a/app/components/searchworks4/record_summary_component.html.erb
+++ b/app/components/searchworks4/record_summary_component.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-light p-4 record-summary">
+<div class="bg-light p-4 border-top border-bottom record-summary">
   <div class="d-flex gap-3">
     <%= presenter.thumbnail.render %>
     <div>

--- a/app/views/catalog/_single_citation_with_modal.html.erb
+++ b/app/views/catalog/_single_citation_with_modal.html.erb
@@ -4,6 +4,6 @@
   <% end %>
   <%= render Searchworks4::Citations::CitationComponent.new(presenter:) %>
   <% component.with_footer do %>
-    <button type="button" class="btn btn-outline-primary" data-bl-dismiss="modal">Close</button>
+    <button type="button" class="btn btn-outline-primary m-3" data-bl-dismiss="modal">Close</button>
   <% end %>
 <% end %>


### PR DESCRIPTION
Adds the top/bottom border and `Close` button margin from the design.

After:
<img width="807" alt="Screenshot 2025-06-26 at 1 17 27 PM" src="https://github.com/user-attachments/assets/6dac5ef4-5f1a-43f3-a293-4f444e2c1e86" />
