### PR TITLE
fix padding underneath authors

### DIFF
--- a/app/components/searchworks4/record_summary_component.html.erb
+++ b/app/components/searchworks4/record_summary_component.html.erb
@@ -4,7 +4,7 @@
     <div>
       <div class="fw-semibold"><%= presenter.heading %></div>
       <div><%= resource_icon %> <%= presenter.document_format %> <%= presenter.main_title_date %></div>
-      <ul class="list-unstyled">
+      <ul class="list-unstyled mb-1">
         <% authors.each do |author| %>
           <li><%= author %></li>
         <% end %>


### PR DESCRIPTION
Before
<img width="492" alt="Screenshot 2025-06-26 at 6 02 22 PM" src="https://github.com/user-attachments/assets/bbcf95ce-5864-41c5-a1a0-3337b1c431eb" />

After
<img width="500" alt="Screenshot 2025-06-26 at 6 00 13 PM" src="https://github.com/user-attachments/assets/67abade2-774e-44d9-96df-4c6b9e9109f4" />

Allows the info to look more centered.