### PR TITLE
Update mini-bento styles

### DIFF
--- a/app/assets/stylesheets/searchworks4/mini-bento.css
+++ b/app/assets/stylesheets/searchworks4/mini-bento.css
@@ -3,8 +3,14 @@
   padding: 1.5rem 1rem;
 
   .alternate-catalog-body {
-    .alternate-catalog-desc, .btn {
+    .alternate-catalog-desc,
+    .alternate-catalog-other-tools .alternate-catalog-view-all,
+    .btn {
       font-size: 0.875rem;
+    }
+
+    .alternate-catalog-primary-tools .alternate-catalog-name {
+      --bs-heading-color: var(--stanford-cardinal);
     }
 
     .btn {
@@ -14,6 +20,7 @@
 
   .badge.rounded-pill {
     --bs-badge-color: var(--stanford-black);
+    --bs-badge-font-size: 0.875rem;
     --bs-badge-font-weight: 400;
 
     background-color: var(--stanford-10-black);

--- a/app/components/search_result/mini_bento/layout_component.html.erb
+++ b/app/components/search_result/mini_bento/layout_component.html.erb
@@ -5,63 +5,66 @@
     </button>
   </div>
 <% end %>
-<div class='alternate-catalog accordion accordion-collapse collapse d-md-block' data-alternate-catalog="<%= url %>" data-controller="analytics" data-analytics-category-value="alternate-catalog">
+<div class='alternate-catalog accordion accordion-collapse collapse d-md-block mb-3' data-alternate-catalog="<%= url %>" data-controller="analytics" data-analytics-category-value="alternate-catalog">
   <div class="row">
-    <h3 class="alternate-catalog-title col"></h3>
+    <h2 class="alternate-catalog-title col mb-3"></h2>
     <% if close? %>
       <button type='button' class='alternate-catalog-close btn-close col-2 me-2 d-md-none d-block' aria-label="Close">
       </button>
     <% end %>
   </div>
   <div class="alternate-catalog-body row d-none">
-    <div class="col-12">
-      <h4 class="alternate-catalog-name mb-0">
+    <div class="alternate-catalog-primary-tools col-12">
+      <h3 class="alternate-catalog-name mb-0">
+        <span class="fw-normal">SearchWorks</span>
         <%= name %>
         <span class="badge rounded-pill alternate-catalog-count"></span>
-      </h4>
-      <div class='alternate-catalog-desc'>
+      </h3>
+      <div class="alternate-catalog-desc mb-2">
         <%= description %>
       </div>
       <div>
         <%= link_to(url, class: 'btn btn-outline-secondary', data: { action: "click->analytics#trackLink"}) do %>
-          View all <%= result_singular %> results
+          View <%= result_singular %> results
         <% end %>
       </div>
     </div>
 
-    <div class="col-12">
-      <h4 class="alternate-catalog-name mt-3 mb-1">
-        Other search tools
-      </h4>
-      <div class="mb-2">
-        <%= link_to(bento_url) do %>
-          View results from all tools
-        <% end %>
+    <div class="alternate-catalog-other-tools col-12">
+      <div class="d-flex flex-wrap align-items-baseline mb-1">
+        <h3 class="alternate-catalog-name mt-3 mb-1 me-2">
+          Other search tools
+        </h3>
+        <div class="alternate-catalog-view-all mb-2">
+          <%= link_to(bento_url) do %>
+            View results from all tools
+          <% end %>
+        </div>
       </div>
 
-      <div data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= archive_search_url %>">
-        <%= link_to archive_search_url, class: 'su-underline' do %>
+      <div class="mb-2" data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= archive_search_url %>">
+        <%= link_to archive_search_url, class: 'su-underline pe-2' do %>
           Archival Collections at Stanford
         <% end %>
         <span class="badge rounded-pill" data-blacklight-result-count-target="count"></span>
       </div>
 
-      <div data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= geo_search_url %>">
-        <%= link_to geo_search_url,  class: 'su-underline' do %>
+      <div class="mb-2" data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= geo_search_url %>">
+        <%= link_to geo_search_url,  class: 'su-underline pe-2' do %>
           EarthWorks for geospatial data and maps
         <% end %>
         <span class="badge rounded-pill" data-blacklight-result-count-target="count"></span>
       </div>
 
-      <div data-controller="bento-result-count" data-bento-result-count-url-value="<%= bento_search_url('lib_guides') %>">
-        <%= link_to '', class: 'su-underline', data: {'bento-result-count-target': 'link'} do %>
+      <div class="mb-2" data-controller="bento-result-count" data-bento-result-count-url-value="<%= bento_search_url('lib_guides') %>">
+        <%= link_to '', class: 'su-underline pe-2', data: {'bento-result-count-target': 'link'} do %>
           Guides to collections, tools, and services
         <% end %>
         <span class="badge rounded-pill" data-bento-result-count-target="count"></span>
       </div>
 
       <div data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= exhibits_search_url %>">
-        <%= link_to exhibits_search_url, class: 'su-underline' do %>
+        <%= link_to exhibits_search_url, class: 'su-underline pe-2' do %>
           Spotlight Exhibits
         <% end %>
         <span class="badge rounded-pill" data-blacklight-result-count-target="count"></span>

--- a/config/locales/searchworks.en.yml
+++ b/config/locales/searchworks.en.yml
@@ -51,7 +51,7 @@ en:
         description: Books, media, physical & digital resources
         result_singular: catalog
       catalog:
-        name: SearchWorks Articles+
+        name: Articles+
         description: Journal articles, eBooks, and more from the Library’s digital subscriptions
         result_singular: Articles+
     navigation:

--- a/spec/features/alternate_catalog_spec.rb
+++ b/spec/features/alternate_catalog_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature 'Alterate catalog results', :js do
     it 'draws mini-bento' do
       visit search_catalog_path(q: '1*')
       within '.alternate-catalog' do
-        expect(page).to have_css 'h3', text: 'Looking for more?'
-        expect(page).to have_link 'View all Articles+ results'
+        expect(page).to have_css 'h2', text: 'Looking for more?'
+        expect(page).to have_link 'View Articles+ results'
         expect(page).to have_css '.alternate-catalog-count', text: '4'
       end
     end
@@ -22,8 +22,8 @@ RSpec.feature 'Alterate catalog results', :js do
     it 'draws mini-bento' do
       visit articles_path(q: '1*')
       within '.alternate-catalog' do
-        expect(page).to have_css 'h3', text: 'Looking for more?'
-        expect(page).to have_link 'View all catalog results'
+        expect(page).to have_css 'h2', text: 'Looking for more?'
+        expect(page).to have_link 'View catalog results'
         expect(page).to have_css '.alternate-catalog-count', text: '52'
       end
     end


### PR DESCRIPTION
Closes #5231

Only outstanding question I have is if @dbranchini wants the `View results from all tools` link underlined by default.

Mobile:
<img width="554" alt="Screenshot 2025-06-26 at 5 42 46 PM" src="https://github.com/user-attachments/assets/3bc66973-5729-4f06-90d5-aa0844413935" />

View all wrapped:
<img width="318" alt="Screenshot 2025-06-26 at 5 42 29 PM" src="https://github.com/user-attachments/assets/cc4b60bb-97d3-4b8b-b4af-53165c26c5fb" />

View all unwrapped:
<img width="339" alt="Screenshot 2025-06-26 at 5 42 06 PM" src="https://github.com/user-attachments/assets/1c7324fd-6304-4a41-8dbf-6c6123fd6947" />
