### PR TITLE
Apply typography header style to the right sidebar

### DIFF
--- a/app/assets/stylesheets/searchworks4/typography.css
+++ b/app/assets/stylesheets/searchworks4/typography.css
@@ -42,6 +42,7 @@ dt {
   font-weight: 600;
 }
 
+aside,
 .sidebar {
   h2,
   .h2 {


### PR DESCRIPTION
This contains the mini-bento at xxl sizes

Ref #5143 
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before:
<img width="361" alt="Screenshot 2025-06-27 at 11 06 15 AM" src="https://github.com/user-attachments/assets/fa3d4611-843c-4ada-8f6d-937ac8a3250d" />

After:
<img width="396" alt="Screenshot 2025-06-27 at 11 05 45 AM" src="https://github.com/user-attachments/assets/e1e97e22-19a1-4577-85c2-03a20c3d3846" />
