### PR TITLE
setting up proxy links for popular database links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,4 +68,11 @@ module ApplicationHelper
   def search_type_name
     t("searchworks.search_dropdown.#{controller_name}.label")
   end
+
+  # Return an Ezproxy link for URLs that match a proxied URL
+  # If the link does not match a URL that should be proxied, return the link on its own
+  def ezproxy_database_link(url, title)
+    restricted_title = 'available to stanford affiliated users'
+    Links::Ezproxy.new(url: url, link_title: "#{title}(#{restricted_title})", document: nil).to_proxied_url || url
+  end
 end

--- a/app/models/links/ezproxy.rb
+++ b/app/models/links/ezproxy.rb
@@ -52,8 +52,9 @@ class Links
         sul_restricted?
     end
 
+    # Popular database links may not have any associated Solr documents
     def libraries
-      @libraries ||= document.fetch(:holdings_library_code_ssim, [])
+      @libraries ||= document&.fetch(:holdings_library_code_ssim, []) || []
     end
 
     def ezproxied_hosts

--- a/app/views/databases/_popular_databases.html.erb
+++ b/app/views/databases/_popular_databases.html.erb
@@ -5,36 +5,36 @@
           <li class="mb-3">
             <div class="fw-semibold">Academic search premier</div>
             <div>Multidisciplinary database of over 4,650 mostly scholarly publications, many full-text; a great place to start your research.</div>
-            <div><a href="https://research.ebsco.com/c/qmsjx4?db=aph">research.ebscohost.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
+            <div><a href="<%= ezproxy_database_link('https://research.ebsco.com/c/qmsjx4?db=aph', 'Academic search premier') %>">research.ebscohost.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
           </li>
 
           <li class="mb-3">
             <div class="fw-semibold">ProQuest</div>
             <div>From business and political science to literature and psychology, access to a wide range of popular academic subjects; includes more than 5,000  titles (over 3,500 in full text) from 1971 forward.</div>
-            <div><a href="https://search.proquest.com">search.proquest.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
+            <div><a href="<%= ezproxy_database_link('https://search.proquest.com', 'ProQuest') %>">search.proquest.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
           </li>
 
           <li class="mb-3">
             <div class="fw-semibold">Web of Science</div>
             <div>Web of Science provides access to information on science, social  sciences, and arts and humanities, as well as search and analysis (citation) tools.</div>
-            <div><a href="https://www.webofscience.com">www.webofscience.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
+            <div><a href="<%= ezproxy_database_link('https://www.webofscience.com', 'Web of Science') %>">www.webofscience.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
           </li>
 
           <li class="mb-3">
             <div class="fw-semibold">JSTOR</div>
             <div>A digital library for scholars, researchers, and students, offering access to thousands of academic journals, books, and primary sources across many disciplines.</div>
-            <div><a href="https://www.jstor.org">www.jstor.org</a> <%= render StanfordOnlyPopoverComponent.new %></div>
+            <div><a href="<%= ezproxy_database_link('https://www.jstor.org', 'JSTOR') %>">www.jstor.org</a> <%= render StanfordOnlyPopoverComponent.new %></div>
           </li>
 
           <li class="mb-3">
             <div class="fw-semibold">IEEE Xplore</div>
             <div>A research database for electrical engineering, computer science, and electronics literature, providing access to IEEE journals, conferences, and standards.</div>
-            <div><a href="https://ieeexplore.ieee.org">ieeexplore.ieee.org</a> <%= render StanfordOnlyPopoverComponent.new %></div>
+            <div><a href="<%= ezproxy_database_link('https://ieeexplore.ieee.org', 'IEEE Xplore') %>">ieeexplore.ieee.org</a> <%= render StanfordOnlyPopoverComponent.new %></div>
           </li>
 
           <li class="mb-3">
             <div class="fw-semibold">Google Scholar</div>
             <div>A freely accessible web search engine that indexes the full text or metadata of scholarly literature across an array of publishing formats and disciplines.</div>
-            <div><a href="https://scholar.google.com">scholar.google.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
+            <div><a href="<%= ezproxy_database_link('https://scholar.google.com', 'Google Scholar') %>">scholar.google.com</a> <%= render StanfordOnlyPopoverComponent.new %></div>
           </li>
         </ul>

--- a/config/ezproxy/sul_proxy_file.txt
+++ b/config/ezproxy/sul_proxy_file.txt
@@ -1624,3 +1624,5 @@ archives.datapages.com
 ae.eastview.com
 bulletin.ceramics.org
 sciendo.com
+research.ebsco.com
+scholar.google.com

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -104,4 +104,25 @@ RSpec.describe ApplicationHelper do
       expect(result).to have_link(text: /library website/, href: 'https://library.stanford.edu/search/all?search=kittens')
     end
   end
+
+  describe '#ezproxy_database_link' do
+    subject(:link) { helper.ezproxy_database_link(url, title) }
+    let(:link_title) { 'title' }
+
+    context 'with a URL matching a SUL proxied host' do
+      let(:url) { 'https://research.ebsco.com/whatever' }
+
+      it 'returns a proxy URL' do
+        expect(link).to eq('https://stanford.idm.oclc.org/login?qurl=https%3A%2F%2Fresearch.ebsco.com%2Fwhatever')
+      end
+    end
+
+    context 'with a URL not matching a SUL proxied host' do
+      let(:url) { 'https://not.website.com/whatever' }
+
+      it 'returns the URL in its original form' do
+        expect(link).to eq(url)
+      end
+    end
+  end
 end

--- a/spec/models/links/ezproxy_spec.rb
+++ b/spec/models/links/ezproxy_spec.rb
@@ -152,5 +152,34 @@ RSpec.describe Links::Ezproxy do
         it { expect(ezproxy.to_proxied_url).to be_nil }
       end
     end
+
+    context 'Database link' do
+      let(:document) { nil }
+
+      context 'with a url matching a SUL proxied host' do
+        let(:url) { 'https://research.ebsco.com/whatever' }
+
+        context 'link title is a SUL restriction note' do
+          let(:link_title) { 'Available to Stanford Affiliated users' }
+
+          it 'adds the proxy prefix' do
+            expect(ezproxy.to_proxied_url).to eq 'https://stanford.idm.oclc.org/login?qurl=https%3A%2F%2Fresearch.ebsco.com%2Fwhatever'
+          end
+        end
+
+        context 'link title is NOT a SUL restriction note' do
+          let(:link_title) { 'Some other link note' }
+
+          it { expect(ezproxy.to_proxied_url).to be_nil }
+        end
+      end
+
+      context 'with a url NOT matching a SUL proxied host' do
+        let(:url) { 'https://stanford.idm.oclc.org/login?url=https://library.stanford.edu' }
+        let(:link_title) { 'Available to Stanford Affiliated users' }
+
+        it { expect(ezproxy.to_proxied_url).to be_nil }
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #5539 

What this PR does:

- Adds two URLs from the database links that were not already in the sul proxy list (research.ebsco.com and scholar.google.com)
- Allow the EZProxy class to handle a situation where there is no Solr document (i.e. for the database links)
- Sets up a helper to get the proxied url. The helper also appends text to the title which triggers the proxy URL to be formed. 