### PR TITLE
Eds error

### DIFF
--- a/app/models/eds_document.rb
+++ b/app/models/eds_document.rb
@@ -360,9 +360,9 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
     rescue ArgumentError => e
       # We still want to notify honeybadger but can provide more information
       # about the html
-      Honeybadger.notify(e, error_message: "Error with arguments passed to Sanitize/Nokogiri", context: { html: })
-      # Replacing the html with an empty string to allow the page to still load
-      sanitized_html = ""
+      Honeybadger.notify(e, error_message: 'Error with arguments passed to Sanitize/Nokogiri', context: { html: })
+      # Return an empty string to allow the page to still load
+      return ''
     end
     # sanitize 5.0 fails to restore element case after doing lowercase
     sanitized_html = sanitized_html.gsub('<searchlink', '<searchLink')

--- a/app/models/eds_document.rb
+++ b/app/models/eds_document.rb
@@ -342,6 +342,7 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
                                               'searchlink' => %w[fieldcode term]
                                             ))
     sanitize_config = config.nil? ? default_config : config
+    puts "--->EDS DOCUMENT MODEL"
 
     html = CGI.unescapeHTML(data.to_s)
     # need to double-unescape data with an ephtml section
@@ -351,10 +352,27 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
       html = html.gsub("\\n ", '')
     end
 
-    sanitized_html = Sanitize.fragment(html, sanitize_config)
+    #puts html
+    puts html.length
+    begin
+      puts "Testing html against Nokogir"
+      e = Nokogiri.HTML5(html[7500, 15000], max_attributes: -1)
+      e.xpath('//*').each do |element|
+        puts element.name
+        puts element.attributes
+      end
+
+    rescue StandardError => e
+      puts "Error #{e}"
+    end
+    puts "HTML Fragment-->>"
+    puts html[7500, 15000]
+    sanitized_html = Sanitize.fragment(html[7500, 15000], sanitize_config)
     # sanitize 5.0 fails to restore element case after doing lowercase
     sanitized_html = sanitized_html.gsub('<searchlink', '<searchLink')
     sanitized_html.gsub('</searchlink>', '</searchLink>')
+    puts "Resulting sanitized html"
+    puts sanitized_html
   end
 
   # add searchlinks when they don't exist

--- a/app/models/eds_document.rb
+++ b/app/models/eds_document.rb
@@ -335,7 +335,6 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
   # elements/attributes that aren't explicitly whitelisted.
   # The RELAXED config: https://github.com/rgrove/sanitize/blob/master/lib/sanitize/config/relaxed.rb
   def html_decode_and_sanitize(data, config = nil)
-    Rails.logger.debug "HTML decode and sanitize"
     default_config = Sanitize::Config.merge(Sanitize::Config::RELAXED,
                                             elements: Sanitize::Config::RELAXED[:elements] +
                                                 %w[relatesto searchlink ephtml],

--- a/app/models/eds_document.rb
+++ b/app/models/eds_document.rb
@@ -342,7 +342,14 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
                                               'searchlink' => %w[fieldcode term]
                                             ))
     sanitize_config = config.nil? ? default_config : config
-    puts "--->EDS DOCUMENT MODEL"
+    # Passing option to handle errant brackets
+    sanitize_config[:parser_options] = { max_attributes: 2048 }
+    puts "updated sanitize config"
+
+    sanitize_config.keys.each do |key|
+      puts key
+    end
+    #puts sanitize_config.inspect
 
     html = CGI.unescapeHTML(data.to_s)
     # need to double-unescape data with an ephtml section
@@ -352,27 +359,10 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
       html = html.gsub("\\n ", '')
     end
 
-    #puts html
-    puts html.length
-    begin
-      puts "Testing html against Nokogir"
-      e = Nokogiri.HTML5(html[7500, 15000], max_attributes: -1)
-      e.xpath('//*').each do |element|
-        puts element.name
-        puts element.attributes
-      end
-
-    rescue StandardError => e
-      puts "Error #{e}"
-    end
-    puts "HTML Fragment-->>"
-    puts html[7500, 15000]
-    sanitized_html = Sanitize.fragment(html[7500, 15000], sanitize_config)
+    sanitized_html = Sanitize.fragment(html, sanitize_config)
     # sanitize 5.0 fails to restore element case after doing lowercase
     sanitized_html = sanitized_html.gsub('<searchlink', '<searchLink')
     sanitized_html.gsub('</searchlink>', '</searchLink>')
-    puts "Resulting sanitized html"
-    puts sanitized_html
   end
 
   # add searchlinks when they don't exist

--- a/spec/models/eds_document_spec.rb
+++ b/spec/models/eds_document_spec.rb
@@ -40,4 +40,36 @@ RSpec.describe EdsDocument do
       expect(document.citations).to eq({ 'apa' => 'EDS citation content' })
     end
   end
+
+  describe '#html_decode_and_sanitize' do
+    # For the malformed HTML to have the attributes for the first element recognized, another beginning tag should be included.
+    # This format mirrors some of the conditions where the HTML has tags that lead to the parser misidentifying elements and attributes.
+    let(:html) { "Dirvi.s.Tutelaribus. <zit #{attributes} •E<I0-3..E*1,3-Z.D3. " }
+
+    context 'when the HTML string has greater than allowed attributes' do
+      # Attributes must be unique otherwise they appear to be deduplicated
+      let(:attributes) do
+        Array.new(3000) do |i|
+          " ABC#{i} "
+        end.join
+      end
+
+      it 'returns an empty string if the HTML throws an error' do
+        expect(document.html_decode_and_sanitize(html)).to eq("")
+      end
+    end
+
+    context 'when the HTML string has fewer than allowed attributes' do
+      # Attributes must be unique otherwise they appear to be deduplicated
+      let(:attributes) do
+        Array.new(2999) do |i|
+          " ABC#{i} "
+        end.join
+      end
+
+      it 'returns an HTML with the first element text without attributes' do
+        expect(document.html_decode_and_sanitize(html)).to eq("Dirvi.s.Tutelaribus. ")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #5182 

Context: The "attributes per element limit exceeded" error occurs in certain conditions where the HTML has errant "<" characters and very long text.  The parser identifies these as HTML elements with the text that follows (before any other opening tags) being identified as attributes. 

What this PR does:

- Increases the number of maximum attributes allowed for Sanitize so errors are not thrown for the original case linked in the Honeybadger report.
- Also adds a rescue condition so that if an argument error is thrown since the number of attributes has been exceeded even beyond the new limit, the code will send a honeybadger notification sending the HTML that triggered the error.  The code will also replace the html with an empty string so the page can still function. 
- Sets up related tests