### PR TITLE
Re-use single_location? to make sure there's not multiple locations (…

### DIFF
--- a/app/components/searchworks4/physical_availability_component.rb
+++ b/app/components/searchworks4/physical_availability_component.rb
@@ -23,7 +23,7 @@ module Searchworks4
     end
 
     def single_item?
-      document.holdings.items.one? && document.holdings.libraries.one?
+      document.holdings.items.one? && single_location?
     end
 
     def truncated_display?


### PR DESCRIPTION
…that may or may not have an item.)

Fixes #5497
