### PR TITLE
Clean up btn-sm text alignment by resetting the line-height.

### DIFF
--- a/app/components/searchworks4/citations/citation_component.html.erb
+++ b/app/components/searchworks4/citations/citation_component.html.erb
@@ -19,7 +19,7 @@
 
   <% citations.each do |style, citation| %>
     <div class="mb-4 bg-light p-2" data-citation-style-picker-target="tab" data-controller="copy-text" id="tab-<%= style %>" hidden>
-      <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm ms-4" data-action="copy-text#copy">Copy</button></h5>
+      <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm lh-1 ms-4" data-action="copy-text#copy">Copy</button></h5>
       <% Array(citation).each do |cite| %>
         <div class="mb-2" data-copy-text-target="text">
           <%= cite %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,6 +1,6 @@
 <% if show_sort_and_per_page? and !active_sort_fields.blank? %>
   <div id="sort-dropdown" class="d-flex flex-row dropdown" data-controller="analytics" data-analytics-category-value="sort-type">
-    <button type="button" class="btn <%= %w[catalog databases].include?(controller_name) ? 'btn-sm btn-outline-primary' : 'btn-sul-toolbar' %> dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="btn <%= %w[catalog databases].include?(controller_name) ? 'btn-sm btn-outline-primary lh-1' : 'btn-sul-toolbar' %> dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <%= t('blacklight.search.sort.label_html', :field =>current_sort_field.label).html_safe %>
     </button>
 

--- a/app/views/shared/_per_page_widget.html.erb
+++ b/app/views/shared/_per_page_widget.html.erb
@@ -1,7 +1,7 @@
 <% if show_sort_and_per_page? and !blacklight_config.per_page.blank? %>
   <span class="visually-hidden"><%= t('blacklight.search.per_page.title') %></span>
   <div id="per_page-dropdown" class="btn-group" data-controller="analytics" data-analytics-category-value="per-page">
-    <button type="button" class="btn <%= %w[catalog databases].include?(controller_name) ? 'btn-sm btn-outline-primary' : 'btn-sul-toolbar' %> dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="btn <%= %w[catalog databases].include?(controller_name) ? 'btn-sm btn-outline-primary lh-1' : 'btn-sul-toolbar' %> dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <%= t(:'blacklight.search.per_page.button_label_html', :count => sw_current_per_page(@response)).html_safe %>
     </button>
     <div class="dropdown-menu" role="menu">


### PR DESCRIPTION
The text alignment within the `btn-sm` elements (below) has just a little too much space below the button text. Resetting the line height seems to make it a little better: 

---

Before:
<img width="440" alt="Screenshot 2025-06-30 at 09 48 41" src="https://github.com/user-attachments/assets/6aa2ec66-b4e4-4a34-8654-43b9cae45159" />
<img width="250" alt="Screenshot 2025-06-30 at 09 48 51" src="https://github.com/user-attachments/assets/e83cfcbd-f0de-4004-b9ac-8a195226ab61" />

After:
<img width="632" alt="Screenshot 2025-06-30 at 09 46 34" src="https://github.com/user-attachments/assets/2d09e8cb-e323-46cd-bb1a-2b85269c9c38" />
<img width="124" alt="Screenshot 2025-06-30 at 09 46 43" src="https://github.com/user-attachments/assets/d30d26a8-00fb-42d2-8d6c-5cef9e46281b" />

