### PR TITLE
Render MARC dt/dd pairs using a layout component.

### DIFF
--- a/app/components/record/marc_contents_summary_component.html.erb
+++ b/app/components/record/marc_contents_summary_component.html.erb
@@ -1,6 +1,10 @@
 <% if document.marc_links.finding_aid.present? %>
-  <dt title="Finding aid">Finding aid</dt>
-  <dd><%= document.marc_links.finding_aid.map(&:html).join("<br/>").html_safe %></dd>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { 'Finding aid' } %>
+    <% component.with_value do %>
+      <%= document.marc_links.finding_aid.map(&:html).join("<br/>").html_safe %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <%= render_if_present document.marc_field(:organization_and_arrangement) %>
@@ -8,66 +12,73 @@
 
 <% toc = document.fetch(:toc_struct, []).first %>
 <% if toc.present? %>
-  <dt><%= toc[:label] %></dt>
-  <dd data-controller="long-text" data-long-text-truncate-class="truncate-5">
-    <div data-long-text-target="text">
-      <%- unless toc[:fields].nil? -%>
-        <%- toc[:fields].each do |toc_field| -%>
-          <ul class="toc">
-            <% Array.wrap(toc_field).each do |field| %>
-              <li><%= render_struct_field_data(document, field) %></li>
-            <% end %>
-          </ul>
-        <%- end -%>
-      <%- end -%>
-      <%- unless toc[:vernacular].nil? -%>
-        <%- toc[:vernacular].each do |toc_field| -%>
-          <ul class="toc">
-            <%- toc_field.each do |field| -%>
-              <li><%= field %></li>
-            <%- end -%>
-          </ul>
-        <%- end -%>
-      <%- end -%>
-      <%- unless toc[:unmatched_vernacular].nil? -%>
-        <%- toc[:unmatched_vernacular].each do |toc_field| -%>
-          <ul class="toc">
-            <%- toc_field.each do |field| -%>
-              <li><%= field %></li>
-            <%- end -%>
-          </ul>
-        <%- end -%>
-      <%- end -%>
-    </div>
-  </dd>
-<% end %>
-<% summaries.each do |summary|%>
-  <% summary.fetch(:fields, []).each do |field| %>
-    <dt><%= summary[:label] || 'Summary' %></dt>
-    <dd data-controller="long-text" data-long-text-truncate-class="truncate-5">
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { toc[:label] } %>
+    <% component.with_value data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-5'} do %>
       <div data-long-text-target="text">
-        <%= render_struct_field_data document, field[:field] %>
-        <%= "<br/>#{field[:vernacular]}".html_safe unless field[:vernacular].nil? %>
-        <%= "<br/>".html_safe if field != summary[:fields].last %>
+        <%- unless toc[:fields].nil? -%>
+          <%- toc[:fields].each do |toc_field| -%>
+            <ul class="toc">
+              <% Array.wrap(toc_field).each do |field| %>
+                <li><%= render_struct_field_data(document, field) %></li>
+              <% end %>
+            </ul>
+          <%- end -%>
+        <%- end -%>
+        <%- unless toc[:vernacular].nil? -%>
+          <%- toc[:vernacular].each do |toc_field| -%>
+            <ul class="toc">
+              <%- toc_field.each do |field| -%>
+                <li><%= field %></li>
+              <%- end -%>
+            </ul>
+          <%- end -%>
+        <%- end -%>
+        <%- unless toc[:unmatched_vernacular].nil? -%>
+          <%- toc[:unmatched_vernacular].each do |toc_field| -%>
+            <ul class="toc">
+              <%- toc_field.each do |field| -%>
+                <li><%= field %></li>
+              <%- end -%>
+            </ul>
+          <%- end -%>
+        <%- end -%>
       </div>
-    </dd>
+    <% end %>
   <% end %>
-  <% if summary[:unmatched_vernacular].present? %>
-    <dd data-controller="long-text" data-long-text-truncate-class="truncate-5">
-      <div data-long-text-target="text">>
-        <%= summary[:unmatched_vernacular].join("<br/>").html_safe %>
-      </div>
-    </dd>
+<% end %>
+
+<% summaries.each do |summary|%>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { summary[:label] || 'Summary' } %>
+    <% summary.fetch(:fields, []).each do |field| %>
+      <% component.with_value data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-5'} do %>
+        <div data-long-text-target="text">
+          <%= render_struct_field_data document, field[:field] %>
+          <%= "<br/>#{field[:vernacular]}".html_safe unless field[:vernacular].nil? %>
+          <%= "<br/>".html_safe if field != summary[:fields].last %>
+        </div>
+      <% end %>
+    <% end %>
+    <% if summary[:unmatched_vernacular].present? %>
+      <% component.with_value data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-5'} do %>
+        <div data-long-text-target="text">
+          <%= summary[:unmatched_vernacular].join("<br/>").html_safe %>
+        </div>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>
 
 <% if document.marc_links.supplemental.present? %>
