### PR TITLE
fix escaping on marc fields

### DIFF
--- a/app/components/record/marc_document_component.html.erb
+++ b/app/components/record/marc_document_component.html.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <div class='upper-record-metadata mb-3'>
-      <div><%= helpers.render_resource_icon presenter.formats %> <%= presenter.document_format %> &mdash; <%= document.marc_field('3003abcefg').values.join(' ') %></div>
+      <div><%= helpers.render_resource_icon presenter.formats %> <%= presenter.document_format %> &mdash; <%= safe_join(document.marc_field('3003abcefg').values, ' ') %></div>
     </div>
   <% end %>
 


### PR DESCRIPTION
closes #5543 

I don't know how to do this without html safe. I could use help
<img width="596" height="316" alt="Screenshot 2025-07-11 at 4 55 15 PM" src="https://github.com/user-attachments/assets/8a8c04b7-d3a3-457e-a6ac-6f9d0c5215e7" />
