### PR TITLE
Apply the same styles to book covers + stacks thumbnails.

### DIFF
--- a/app/assets/stylesheets/searchworks4/search-results.css
+++ b/app/assets/stylesheets/searchworks4/search-results.css
@@ -5,9 +5,6 @@
   padding-top: 1rem;
 }
 
-.index_title {
-}
-
 .bookmark-toggle {
   --bl-icon-color: var(--bs-primary);
 

--- a/app/assets/stylesheets/searchworks4/search-results.css
+++ b/app/assets/stylesheets/searchworks4/search-results.css
@@ -54,7 +54,8 @@
   }
 }
 
-.stacks-image {
+.stacks-image,
+.cover-image {
   display: block;
   max-height: 200px;
   max-width: 80px;


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
After:
<img width="504" alt="Screenshot 2025-06-27 at 08 40 15" src="https://github.com/user-attachments/assets/24d90a4c-0bc0-4042-8024-a281efec771f" />

Before:
<img width="538" alt="Screenshot 2025-06-27 at 08 40 32" src="https://github.com/user-attachments/assets/83152db0-978c-453d-a81d-cbc00cfc7518" />
