### PR TITLE
Results toolbar spec doesn't need selenium

### DIFF
--- a/spec/features/blacklight_customizations/results_toolbar_spec.rb
+++ b/spec/features/blacklight_customizations/results_toolbar_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.feature "Results Toolbar", :js do
+RSpec.feature "Results Toolbar" do
   before do
     stub_article_service(docs: StubArticleService::SAMPLE_RESULTS)
   end


### PR DESCRIPTION
This makes the tests run faster

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