-  <dt title="Supplemental links">Supplemental links</dt>
-  <dd>
-    <%= document.marc_links.supplemental.map do |link| %>
-      <% "#{link.html} #{ render StanfordOnlyPopoverComponent.new if link.stanford_only? }" %>
-    <% end.join("<br/>").html_safe %>
-  </dd>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { 'Supplemental links' } %>
+    <% component.with_value do %>
+      <%= document.marc_links.supplemental.map do |link| %>
+        <%= "#{link.html} #{ render StanfordOnlyPopoverComponent.new if link.stanford_only? }".html_safe %>
+      <% end.join("<br/>").html_safe %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <%= render_if_present document.included_works %>

--- a/app/components/record/marc_document_component.html.erb
+++ b/app/components/record/marc_document_component.html.erb
@@ -69,9 +69,11 @@
       <%= render_if_present document.subjects('690') %>
 
       <% if document.is_a_database? && document[:db_az_subject] %>
-        <dt>Database topics</dt>
-        <% document[:db_az_subject].each do |subject| %>
-          <dd><%= helpers.link_to_database_search(subject) %></dd>
+        <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+          <% component.with_label { 'Database topics' } %>
+          <% document[:db_az_subject].each do |subject| %>
+            <% component.with_value { helpers.link_to_database_search(subject) } %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/searchworks4/metadata_field_layout_component.html.erb
+++ b/app/components/searchworks4/metadata_field_layout_component.html.erb
@@ -1,0 +1,6 @@
+<div class="my-3">
+  <%= tag.dt label, title: (label if label.to_s.length > 20 )%>
+  <% values.each do |v| %>
+    <%= v %>
+  <% end %>
+</div>

--- a/app/components/searchworks4/metadata_field_layout_component.rb
+++ b/app/components/searchworks4/metadata_field_layout_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Searchworks4
+  class MetadataFieldLayoutComponent < ViewComponent::Base
+    renders_one :label
+    renders_many :values, lambda { |**kwargs, &block|
+      tag.dd(**kwargs, &block)
+    }
+
+    def render?
+      values?
+    end
+  end
+end

--- a/app/views/catalog/_dates_from_solr.html.erb
+++ b/app/views/catalog/_dates_from_solr.html.erb
@@ -18,8 +18,12 @@
 <% unless doc_dates.blank? %>
   <% dates.each do |field, label| %>
     <% if document.has_key?(field)  %>
-      <dt title="<%= label %>"><%= label %></dt>
-      <dd><%= [document[field]].flatten.join("<br/>").html_safe %></dd>
+      <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+        <% component.with_label { label } %>
+        <% component.with_value do %>
+          <%= [document[field]].flatten.join("<br/>").html_safe %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/marc_fields/_included_works.html.erb
+++ b/app/views/marc_fields/_included_works.html.erb
@@ -1,6 +1,10 @@
 <% if included_works.values.present? %>
-  <dt><%= included_works.label %></dt>
-  <% included_works.values.each do |value| %>
-    <dd><%= value[:before_text] %> <%= link_to(value[:link_text], search_catalog_path(q: "\"#{value[:query_text]}\"", search_field: 'author_title')) %> <%= value[:after_text] %></dd>
-  <% end  %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { included_works.label } %>
+    <% included_works.values.each do |value| %>
+      <% component.with_value do %>
+        <%= value[:before_text] %> <%= link_to(value[:link_text], search_catalog_path(q: "\"#{value[:query_text]}\"", search_field: 'author_title')) %> <%= value[:after_text] %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_instrumentation.html.erb
+++ b/app/views/marc_fields/_instrumentation.html.erb
@@ -1,6 +1,8 @@
 <% instrumentation.values.each do |label, values| %>
-  <dt><%= label %></dt>
-  <% values.each do |value| %>
-    <dd><%= value[:value] %></dd>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { label } %>
+    <% values.each do |value| %>
+      <% component.with_value { value[:value] } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/marc_fields/_link_to_search.html.erb
+++ b/app/views/marc_fields/_link_to_search.html.erb
@@ -1,6 +1,8 @@
 <% if link_to_search.values.present? %>
