### PR TITLE
Style no results page

### DIFF
--- a/app/assets/stylesheets/searchworks4/mini-bento.css
+++ b/app/assets/stylesheets/searchworks4/mini-bento.css
@@ -13,6 +13,10 @@
       --bs-heading-color: var(--stanford-cardinal);
     }
 
+    .alternate-catalog-other-tools .alternate-catalog-name {
+      margin-top: 1rem;
+    }
+
     .btn {
       padding: 0.125rem 0.375rem;
     }

--- a/app/assets/stylesheets/searchworks4/zero-results.css
+++ b/app/assets/stylesheets/searchworks4/zero-results.css
@@ -3,6 +3,18 @@
     display: none;
   }
 
+  .border-before {
+    @media (min-width: 768px) {
+      border-left: 1px solid var(--stanford-20-black);
+    }
+  }
+
+  .chat {
+    border-radius: 0.25rem;
+    background-color: rgb(var(--stanford-fog-light-rgb), 0.7);
+    padding: 1rem 0.5rem;
+  }
+
   .clear-all {
     --bs-primary-rgb: var(--stanford-digital-red-rgb)
   }
@@ -23,6 +35,19 @@
       --bs-btn-hover-border-color: transparent;
       --bs-btn-active-border-color: transparent;
       padding-inline: 0;
+    }
+  }
+
+  /* Have primary & other mini-bento tools in columns rather than rows between md and lg */
+  .alternate-catalog {
+    @media (min-width: 768px) and (max-width: 991.99px) {
+      .alternate-catalog-primary-tools, .alternate-catalog-other-tools {
+        flex: 0 0 auto;
+        width: 50%;
+      }
+      .alternate-catalog-other-tools .alternate-catalog-name {
+        margin-top: 0;
+      }
     }
   }
 }

--- a/app/components/search_result/mini_bento/layout_component.html.erb
+++ b/app/components/search_result/mini_bento/layout_component.html.erb
@@ -32,7 +32,7 @@
 
     <div class="alternate-catalog-other-tools col-12">
       <div class="d-flex flex-wrap align-items-baseline mb-1">
-        <h3 class="alternate-catalog-name mt-3 mb-1 me-2">
+        <h3 class="alternate-catalog-name mb-1 me-2">
           Other search tools
         </h3>
         <div class="alternate-catalog-view-all mb-2">

--- a/app/views/shared/_zero_results.html.erb
+++ b/app/views/shared/_zero_results.html.erb
@@ -1,34 +1,34 @@
-<h1 class="h2 mb-4"><%= t('blacklight.search.zero_results.page_heading') %></h1>
+<h1 class="h2 mt-2 mb-4"><%= t('blacklight.search.zero_results.page_heading') %></h1>
 <div class='row zero-results'>
-  <div class="col-md-4 modify-search">
-    <div class="border-before" data-controller="analytics" data-analytics-category-value="zero-results">
-      <h2 class="ps-3"><%= t 'blacklight.search.zero_results.modify_your_search', search_type: search_type_name %></h2>
+  <div class="col-md-6 col-lg-4 modify-search">
+    <div class="border-before pt-3" data-controller="analytics" data-analytics-category-value="zero-results">
+      <h2 class="ps-3 mb-4"><%= t 'blacklight.search.zero_results.modify_your_search', search_type: search_type_name %></h2>
       <ul>
-        <% filters = SearchResult::NoResult::FiltersComponent.new(search_state:) %>
+        <% filters = SearchResult::NoResult::FiltersComponent.new(render_headers: false, start_over_component: nil, search_state:) %>
         <% if filters.render? %>
           <li>Remove filters <%= link_to 'Clear all', search_action_path(q: params[:q]), class: "clear-all text-primary ms-2",
                                  data: { action: "click->analytics#trackLink" } %>
             <%= render filters %>
           </li>
         <% end %>
-        <li>Check spelling.</li>
-        <li>Use fewer keywords or try different keywords that are broader in meaning.</li>
+        <li class="pb-2">Check spelling.</li>
+        <li class="pb-2">Use fewer keywords or try different keywords that are broader in meaning.</li>
         <% if from_advanced_search? %>
-        <li><%= link_to t('blacklight.search.zero_results.return_to_advanced_search'), :back, class: 'font-weight-bolder fw-semibold',
+        <li class="pb-2"><%= link_to t('blacklight.search.zero_results.return_to_advanced_search'), :back, class: 'font-weight-bolder fw-semibold',
                 data: { action: "click->analytics#trackLink" } %></li>
         <% else %>
-        <li>Try <%= link_to 'advanced search', blacklight_advanced_search_engine.advanced_search_path,
+        <li class="pb-2">Try <%= link_to 'advanced search', blacklight_advanced_search_engine.advanced_search_path,
                     class: 'su-underline',
                     data: { action: "click->analytics#trackLink"} %> to construct a targeted query.</li>
         <% end %>
-        <li>Visit our <%= link_to 'SearchWorks Guide', 'https://guides.library.stanford.edu/searchworks',
+        <li class="pb-2">Visit our <%= link_to 'SearchWorks Guide', 'https://guides.library.stanford.edu/searchworks',
                                   class: 'su-underline' %> for more search tips.</li>
       </ul>
     </div>
   </div>
-  <div class="col-md-4 more-help">
-    <div class="border-before ps-3">
-      <h2>Need more help?</h2>
+  <div class="col-md-6 col-lg-4 more-help">
+    <div class="border-before ps-3 pt-3">
+      <h2 class="mb-4">Need more help?</h2>
 
       <h3>Contact our reference team</h3>
       <div class="mb-2">
@@ -55,19 +55,19 @@
 
       <h3 class="mt-3">Search other libraries</h3>
       <ul>
-        <li>
+        <li class="pb-2">
           <%= link_to 'WorldCat', "https://www.worldcat.org/search?qt=worldcat_org_all&q=#{params.fetch(:q, nil)}", class: 'su-underline' %>
           to search libraries across the globe
         </li>
-      <li>
+        <li>
           <%= link_to 'HathiTrust', "https://catalog.hathitrust.org/Search/Home?lookfor=#{params.fetch(:q, nil)}", class: 'su-underline' %>
           to search millions of digitized materials, especially helpful for government documents
-      </li>
+        </li>
       </ul>
     </div>
   </div>
 
-  <div class="col-md-4 zero-result-container">
+  <div class="col-md-12 col-lg-4 zero-result-container">
     <%= render blacklight_config.index.mini_bento_component.new(close: false) if blacklight_config.index.mini_bento_component%>
   </div>
 </div>


### PR DESCRIPTION
Closes #5339

The three column layout could overflow filter names before. @dbranchini suggested trying a variation of one of her [earlier designs](https://www.figma.com/design/fsVWCX66bpvFZGKEHNRBS5/SearchWorks-4.0--WC1-?node-id=819-57015&t=9zBUdA6VHxyixsgy-4) that wrapped mini-bento earlier. That is this:
<img width="872" alt="Screenshot 2025-07-02 at 2 25 26 PM" src="https://github.com/user-attachments/assets/32239f04-7eca-4680-bd00-1282110753cc" />

Three columns:
<img width="1507" alt="Screenshot 2025-07-02 at 2 25 09 PM" src="https://github.com/user-attachments/assets/59e23eb7-81d4-4d4b-8f64-9b0945b46df3" />
