### PR TITLE
Fix up the constraints component styling.

### DIFF
--- a/app/components/searchworks4/constraints_component.html.erb
+++ b/app/components/searchworks4/constraints_component.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% if @render_headers %>
-    <span class="constraints-label d-flex align-self-center fw-bold"><%= t('blacklight.search.filters.title') %></span>
+    <span class="constraints-label d-flex align-self-center fw-bold me-1"><%= t('blacklight.search.filters.title') %></span>
   <% end %>
   <% if query_constraints_area.present? %>
     <% query_constraints_area.each do |constraint| %>

--- a/app/components/searchworks4/constraints_component.rb
+++ b/app/components/searchworks4/constraints_component.rb
@@ -8,6 +8,7 @@ module Searchworks4
                    facet_constraint_component_options: { layout: Searchworks4::ConstraintLayoutComponent },
                    **args)
       super
+      @classes += ' gap-2'
     end
   end
 end


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before (little to no padding between items, `x` floating off in space):
<img width="899" alt="Screenshot 2025-06-26 at 17 05 46" src="https://github.com/user-attachments/assets/2874b7d1-b665-41fc-a978-687aac56d30a" />

After:
<img width="833" alt="Screenshot 2025-06-26 at 17 05 55" src="https://github.com/user-attachments/assets/6c0546d1-4365-4bc7-8b49-e1193c5d850c" />