-  <dt><%= link_to_search.label %></dt>
-  <% link_to_search.values.each do |value| %>
-    <dd><%= link_to(value.strip, link_to_search.url.merge!(q: "\"#{value.strip}\"")) %></dd>
-  <% end  %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { link_to_search.label } %>
+    <% link_to_search.values.each do |value| %>
+      <% component.with_value { link_to(value.strip, link_to_search.url.merge!(q: "\"#{value.strip}\"")) } %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_linked_author.html.erb
+++ b/app/views/marc_fields/_linked_author.html.erb
@@ -1,16 +1,17 @@
 <% if linked_author.present? && linked_author.values.present? %>
-  <dt><%= linked_author.label %></dt>
-  <% linked_author.values.each do |author| %>
-    <dd>
-      <%= link_to(author[:link].strip, search_catalog_path(q: "\"#{author[:search]}\"", search_field: 'search_author')) if author[:link].present? %>
-      <%= author[:post_text] if author[:post_text] %>
-    </dd>
-
-    <% if author[:vern] %>
-      <dd>
-        <%= link_to(author[:vern][:link].strip, search_catalog_path(q: "\"#{author[:vern][:search]}\"", search_field: 'search_author')) if author[:vern][:link].present? %>
-        <%= author[:vern][:post_text] if author[:vern][:post_text] %>
-      </dd>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { linked_author.label } %>
+    <% linked_author.values.each do |author| %>
+      <% component.with_value do %>
+        <%= link_to(author[:link].strip, search_catalog_path(q: "\"#{author[:search]}\"", search_field: 'search_author')) if author[:link].present? %>
+        <%= author[:post_text] if author[:post_text] %>
+      <% end %>
+      <% if author[:vern] %>
+        <% component.with_value do %>
+          <%= link_to(author[:vern][:link].strip, search_catalog_path(q: "\"#{author[:vern][:search]}\"", search_field: 'search_author')) if author[:vern][:link].present? %>
+          <%= author[:vern][:post_text] if author[:vern][:post_text] %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/marc_fields/_linked_collection.html.erb
+++ b/app/views/marc_fields/_linked_collection.html.erb
@@ -1,8 +1,10 @@
 <% if linked_collection.values.present? %>
-  <dt><%= linked_collection.label %></dt>
-  <% linked_collection.values.each do |value| %>
-    <dd>
-      <%= link_to(value, search_catalog_path(search_field: :subject_terms, q: "\"#{value}\"")) %>
-    </dd>
-  <% end  %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { linked_collection.label } %>
+    <% linked_collection.values.each do |value| %>
+      <% component.with_value do %>
+        <%= link_to(value, search_catalog_path(search_field: :subject_terms, q: "\"#{value}\"")) %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_linked_related_works.html.erb
+++ b/app/views/marc_fields/_linked_related_works.html.erb
@@ -1,10 +1,12 @@
 <% if linked_related_works.present? %>
-  <dt><%= linked_related_works.label %></dt>
-  <% linked_related_works.values.each do |related_work| %>
-    <dd>
-      <%= related_work[:pre_text] %>
-      <%= link_to(related_work[:link], search_catalog_path(q: related_work[:search], search_field: 'search_title')) %>
-      <%= related_work[:post_text] %>
-    </dd>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { linked_related_works.label } %>
+    <% linked_related_works.values.each do |related_work| %>
+      <% component.with_value do %>
+        <%= related_work[:pre_text] %>
+        <%= link_to(related_work[:link], search_catalog_path(q: related_work[:search], search_field: 'search_title')) %>
+        <%= related_work[:post_text] %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/marc_fields/_linked_serials.html.erb
+++ b/app/views/marc_fields/_linked_serials.html.erb
@@ -1,12 +1,14 @@
 <% linked_serials.values.each do |value| %>
-  <dt><%= value[:label] %></dt>
-  <dd>
-    <% value[:values].each do |val|%>
-      <% if val[:link] %>
-        <%= link_to(val[:link], search_catalog_path(q: (val[:href] || val[:link]), search_field: val[:search_field])) %>
-      <% else %>
-        <%= val[:text] %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { value[:label] } %>
+    <% component.with_value do %>
+      <% value[:values].each do |val| %>
+        <% if val[:link] %>
+          <%= link_to(val[:link], search_catalog_path(q: (val[:href] || val[:link]), search_field: val[:search_field])) %>
+        <% else %>
+          <%= val[:text] %>
+        <% end %>
       <% end %>
     <% end %>
