### PR TITLE
Adjust padding around the facets header

### DIFF
--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -30,7 +30,7 @@
     <div class="row">
       <div class="col-xxl-10 col-xl-12">
         <section class="home-page-facets facets sidenav">
-          <h2 class="h3">Browse by</h2>
+          <h2 class="h3 facets-heading">Browse by</h2>
           <div class="accordion" data-controller="analytics" data-action="hide.bs.collapse->analytics#trackFacetHide show.bs.collapse->analytics#trackFacetShow">
             <%= render Blacklight::FacetComponent.with_collection(blacklight_config.facet_fields.slice('access_facet', 'format_main_ssim', 'building_facet').values, response: @response)%>
           </div>


### PR DESCRIPTION
Before:
<img width="241" alt="Screenshot 2025-07-01 at 09 57 12" src="https://github.com/user-attachments/assets/af8b1ede-8381-499f-8379-69ea6a8a1d30" />

After:
<img width="314" alt="Screenshot 2025-07-01 at 09 57 01" src="https://github.com/user-attachments/assets/af9e8aa4-d3cd-4349-87e1-32ff53919efc" />
