### PR TITLE
Improve toolbar alignment

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -39,3 +39,15 @@
     }
   }
 }
+
+.record-toolbar {
+  --item-padding-x: 0.25rem;
+  .btn {
+    /* --bs-btn-padding-y: 0.25rem; */
+    --bs-btn-padding-x: var(--item-padding-x);
+  }
+  .nav-link {
+    --bs-nav-link-padding-y: 0.25rem;
+    --bs-nav-link-padding-x: var(--item-padding-x);
+  }
+}

--- a/app/components/record_toolbar_component.html.erb
+++ b/app/components/record_toolbar_component.html.erb
@@ -1,6 +1,6 @@
 <nav class="record-toolbar d-flex flex-column flex-xxl-row mb-4 mb-xxl-3 gap-1" aria-label="Tools" data-controller="analytics">
-  <div class="d-flex flex-row">
-    <%= helpers.link_back_to_catalog class: 'btn btn-link btn-sul-toolbar back-to-results', label: t('blacklight.back_to_search').html_safe %>
+  <div class="d-flex d-flex-row column-gap-3 align-items-center">
+    <%= helpers.link_back_to_catalog class: 'back-to-results', label: t('blacklight.back_to_search').html_safe %>
     <%= render ToolbarSearchContextInfoComponent.new(search_context: @search_context, search_session: search_session, current_document: document) %>
   </div>
   <div class="ms-xxl-auto flex-nowrap">
@@ -11,13 +11,13 @@
       <% if citable? %>
         <li>
           <%= link_to cite_path, id: 'citeLink', data: { action: "click->analytics#trackLink", blacklight_modal: "trigger" },
-              class: 'btn btn-link btn-sul-toolbar' do %>
+              class: 'nav-link' do %>
             <i class="bi bi-quote me-1"></i>Cite
           <% end %>
         </li>
       <% end %>
       <li>
-        <a data-blacklight-modal="trigger" href="<%= email_solr_document_path(document) %>"><i class="bi bi-envelope me-1"></i>Email</a>
+        <a class="nav-link"data-blacklight-modal="trigger" href="<%= email_solr_document_path(document) %>"><i class="bi bi-envelope me-1"></i>Email</a>
       </li>
       <li>
         <button class="btn btn-link" type="button" data-controller="copy-link" data-action="click->copy-link#copyLink" data-copy-link-url-value="<%= solr_document_url(document) %>"><i class="bi bi-link-45deg me-1"></i>Copy link</button>

--- a/app/components/toolbar_search_context_info_component.html.erb
+++ b/app/components/toolbar_search_context_info_component.html.erb
@@ -1,7 +1,7 @@
 <div class="sul-record-page-info">
-  <div class="sul-record-page-info-inner">
-    <%= link_to_previous_document @search_context[:prev], classes: 'previous btn btn-link btn-sul-toolbar' if @search_context[:prev] %>
+  <div class="sul-record-page-info-inner d-flex column-gap-2">
+    <%= link_to_previous_document @search_context[:prev], classes: 'previous' if @search_context[:prev] %>
     <span class="page-entries"><%= item_page_entry_info %></span>
-    <%= link_to_next_document @search_context[:next], classes: 'next btn btn-link btn-sul-toolbar' if @search_context[:next] %>
+    <%= link_to_next_document @search_context[:next], classes: 'next' if @search_context[:next] %>
   </div>
 </div>

--- a/spec/features/blacklight_customizations/record_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/record_toolbar_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Record Toolbar", :js do
       within "#content" do
         within ".record-toolbar" do
           expect(page).to have_no_css("button.navbar-toggler", visible: true)
-          expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Search results", visible: true)
+          expect(page).to have_link "Search results"
           expect(page).to have_no_css("a.previous.disabled", visible: true)
           expect(page).to have_no_css("a.previous", visible: true)
           expect(page).to have_no_css("a.next.disabled", visible: true)
@@ -59,7 +59,7 @@ RSpec.feature "Record Toolbar", :js do
         within "#content" do
           within ".record-toolbar" do
             expect(page).to have_no_css("button.navbar-toggler", visible: true)
-            expect(page).to have_css("a.btn.btn-sul-toolbar", text: "Search results", visible: true)
+            expect(page).to have_link "Search results"
             expect(page).to have_css("a.previous", visible: true)
             expect(page).to have_css("a.next", visible: true)
           end


### PR DESCRIPTION
Remove .btn.btn-link from non-button elements

Ensure consistent padding in the toolbar. Note how "<- Search results" now aligns left.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->

Fixes #5391 

Before
<img width="1025" alt="Screenshot 2025-07-03 at 9 26 18 AM" src="https://github.com/user-attachments/assets/ee4ed446-06dd-4bcd-94f1-1d24bcbd73d7" />

After

<img width="1031" alt="Screenshot 2025-07-03 at 9 57 44 AM" src="https://github.com/user-attachments/assets/b4826907-6fb6-4408-bfbe-31aea6e57065" />