-  </dd>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_linked_series.html.erb
+++ b/app/views/marc_fields/_linked_series.html.erb
@@ -1,9 +1,11 @@
-<dt><%= linked_series.label %></dt>
-<% linked_series.values.each do |series| %>
-  <dd>
-    <% if series[:link] %>
-      <%= link_to(series[:link].strip, search_catalog_path(q: "\"#{series[:link].strip}\"", search_field: 'search_series')) %>
+<%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+  <% component.with_label { linked_series.label } %>
+  <% linked_series.values.each do |series| %>
+    <% component.with_value do %>
+      <% if series[:link] %>
+        <%= link_to(series[:link].strip, search_catalog_path(q: "\"#{series[:link].strip}\"", search_field: 'search_series')) %>
+      <% end %>
+      <%= series[:extra_text] %>
     <% end %>
-    <%= series[:extra_text] %>
-  </dd>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_local_subjects.html.erb
+++ b/app/views/marc_fields/_local_subjects.html.erb
@@ -1,6 +1,8 @@
 <% if local_subjects.values.present? %>
-  <dt><%= local_subjects.label %></dt>
-  <% local_subjects.values.each do |value| %>
-    <dd><%= link_to(value.strip, marc_field.url.merge!(q: "\"#{value.strip}\"")) %></dd>
-  <% end  %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { local_subjects.label } %>
+    <% local_subjects.values.each do |value| %>
+      <% component.with_value { link_to(value.strip, marc_field.url.merge!(q: "\"#{value.strip}\"")) } %>
+    <% end  %>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_marc_field.html.erb
+++ b/app/views/marc_fields/_marc_field.html.erb
@@ -1,6 +1,6 @@
-<% if marc_field.values.present? %>
-  <dt><%= marc_field.label %></dt>
-  <% marc_field.values.each do |value| %>
-    <dd><%= auto_link(value) %></dd>
-  <% end  %>
+<%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+  <% component.with_label { marc_field.label } %>
+  <% marc_field.values.each do |v| %>
+    <% component.with_value { auto_link(v) } %>
+  <% end %>
 <% end %>

--- a/app/views/marc_fields/_production_notice.html.erb
+++ b/app/views/marc_fields/_production_notice.html.erb
@@ -1,8 +1,8 @@
-<% if production_notice.values.present? %>
-  <% production_notice.values.each do |label,values| %>
-    <dt><%= label %></dt>
-    <% values.each do |value| %>
-      <dd><%= auto_link(value) %></dd>
+<% production_notice.values&.each do |label,values| %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { label } %>
+    <% values.each do |v|%>
+      <% component.with_value { auto_link(v) } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/marc_fields/_subjects.html.erb
+++ b/app/views/marc_fields/_subjects.html.erb
@@ -1,13 +1,15 @@
 <% if subjects.values.present? %>
-  <dt><%= subjects.label %></dt>
-  <% subjects.values.each do |value| %>
-    <dd>
-      <% value.each_with_index do |field, index| %>
-        <%= ' > ' unless index == 0 %>
-        <% link_text = value[0..index].join(' ') %>
-        <% title_text = value[0..index].join(' - ') %>
-        <%= link_to(field.strip, search_catalog_path(q: "\"#{link_text}\"", search_field: 'subject_terms'), title: title_text, 'aria-label' => title_text) %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+    <% component.with_label { subjects.label } %>
+    <% subjects.values.each do |value| %>
+      <% component.with_value do %>
+        <% value.each_with_index do |field, index| %>
+          <%= ' > ' unless index == 0 %>
+          <% link_text = value[0..index].join(' ') %>
+          <% title_text = value[0..index].join(' - ') %>
+          <%= link_to(field.strip, search_catalog_path(q: "\"#{link_text}\"", search_field: 'subject_terms'), title: title_text, 'aria-label' => title_text) %>
+        <% end %>
       <% end %>
-    </dd>
+    <% end  %>
   <% end  %>
 <% end %>

--- a/spec/components/record/marc_document_component_spec.rb
+++ b/spec/components/record/marc_document_component_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Record::MarcDocumentComponent, type: :component do
       expect(page).to have_css('dd', text: 'Waltzes.', count: 1)
       expect(page).to have_css('dd', text: 'Canons, fugues, etc. (Piano)', count: 1)
       expect(page).to have_css('dd', text: 'Marches.', count: 1)
-      expect(page).to have_css('dd', text: "Piano, Musique de.\n         > \n        Sound recordings.", count: 1)
+      expect(page).to have_css('dd', text: /Piano, Musique de\.\s*>\s*Sound recordings\./, count: 1)
     end
   end
 


### PR DESCRIPTION
This allows us to create a little more space around different fields:

Before/After:
<img width="653" alt="Screenshot 2025-07-07 at 09 06 42" src="https://github.com/user-attachments/assets/2ececa41-dd4c-4b96-a838-835386320490" />
