### PR TITLE
Allow field labels to wrap now that we're wrapping the dt/dds

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -1,12 +1,10 @@
 @media (min-width: 520px) {
   .dl-horizontal {
     dt {
-      clear: left;
       float: left;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
       width: 10em;
+      overflow-wrap: break-word;
+      hyphens: auto;
     }
 
     dd {

--- a/app/components/searchworks4/metadata_field_layout_component.html.erb
+++ b/app/components/searchworks4/metadata_field_layout_component.html.erb
@@ -1,4 +1,4 @@
-<div class="my-3">
+<div class="my-3 clearfix">
   <%= tag.dt label, title: (label if label.to_s.length > 20 )%>
   <% values.each do |v| %>
     <%= v %>

--- a/app/views/catalog/mastheads/_collection.html.erb
+++ b/app/views/catalog/mastheads/_collection.html.erb
@@ -13,17 +13,23 @@
     <% component.with_aside do %>
         <dl class="dl-horizontal dl-invert collection-metadata">
           <% if @parent.collection_members.present? %>
-            <dt>Digital collection</dt>
-            <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'digital item'), @parent) %></dd>
+            <div class="clearfix">
+              <dt>Digital collection</dt>
+              <dd><%= link_to_collection_members(pluralize(@parent.collection_members.total, 'digital item'), @parent) %></dd>
+            </div>
           <% end %>
           <% # this stuff is temporary until we have item level merge (mods + marc) %>
           <% if @parent.extent_sans_format.present? %>
-            <dt>Physical collection</dt>
-            <dd><%= @parent.extent_sans_format %></dd>
+            <div class="clearfix">
+              <dt>Physical collection</dt>
+              <dd><%= @parent.extent_sans_format %></dd>
+            </div>
           <% end %>
           <% if @parent.marc_links.finding_aid.present? %>
-            <dt>Finding aid</dt>
-            <dd><%= @parent.marc_links.finding_aid.first.html.html_safe %></dd>
+            <div class="clearfix">
+              <dt>Finding aid</dt>
+              <dd><%= @parent.marc_links.finding_aid.first.html.html_safe %></dd>
+            </div>
           <% end %>
         </dl>
     <% end %>


### PR DESCRIPTION
E.g. (silly worst case:)
<img width="398" height="312" alt="Screenshot 2025-07-10 at 15 54 21" src="https://github.com/user-attachments/assets/1255b037-0cb8-4dc8-8c09-b159164ec13a" />
