### PR TITLE
Allow long location labels to wrap in the availability table.

### DIFF
--- a/app/components/searchworks4/physical_availability_component.html.erb
+++ b/app/components/searchworks4/physical_availability_component.html.erb
@@ -99,7 +99,7 @@
             <% library.locations.each do |location| %>
               <div class="d-flex flex-column flex-sm-row gap-2 gap-sm-5 p-2 suppress-item-level-request-button-if-there-is-a-location-level-request-button">
                 <div class="pt-2" data-availability-target="location">
-                  <div><%= render LocationComponent.new(location: location, document: document, suppress_off_campus: false) %></div>
+                  <div><%= render LocationComponent.new(location: location, document: document, suppress_off_campus: false, classes: []) %></div>
                   <% unless document.holdings.libraries.one? && document.holdings.libraries.first.locations.one? %>
                     <%= render LocationRequestLinkComponent.for(document:, location:, library_code: library.code, hide_icon: true, classes: %w[btn btn-sm btn-secondary location-request-link]) %>
                   <% end %>

--- a/app/javascript/controllers/availability_controller.js
+++ b/app/javascript/controllers/availability_controller.js
@@ -9,11 +9,15 @@ export default class extends Controller {
   }
   
   // The length of location labels can vary dramatically. It looks better if the items area aligns for all locations within an instance.
-  updateLocationColumnsToEqualWidth(maxWidth = 50, additionalPadding = 10) {
+  updateLocationColumnsToEqualWidth(maxWidth = 30, additionalPadding = 5) {
     const bestWidth = Math.min(maxWidth, this.maxLocationColumnWidth());
 
     this.locationTargets.forEach((location) => {
-      location.style.minWidth = `${bestWidth + additionalPadding}ch`;
+      if (location.children[0].textContent.trim().length > maxWidth) {
+        location.style.width = `${bestWidth + additionalPadding}ch`;
+      } else {
+        location.style.minWidth = `${bestWidth + additionalPadding}ch`;
+      }
     });
   }
 


### PR DESCRIPTION
After:
<img width="683" height="439" alt="Screenshot 2025-07-14 at 09 46 54" src="https://github.com/user-attachments/assets/eca0834d-234d-441c-91ea-4e5960b2a885" />

Before:
<img width="683" height="442" alt="Screenshot 2025-07-14 at 09 47 24" src="https://github.com/user-attachments/assets/dedf0103-2fc2-4018-82be-b0e658b96514" />
