### PR TITLE
Remove extraneous padding on the cite modal

### DIFF
--- a/app/components/searchworks4/citations/citation_component.html.erb
+++ b/app/components/searchworks4/citations/citation_component.html.erb
@@ -1,7 +1,6 @@
 <%= render Searchworks4::RecordSummaryComponent.new(presenter:) %>
 
-<div class="p-4">
-  <div data-controller="citation-style-picker">
+<div class="modal-body" data-controller="citation-style-picker">
   <h4 class="fs-5">Copy citation</h4>
 
   <div class="row mb-3">

--- a/app/views/catalog/_single_citation_with_modal.html.erb
+++ b/app/views/catalog/_single_citation_with_modal.html.erb
@@ -2,8 +2,10 @@
   <% component.with_header do %>
     <h2 class="modal-title">Cite</h2>
   <% end %>
-  <%= render Searchworks4::Citations::CitationComponent.new(presenter:) %>
-  <% component.with_footer do %>
-    <button type="button" class="btn btn-outline-primary" data-bl-dismiss="modal">Close</button>
+  <% component.with_body do %>
+    <%= render Searchworks4::Citations::CitationComponent.new(presenter:) %>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-outline-primary" data-bl-dismiss="modal">Close</button>
+    </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
Fixes #5561

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
<img width="736" height="563" alt="Screenshot 2025-07-11 at 2 23 03 PM" src="https://github.com/user-attachments/assets/eb3b79e8-4c37-4ea5-b7bf-3f720c0514ac" />
