### PR TITLE
Override document_index_view_type to ignore the session store.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -10,6 +10,14 @@ module CatalogHelper
     document_index_view_type.to_s
   end
 
+  # override upstream so we don't check the session for the last view type.
+  def document_index_view_type(query_params = params || {})
+    view_param = query_params[:view]
+    return view_param.to_sym if view_param && document_index_views.key?(view_param.to_sym)
+
+    default_document_index_view_type
+  end
+
   def stackmap_link(document, location)
     item = location.items.first
     params = { callno: item.callnumber,

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe CatalogHelper do
     end
   end
 
+  describe 'document_index_view_type' do
+    before do
+      allow(helper).to receive_messages(blacklight_config: CatalogController.blacklight_config, blacklight_configuration_context: Blacklight::Configuration::Context.new(helper))
+    end
+
+    it 'returns the view type from params if it exists' do
+      params = { view: 'gallery' }
+      expect(helper.document_index_view_type(params)).to eq :gallery
+    end
+
+    it 'returns the default view type if no params are present' do
+      expect(helper.document_index_view_type).to eq :list
+    end
+
+    it 'overrides blacklight to return the default view type even if there is a stored view in the session' do
+      allow(helper).to receive(:session).and_return(preferred_view: :gallery)
+
+      expect(helper.document_index_view_type(params)).to eq :list
+    end
+  end
+
   describe 'new_documents_feed_path' do
     before do
       allow(helper).to receive(:search_state).and_return(Blacklight::SearchState.new({}, CatalogController.blacklight_config))


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
