### PR TITLE
FOLIO uses the instance uuid, not the hrid, for lookups.

### DIFF
--- a/app/controllers/availability_controller.rb
+++ b/app/controllers/availability_controller.rb
@@ -15,7 +15,7 @@ class AvailabilityController < ApplicationController
     # Unfortunately, FOLIO doesn't provide enough information in the RTAC lookup to drive all of our logic,
     # so we also need to retrieve the solr document too.
     @document = search_service.fetch(params[:id])
-    @rtac = LiveLookup.new(params[:id]).records
+    @rtac = LiveLookup.new(params[:uuid_ssi]).records
     @items = @document.holdings.items.index_by(&:live_lookup_item_id)
   end
 

--- a/app/services/live_lookup/solr.rb
+++ b/app/services/live_lookup/solr.rb
@@ -30,7 +30,7 @@ class LiveLookup
     end
 
     def query_params
-      { q: "id:(#{document_ids})",
+      { q: "uuid_ssi:(#{document_ids})",
         fl: 'id, item_display_struct',
         facet: false,
         rows: 100 }


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
