### PR TITLE
Switch prev/next chevrons to use the icon font.

### DIFF
--- a/app/assets/stylesheets/searchworks4/search-results.css
+++ b/app/assets/stylesheets/searchworks4/search-results.css
@@ -66,7 +66,7 @@
 }
 
 .page-entries-info .bi {
-  vertical-align: baseline;
+  font-size: 0.875em;
 }
 
 .truncate-2 {

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -57,10 +57,7 @@
         <div class="sul-toolbar page-entries-info sort-and-per-page d-flex justify-content-between align-items-center">
           <%= tag.nav class: 'page_links' do %>
             <% previous_label = capture do %>
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="12" fill="currentColor" class="bi bi-chevron-double-left" viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M8.354 1.646a.5.5 0 0 1 0 .708L2.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                <path fill-rule="evenodd" d="M12.354 1.646a.5.5 0 0 1 0 .708L6.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-              </svg>
+              <i class="bi bi-chevron-double-left" aria-hidden="true"></i>
               Previous
             <% end %>
             <%= link_to_previous_page @response, previous_label, class: 'me-2' %>
@@ -74,10 +71,7 @@
 
             <% next_label = capture do %>
               Next
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="12" fill="currentColor" class="bi bi-chevron-double-right" viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708"/>
-                <path fill-rule="evenodd" d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708"/>
-              </svg>
+              <i class="bi bi-chevron-double-right" aria-hidden="true"></i>
               <% end %>
             <%= link_to_next_page @response, next_label, class: 'ms-2' %>
           <% end %>

--- a/app/views/databases/_search_results.html.erb
+++ b/app/views/databases/_search_results.html.erb
@@ -39,10 +39,7 @@
         <div class="sul-toolbar page-entries-info sort-and-per-page d-flex justify-content-between align-items-center">
           <%= tag.nav class: 'page_links' do %>
             <% previous_label = capture do %>
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="12" fill="currentColor" class="bi bi-chevron-double-left" viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M8.354 1.646a.5.5 0 0 1 0 .708L2.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                <path fill-rule="evenodd" d="M12.354 1.646a.5.5 0 0 1 0 .708L6.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-              </svg>
+              <i class="bi bi-chevron-double-left" aria-hidden="true"></i>
               Previous
             <% end %>
             <%= link_to_previous_page @response, previous_label, class: 'me-2' %>
@@ -56,10 +53,7 @@
 
             <% next_label = capture do %>
               Next
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="12" fill="currentColor" class="bi bi-chevron-double-right" viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708"/>
-                <path fill-rule="evenodd" d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708"/>
-              </svg>
+              <i class="bi bi-chevron-double-right" aria-hidden="true"></i>
               <% end %>
             <%= link_to_next_page @response, next_label, class: 'ms-2' %>
           <% end %>


### PR DESCRIPTION
This cleans up the vertical alignment between the text + icons. Embedded SVGs considered harmful?

Before:
<img width="409" alt="Screenshot 2025-06-27 at 09 47 15" src="https://github.com/user-attachments/assets/6570dd9a-4f99-4d0f-89e5-9fa35b9d242a" />

After:
<img width="413" alt="Screenshot 2025-06-27 at 09 46 47" src="https://github.com/user-attachments/assets/d442aede-e07f-44bd-90d9-ca62702d8509" />
