### PR TITLE
Remove extraneous markup to fix padding in record tools

### DIFF
--- a/app/components/record_toolbar_component.html.erb
+++ b/app/components/record_toolbar_component.html.erb
@@ -12,7 +12,7 @@
         <li>
           <%= link_to cite_path, id: 'citeLink', data: { action: "click->analytics#trackLink", blacklight_modal: "trigger" },
               class: 'btn btn-link btn-sul-toolbar' do %>
-            <i class="bi bi-quote me-1"></i><%= t('blacklight.tools.cite_html') %>
+            <i class="bi bi-quote me-1"></i>Cite
           <% end %>
         </li>
       <% end %>


### PR DESCRIPTION
The translated value contains FontAwesome icon that we aren't loading.
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before (note space before "Cite")
<img width="521" alt="Screenshot 2025-07-03 at 9 00 45 AM" src="https://github.com/user-attachments/assets/87725054-f623-460d-bb9f-484c63639ece" />

After
<img width="525" alt="Screenshot 2025-07-03 at 9 00 57 AM" src="https://github.com/user-attachments/assets/4256a3bd-7d5e-4081-bd39-e5e30270beaf" />

