### PR TITLE
Separate the link rendering from the link model

### DIFF
--- a/app/assets/stylesheets/searchworks4/links.css
+++ b/app/assets/stylesheets/searchworks4/links.css
@@ -21,10 +21,10 @@
 .nav-pills,
 .zoom-controls .btn-link,
 .bookmark-toolbar,
+.collection-info .finding-aid,
 .export-citations,
 .dropdown-item,
 .facet-options,
-.link-decoration-none
-{
+.link-decoration-none {
   --bs-link-decoration: none;
 }

--- a/app/assets/stylesheets/searchworks4/search-results.css
+++ b/app/assets/stylesheets/searchworks4/search-results.css
@@ -186,18 +186,6 @@ details[open] {
 .collection-info {
   background-color: var(--stanford-fog-light);
 
-  .finding-aid a {
-    --bs-link-decoration: none;
-
-    &::after {
-      content: "\F144";
-      font-family: "bootstrap-icons";
-      padding-left: 0.25rem;
-      --bs-link-decoration: none;
-      vertical-align: bottom;
-    }
-  }
-
   .badge {
     background-color: var(--stanford-20-black);
     --bs-badge-color: var(--stanford-black);

--- a/app/components/access_panels/additional_info_component.html.erb
+++ b/app/components/access_panels/additional_info_component.html.erb
@@ -1,7 +1,7 @@
 <% if document.marc_links.finding_aid.present? %>
     <div class='access-panel-subsection flex-wrap flex-xl-nowrap d-flex row-gap-0 gap-3 align-items-baseline mt-3'>
       <h4 class="fs-15 text-nowrap text-uppercase text-secondary mb-0">Finding aid</h4>
-      <%= document.preferred_finding_aid.html.html_safe %>
+      <%= render Searchworks4::AccessLinkComponent.new(link: document.preferred_finding_aid) %>
     </div>
 <% end %>
 <% if library.library_instructions.present? %>

--- a/app/components/access_panels/collection_component.html.erb
+++ b/app/components/access_panels/collection_component.html.erb
@@ -25,7 +25,7 @@
       <% end %>
       <% if @collection.has_finding_aid? %>
         <dt>Finding aid</dt>
-        <dd><%= @collection.preferred_finding_aid.html.html_safe %></dd>
+        <dd><%= render Searchworks4::AccessLinkComponent.new(link: @collection.preferred_finding_aid) %></dd>
       <% end %>
     </dl>
   <% end %>

--- a/app/components/access_panels/grouped_library_component.html.erb
+++ b/app/components/access_panels/grouped_library_component.html.erb
@@ -6,7 +6,7 @@
   <% if document.marc_links.finding_aid.present? %>
       <div class='access-panel-subsection flex-wrap flex-xl-nowrap d-flex row-gap-0 gap-3 align-items-baseline mb-3'>
         <h4 class="fs-15 text-nowrap text-uppercase text-secondary mb-0">Finding aid</h4>
-        <%= document.preferred_finding_aid.html.html_safe %>
+        <%= render Searchworks4::AccessLinkComponent.new(link: document.preferred_finding_aid) %>
       </div>
   <% end %>
 

--- a/app/components/access_panels/online_link_list_component.html.erb
+++ b/app/components/access_panels/online_link_list_component.html.erb
@@ -12,11 +12,12 @@
   <%= tag.ul class: "links list-unstyled mb-1", id: "online-link-list" do %>
     <% links.each.with_index do |link, index| %>
       <%= tag.li class: "mt-2 #{'border-top' unless index == 0}" do %>
+        <% link_component = Searchworks4::AccessLinkComponent.new(link:) %>
         <div>
-          <%= link.link_html&.html_safe %>
+          <%= link_component.link_html %>
           <%= render StanfordOnlyPopoverComponent.new if link.stanford_only? %>
         </div>
-        <%= link.additional_text_html&.html_safe %>
+        <%= link_component.additional_text_html %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/access_panels/related_component.html.erb
+++ b/app/components/access_panels/related_component.html.erb
@@ -6,7 +6,11 @@
   <% component.with_body do %>
     <ul class="links list-unstyled">
       <% if additional_finding_aids? %>
-        <%= additional_finding_aids.map { |link| content_tag(:li, link.html.html_safe, class: finding_aid_class(link)) }.join.html_safe %>
+        <%= additional_finding_aids.each do |link| %>
+          <%= content_tag :li, class: finding_aid_class(link) do %>
+            <%= render Searchworks4::AccessLinkComponent.new(link:) %>
+          <% end %>
+        <% end %>
       <% end %>
       <% if oclc.present? %>
         <li class="worldcat">

--- a/app/components/record/marc_contents_summary_component.html.erb
+++ b/app/components/record/marc_contents_summary_component.html.erb
@@ -68,7 +68,7 @@
       <ul class="list-unstyled">
         <% document.marc_links.supplemental.each do |link| %>
           <li>
-            <%= link.html %>
+            <%= render Searchworks4::AccessLinkComponent.new(link:) %>
             <%= render StanfordOnlyPopoverComponent.new if link.stanford_only? %>
           </li>
         <% end %>

--- a/app/components/searchworks4/access_link_component.rb
+++ b/app/components/searchworks4/access_link_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Searchworks4
+  class AccessLinkComponent < ViewComponent::Base
+    def initialize(link:)
+      @link = link
+      super
+    end
+
+    attr_accessor :link
+
+    delegate :link_title, :casalini_text, :additional_text, :stanford_only?, :sfx?, :href, to: :link
+
+    def call
+      safe_join([link_html, casalini_text, additional_text_html].compact, ' ')
+    end
+
+    def link_class
+      'sfx' if sfx?
+    end
+
+    def link_html
+      tooltip_attr = if link_title.present? && !stanford_only?
+                       {
+                         title: link_title,
+                         data: { 'bs-placement': 'right', 'bs-toggle': 'tooltip' }
+                       }
+                     else
+                       {}
+                     end
+      content_tag(:a, link_text, href:, class: link_class, **tooltip_attr)
+    end
+
+    def link_text
+      link.link_text || link.link_host
+    end
+
+    def additional_text_html
+      content_tag(:span, additional_text, class: 'additional-link-text') if additional_text
+    end
+  end
+end

--- a/app/components/searchworks4/online_availability_component.html.erb
+++ b/app/components/searchworks4/online_availability_component.html.erb
@@ -4,7 +4,7 @@
   <ul class="list-unstyled mb-0" data-list-toggle-target="group">
     <% links.each do |link| %>
       <li <% if links.many? %>class="mb-1"<% end %>>
-        <%= link.html&.html_safe %>
+        <%= render Searchworks4::AccessLinkComponent.new(link:) %>
         <%= render StanfordOnlyPopoverComponent.new if link.stanford_only? %>
       </li>
     <% end %>

--- a/app/components/searchworks4/search_result/collection_finding_aid_link_component.html.erb
+++ b/app/components/searchworks4/search_result/collection_finding_aid_link_component.html.erb
@@ -1,0 +1,6 @@
+    <div class="clearfix finding-aid">
+      <b class="me-1">Finding aid</b>
+      <%= tag.a href: do %>
+        <%= link_text %><i class="ms-1 bi bi-arrow-up-right"></i>
+      <% end %>
+    </div>

--- a/app/components/searchworks4/search_result/collection_finding_aid_link_component.rb
+++ b/app/components/searchworks4/search_result/collection_finding_aid_link_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Searchworks4
+  module SearchResult
+    class CollectionFindingAidLinkComponent < Searchworks4::AccessLinkComponent
+      def initialize(finding_aid:)
+        @finding_aid = finding_aid
+        super(link: finding_aid.first)
+      end
+
+      def render?
+        @link.present?
+      end
+    end
+  end
+end

--- a/app/components/searchworks4/search_result/collection_info_component.html.erb
+++ b/app/components/searchworks4/search_result/collection_info_component.html.erb
@@ -17,11 +17,7 @@
         <b>Digital collection</b> <%= render BadgeCounterComponent.new(collection.collection_members.total, 'item') %></span>
       </div>
     <% end %>
-    <% if collection.marc_links.finding_aid.present? %>
-      <div class="clearfix finding-aid">
-        <b class="me-1">Finding aid</b> <%= collection.marc_links.finding_aid.first.html.html_safe %>
-      </div>
-    <% end %>
+    <%= render Searchworks4::SearchResult::CollectionFindingAidLinkComponent.new(finding_aid: collection.marc_links.finding_aid) %>
   </div>
 
   <% if collection[:summary_display] %>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -555,7 +555,7 @@ class CatalogController < ApplicationController
 
   def augment_solr_document_json_response(documents)
     documents.map do |document|
-      JsonResultsDocumentPresenter.new(document)
+      JsonResultsDocumentPresenter.new(document, view_context)
     end
   end
   helper_method :augment_solr_document_json_response

--- a/app/models/json_results_document_presenter.rb
+++ b/app/models/json_results_document_presenter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class JsonResultsDocumentPresenter
-  def initialize(source_document)
+  def initialize(source_document, view_context)
     @source_document = source_document
+    @view_context = view_context
   end
 
   def as_json(*)
@@ -24,7 +25,8 @@ class JsonResultsDocumentPresenter
 
     {
       'fulltext_link_html' => online_links.map do |link|
-        html = link.stanford_only? ? "<span class=\"stanford-only\">#{link.html}</span>" : link.html
+        access_link = Searchworks4::AccessLinkComponent.new(link:).render_in(@view_context)
+        html = link.stanford_only? ? "<span class=\"stanford-only\">#{access_link}</span>" : access_link
 
         "<span class=\"online-label\">Online</span> #{html}"
       end

--- a/app/models/links/link.rb
+++ b/app/models/links/link.rb
@@ -4,7 +4,7 @@ class Links
   class Link
     include ActionView::Helpers::TagHelper
 
-    attr_accessor :href, :file_id, :druid, :type, :sort
+    attr_accessor :href, :file_id, :druid, :type, :sort, :link_title, :link_text, :additional_text
 
     def initialize(options = {})
       @additional_text = options[:additional_text]
@@ -24,12 +24,8 @@ class Links
       @type = options[:type]
     end
 
-    def html
-      @html ||= safe_join([link_html, casalini_text, additional_text_html].compact, ' ')
-    end
-
     def text
-      @text ||= safe_join([@link_text || link_host, casalini_text, additional_text_html].compact, ' ')
+      @text ||= safe_join([@link_text || link_host, casalini_text, additional_text].compact, ' ')
     end
 
     def part_label(index:)
@@ -60,16 +56,8 @@ class Links
       @ill
     end
 
-    def additional_text_html
-      content_tag(:span, @additional_text, class: 'additional-link-text') if @additional_text
-    end
-
     def casalini_text
       '(source: Casalini)' if @casalini
-    end
-
-    def link_class
-      'sfx' if @sfx
     end
 
     def link_host
@@ -84,18 +72,6 @@ class Links
       host || @href
     rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
       @href
-    end
-
-    def link_html
-      tooltip_attr = if @link_title.present? && !stanford_only?
-                       {
-                         title: @link_title,
-                         data: { 'bs-placement': 'right', 'bs-toggle': 'tooltip' }
-                       }
-                     else
-                       {}
-                     end
-      content_tag(:a, @link_text || link_host, href: @href, class: link_class, **tooltip_attr)
     end
   end
 end

--- a/app/views/search_works_record_mailer/full_email_record.html.erb
+++ b/app/views/search_works_record_mailer/full_email_record.html.erb
@@ -20,7 +20,7 @@
           <h2>Online</h2>
           <div class="preferred-online-links">
           <% document.preferred_online_links.each do |link| %>
-            <%= link.html.html_safe %><br/>
+            <%= render Searchworks4::AccessLinkComponent.new(link:) %><br/>
           <% end %>
           </div>
         <% end %>

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
       links = sfx.links
       expect(links.length).to eq 1
       expect(links.first).to be_sfx
-      expect(links.first.html).to match %r{^<a href=.*class="sfx">Find full text<\/a>$}
+      expect(links.first.link_text).to eq 'Find full text'
     end
 
     it 'returns fulltext links for collection members' do

--- a/spec/components/searchworks4/access_link_component_spec.rb
+++ b/spec/components/searchworks4/access_link_component_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Searchworks4::AccessLinkComponent, type: :component do
+  let(:link) do
+    Links::Link.new(
+      href: 'http://link.edu', link_text: 'Link Text', fulltext: true, stanford_only: true, finding_aid: true, sfx: true, managed_purl: true
+    )
+  end
+
+  before do
+    render_inline(described_class.new(link: link))
+  end
+
+  it 'assembles the html link' do
+    expect(page).to have_link 'Link Text', href: 'http://link.edu', class: 'sfx'
+  end
+end

--- a/spec/models/concerns/marc_links_spec.rb
+++ b/spec/models/concerns/marc_links_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe MarcLinks do
     it 'decodes structured data in the document' do
       expect(document.marc_links.all.length).to eq 4
       expect(document.marc_links.fulltext.first.text).to eq 'fulltext'
-      expect(document.marc_links.finding_aid.first.html).to eq '<a href="http://oac.cdlib.org/findai/ark:/13030/an-ark">Online Archive of California</a>'
+      expect(document.marc_links.finding_aid.first.href).to eq 'http://oac.cdlib.org/findai/ark:/13030/an-ark'
+      expect(document.marc_links.finding_aid.first.link_text).to eq 'Online Archive of California'
       expect(document.marc_links.supplemental.first).to be_stanford_only
       expect(document.marc_links.managed_purls.first.text).to eq 'druid'
       expect(document.marc_links.managed_purls.first.file_id).to eq 'x'
@@ -66,8 +67,8 @@ RSpec.describe MarcLinks do
 
       it 'returns both fulltext and supplemental links' do
         expect(marc_links.length).to eq 2
-        expect(marc_links.first.html).to match(%r{^<a href="https://library\.stanford\.edu"})
-        expect(marc_links.last.html).to match(%r{^<a href="https://searchworks\.stanford\.edu">link text</a>$})
+        expect(marc_links.first.href).to eq "https://library.stanford.edu"
+        expect(marc_links.last.href).to eq "https://searchworks.stanford.edu"
       end
 
       it 'returns the plain text and href separately' do
@@ -98,9 +99,10 @@ RSpec.describe MarcLinks do
         it 'identifies finding aid links' do
           expect(marc_links.first).to be_finding_aid
           expect(document.marc_links.finding_aid.length).to eq 1
-          expect(document.marc_links.finding_aid.first.html).to match(
-            %r{<a href=".*oac\.cdlib\.org/findaid/ark:/something-else">Online Archive of California</a>}
-          )
+          finding_aid = document.marc_links.finding_aid.first
+
+          expect(finding_aid.href).to eq "http://oac.cdlib.org/findaid/ark:/something-else"
+          expect(finding_aid.text).to eq "Online Archive of California"
         end
       end
 
@@ -127,9 +129,9 @@ RSpec.describe MarcLinks do
         it 'displays the preferred (Archives) finding aid' do
           expect(marc_links.first).to be_finding_aid
           expect(document.marc_links.finding_aid.length).to eq 2
-          expect(document.marc_links.finding_aid.first.html).to match(
-            %r{<a href=".*archives\.stanford\.edu/findaid/ark:/archives-ark-id">Archival Collections at Stanford</a>}
-          )
+          finding_aid = document.marc_links.finding_aid.first
+          expect(finding_aid.href).to eq "http://archives.stanford.edu/findaid/ark:/archives-ark-id"
+          expect(finding_aid.text).to eq "Archival Collections at Stanford"
         end
       end
 
@@ -159,10 +161,10 @@ RSpec.describe MarcLinks do
 
         it 'parses them properly' do
           expect(marc_links.length).to eq 4
-          expect(marc_links.first.html).to match(
-            %r{<a href=.*example\.com/lookup\?\^The\+Query.*>www\.example\.com</a>}
-          )
-          expect(marc_links[2].html).to match(%r{<a.*> at: </a>})
+
+          expect(marc_links.first.href).to eq "http://www.example.com/lookup?^The+Query+Is+No+Good"
+          expect(marc_links.first.text).to eq "www.example.com"
+          expect(marc_links[2].text).to eq " at: "
         end
       end
 
@@ -178,7 +180,7 @@ RSpec.describe MarcLinks do
           expect(marc_links.first).to be_sfx
           expect(document.marc_links.sfx.length).to eq 1
           expect(document.marc_links.sfx.first).to be_sfx
-          expect(document.marc_links.sfx.first.html).to match(%r{^<a href=.*class="sfx">Find full text</a>$})
+          expect(document.marc_links.sfx.first.text).to eq 'Find full text'
         end
       end
 
@@ -199,8 +201,8 @@ RSpec.describe MarcLinks do
 
           it 'returns the URL in the url parameter for ezproxy links (but fallback on the URL host)' do
             expect(marc_links.length).to eq 2
-            expect(marc_links.first.html).to match(%r{<a href=.*>library\.stanford\.edu</a>})
-            expect(marc_links.last.html).to match(%r{<a href=.*>ezproxy\.stanford\.edu</a>})
+            expect(marc_links.first.text).to eq 'library.stanford.edu'
+            expect(marc_links.last.text).to eq 'ezproxy.stanford.edu'
           end
         end
 

--- a/spec/models/json_results_document_presenter_spec.rb
+++ b/spec/models/json_results_document_presenter_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe JsonResultsDocumentPresenter do
-  subject(:presenter) { described_class.new(source_document) }
+  subject(:presenter) { described_class.new(source_document, view_context) }
 
   let(:document_data) { { id: 'abc123', title_display: 'The Title' } }
   let(:source_document) { SolrDocument.new(document_data) }
+  let(:view_context) { ApplicationController.new.view_context }
 
   describe '#as_json' do
     it 'returns the SolrDocument as_json response' do

--- a/spec/models/links/link_spec.rb
+++ b/spec/models/links/link_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe 'Link' do
     )
   end
 
-  it 'assembles the html link' do
-    expect(link.html).to eq '<a href="http://link.edu" class="sfx">Link Text</a>'
-  end
-
-  it 'makes an html_safe html link' do
-    expect(link.html).to be_html_safe
-  end
-
   it 'assembles the text' do
     expect(link.text).to eq 'Link Text'
   end


### PR DESCRIPTION
Currently it's hard to customize the rendering of the link to match the designs (which ask for icons in some of the links).

This brings some consistency to icon rendering.
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
