### PR TITLE
Get link hover decoration back on non-underlined links

### DIFF
--- a/app/assets/stylesheets/searchworks4/links.css
+++ b/app/assets/stylesheets/searchworks4/links.css
@@ -26,4 +26,9 @@ a:not(.btn),
 .btn-link {
   text-decoration: var(--bs-link-decoration);
   -webkit-text-decoration: var(--bs-link-decoration);
+
+  &:hover {
+    text-decoration: var(--bs-link-hover-decoration);
+    -webkit-text-decoration: var(--bs-link-hover-decoration);
+  }
 }


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
