### PR TITLE
Add Stanford only checkbox to Theses/Dissertation page

### DIFF
--- a/app/assets/stylesheets/searchworks4/facets.css
+++ b/app/assets/stylesheets/searchworks4/facets.css
@@ -155,3 +155,7 @@
     --bs-link-decoration: none;
   }
 }
+
+label[for="facet_option_stanford_only"] > a {
+  color: var(--stanford-red);
+}

--- a/app/components/searchworks4/theses_dissertation_facet_header_component.html.erb
+++ b/app/components/searchworks4/theses_dissertation_facet_header_component.html.erb
@@ -1,0 +1,34 @@
+<div class="p-2 mb-2 d-flex justify-content-center" data-controller='facet-checkboxes'>
+  <button class="btn btn-outline-secondary p-3 position-relative">
+    <%= label_tag("facet_option_stanford_only") do %>
+      <%= check_box(
+            'f',
+            'stanford_only',
+            {
+              multiple: true,
+              id: "facet_option_stanford_only",
+              checked: stanford_only_selected?,
+              data: { action: 'facet-checkboxes#toggleCheckbox' }
+            },
+            "Show Stanford work only",
+            nil
+          )
+      %>
+      <%= link_to(
+            stanford_only_selected? ? theses_all_path : theses_stanford_only_path,
+            data: {
+              newState: !stanford_only_selected?,
+              action: 'facet-checkboxes#toggleLink',
+              turbo: false
+            },
+            class: 'ms-1 btn',
+          ) do %>
+        Show Stanford work only
+      <% end %>
+    <% end %>
+  </button>
+
+  <div data-facet-checkboxes-target="loadingIndicator" class="d-none position-absolute opacity-75 top-50 start-50 translate-middle">
+    <div class='loading-spinner'></div>
+  </div>
+</div>

--- a/app/components/searchworks4/theses_dissertation_facet_header_component.rb
+++ b/app/components/searchworks4/theses_dissertation_facet_header_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Searchworks4
+  class ThesesDissertationFacetHeaderComponent < ViewComponent::Base
+    delegate :search_state, :add_filter_unless_present, :remove_filter_if_present, to: :helpers
+
+    def theses_stanford_only_path
+      state = search_state.deep_dup
+      state = add_filter_unless_present(state, 'stanford_work_facet_hsim', 'Thesis/Dissertation')
+      search_catalog_path(state.to_h)
+    end
+
+    def theses_all_path
+      state = search_state.deep_dup
+      state = remove_filter_if_present(state, 'stanford_work_facet_hsim', 'Thesis/Dissertation')
+      search_catalog_path(state.to_h)
+    end
+
+    # Don't let rubocop change values.include? to .values?
+    # rubocop:disable Performance/InefficientHashSearch
+    def stanford_only_selected?
+      state = search_state.deep_dup
+      state.filter('stanford_work_facet_hsim').values.include?('Thesis/Dissertation')
+    end
+    # rubocop:enable Performance/InefficientHashSearch
+  end
+end

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -22,4 +22,17 @@ module FacetsHelper
 
     render Constants::ARTICLES_ICON_COMPONENTS[value].new
   end
+
+  # Don't let rubocop change values.include? to .values?
+  # rubocop:disable Performance/InefficientHashSearch
+  def add_filter_unless_present(state, filter_key, value)
+    state = state.filter(filter_key).add(value) unless state.filter(filter_key).values.include?(value)
+    state
+  end
+
+  def remove_filter_if_present(state, filter_key, value)
+    state = state.filter(filter_key).remove(value) if state.filter(filter_key).values.include?(value)
+    state
+  end
+  # rubocop:enable Performance/InefficientHashSearch
 end

--- a/app/views/catalog/_facet_header.html.erb
+++ b/app/views/catalog/_facet_header.html.erb
@@ -5,4 +5,8 @@
       <div class='loading-spinner'></div>
     </div>
   </div>
+<% end %>    
+
+<% if PageLocation.new(search_state).access_point == :dissertation_theses %>
+  <%= render Searchworks4::ThesesDissertationFacetHeaderComponent.new(search_state: search_state) %>
 <% end %>

--- a/spec/features/access_points/dissertation_theses_spec.rb
+++ b/spec/features/access_points/dissertation_theses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Dissertation Theses Access Point' do
+RSpec.describe 'Dissertation Theses Access Point', :js do
   before do
     visit root_path
     within '.features' do
@@ -29,5 +29,23 @@ RSpec.describe 'Dissertation Theses Access Point' do
       expect(page).to have_css('h3', text: 'Genre')
       expect(page).to have_css('h3', text: 'Date')
     end
+  end
+
+  it 'Toggles the Stanford work facet' do
+    expect(page).to have_css('#facet_option_stanford_only', visible: :visible)
+    # Without the Stanford work filter, there should be 3 results
+    expect(page).to have_css('article', count: 3)
+
+    # Check the checkbox to filter by Stanford work
+    check "Show Stanford work only"
+
+    # Expect the Stanford work filter to be applied
+    expect(page).to have_css('article', count: 1)
+
+    # Uncheck the checkbox to remove the filter
+    uncheck "Show Stanford work only"
+
+    # Expect the Stanford work filter to be removed
+    expect(page).to have_css('article', count: 3)
   end
 end


### PR DESCRIPTION
This should close [#5449](https://github.com/sul-dlss/SearchWorks/issues/5449)

Adding a `:js` makes the spec file run a lot slower -- up for debate if the test is worth the slowdown.


<img width="1185" alt="Screenshot 2025-07-09 at 10 00 25 PM" src="https://github.com/user-attachments/assets/3652770a-7343-45c1-aede-2eac79500494" />

