### PR TITLE
Store the as-used session token in the user session (e.g. if we rotated it during one of our requests)

### DIFF
--- a/app/models/eds/repository.rb
+++ b/app/models/eds/repository.rb
@@ -25,6 +25,8 @@ module Eds
       end
     end
 
+    delegate :session_token, to: :connection
+
     private
 
     def eds_search(search_builder = {})

--- a/app/services/eds/search_service.rb
+++ b/app/services/eds/search_service.rb
@@ -15,6 +15,8 @@ module Eds
 
     attr_reader :blacklight_config, :user_params, :context # used by search_builder
 
+    delegate :session_token, to: :@repository
+
     def search_builder
       blacklight_config.search_builder_class.new(self)
     end


### PR DESCRIPTION
If an EDS session token is expired, the `Eds::Session` will retry the request after requesting a new session token. When the token changes, we should replace the token we stored in the user session with the one we got after attempting the request.