### PR TITLE
fix mini-bento resize from large to small

### DIFF
--- a/app/assets/stylesheets/searchworks4/facets.css
+++ b/app/assets/stylesheets/searchworks4/facets.css
@@ -39,3 +39,11 @@
 .sidebar:has(.alternate-catalog.show) .mini-bento.btn[aria-expanded="true"] {
   display: none;
 }
+
+/* This is for resizing for large to small.
+If the user has not clicked on the mini bento button
+and there is a show class then it will hide the mini bento
+ */
+.sidebar:has(.mini-bento.btn[aria-expanded="false"]) .alternate-catalog.show {
+  display: none;
+}


### PR DESCRIPTION
If you resize the screen from large to small the mini bento will show up below the button. This fixes it.