### PR TITLE
Fix sort and per page dropdown alignment

### DIFF
--- a/app/assets/stylesheets/searchworks4/search-results.css
+++ b/app/assets/stylesheets/searchworks4/search-results.css
@@ -82,7 +82,11 @@
 }
 
 .active-icon {
-  margin-left: -20px;
+  margin-left: -1.125rem;
+  &::before {
+    font-size: 1rem;
+    margin-right: 0.125rem;
+  }
 }
 
 .sort-and-per-page .dropdown-menu {

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -6,12 +6,10 @@
 
     <div class="dropdown-menu" role="menu">
       <%- active_sort_fields.each do |sort_key, field| %>
-      <%= link_to url_for(search_state.params_for_search(sort: sort_key)), class: 'dropdown-item', 'aria-current': current_sort_field.label == field.label,
-          data: { action: "click->analytics#trackLink" }, role: 'menuitem', tabindex: '-1' do %>
-          <% if current_sort_field.label == field.label %>
-            <%= t 'blacklight.search.highlight.active_html' %>
-          <% end %>
-          <%= field.label %><% end %>
+        <%= link_to url_for(search_state.params_for_search(sort: sort_key)), class: 'dropdown-item', 'aria-current': current_sort_field.label == field.label,
+            data: { action: "click->analytics#trackLink" }, role: 'menuitem', tabindex: '-1' do %>
+          <%= t 'blacklight.search.highlight.active_html' if current_sort_field.label == field.label %><%= field.label %>
+        <% end %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/shared/_per_page_widget.html.erb
+++ b/app/views/shared/_per_page_widget.html.erb
@@ -8,10 +8,7 @@
       <%- sw_per_page_options_for_select.each do |(label, count)| %>
       <%= link_to url_for(search_state.params_for_search(per_page: count)), class: 'dropdown-item', 'aria-current': sw_current_per_page(@response) == count,
           data: { action: "click->analytics#trackLink" }, role: 'menuitem', tabindex: '-1' do %>
-          <% if sw_current_per_page(@response) == count %>
-            <%= t 'blacklight.search.highlight.active_html' %>
-          <% end %>
-          <%= label %>
+          <%= t 'blacklight.search.highlight.active_html' if sw_current_per_page(@response) == count %><%= label %>
         <% end %>
       <%- end -%>
     </div>


### PR DESCRIPTION
Closes #5255 

<img width="182" alt="Screenshot 2025-07-01 at 4 38 34 PM" src="https://github.com/user-attachments/assets/486a6fb1-a3c0-47da-8cdd-3ba210bd8984" />
<img width="228" alt="Screenshot 2025-07-01 at 4 38 02 PM" src="https://github.com/user-attachments/assets/d9c6b86b-141f-4452-a477-ff47609f0391" />
<img width="223" alt="Screenshot 2025-07-01 at 4 37 49 PM" src="https://github.com/user-attachments/assets/45185349-a375-4717-b0f1-3348b8ac55ad" />

Removes the whitespace that was being underlined in the active before:
<img width="77" alt="Screenshot 2025-07-01 at 4 44 16 PM" src="https://github.com/user-attachments/assets/7672573e-53ab-40c6-85a1-39cf780a617c" />
