### PR TITLE
Move and restyle donor masthead

### DIFF
--- a/app/assets/stylesheets/searchworks4.scss
+++ b/app/assets/stylesheets/searchworks4.scss
@@ -13,6 +13,7 @@ layer(framework);
 @import url("searchworks4/availability-icons.css") layer(local);
 @import url("searchworks4/blacklight.css") layer(local);
 @import url("searchworks4/bookmarks.css") layer(local);
+@import url("searchworks4/bookplates.css") layer(local);
 @import url("searchworks4/browse-embed.css") layer(local);
 @import url("searchworks4/browse-nearby.css") layer(local);
 @import url("searchworks4/course-reserves.css") layer(local);

--- a/app/assets/stylesheets/searchworks4/bookplates.css
+++ b/app/assets/stylesheets/searchworks4/bookplates.css
@@ -1,0 +1,12 @@
+.bookplate-fund-masthead {
+  background-color: var(--stanford-fog-light);
+
+  img {
+    width: 100%;
+    max-width: 200px;
+
+    @media (width >= 1199.98px) {
+      max-width: 400px;
+    }
+  }
+}

--- a/app/assets/stylesheets/searchworks4/gallery-view.css
+++ b/app/assets/stylesheets/searchworks4/gallery-view.css
@@ -1,4 +1,4 @@
-.gallery {
+.gallery, .documents-gallery {
   --gallery-document-total-height: 349px;
   --gallery-document-width: 140px;
   --gallery-document-thumbnail-height: 171px;

--- a/app/components/bookplate_fund_component.html.erb
+++ b/app/components/bookplate_fund_component.html.erb
@@ -1,20 +1,20 @@
-<% bookplate = bookplate_from_document_list %>
-<% if bookplate.present? %>
-  <%= render Masthead::LayoutComponent.new do |component| %>
-    <% component.with_header { bookplate.text } %>
+<div class="bookplate-fund-masthead col p-3 mb-4">
+  <div class="row">
+    <div class="col-sm-4 col-md-3 d-flex flex-column align-items-md-end">
+      <%= image_tag(thumbnail_url, alt: text, class: 'mb-2 mx-auto') %>
+    </div>
 
-    <%= image_tag(bookplate.thumbnail_url, alt: bookplate.text) %>
-
-    <% component.with_aside do %>
-      <p>
+    <div class="col-sm-8 col-md-9">
+      <h1 class="h2 mb-3"><%= text %></h1>
+      <p class="mb-3">
         The library resources listed below were acquired with the generous support of this endowed materials fund.
       </p>
-      <p>
+      <p class="mb-3">
         Donors and family representatives who have created and sustained library endowments ensure the most relevant research materials are available to students, faculty and scholars in perpetuity, a tradition started by Jane Stanford when she created the first library endowment from the proceeds of the sale of her jewel collection.
       </p>
-      <p>
+      <p class="mb-3">
         Learn more about the many ways to <a href="https://library.stanford.edu/support-stanford-libraries">support teaching, learning and research at Stanford Libraries.</a>
       </p>
-    <% end %>
-  <% end %>
-<% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/bookplate_fund_component.rb
+++ b/app/components/bookplate_fund_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BookplateFundComponent < ViewComponent::Base
+  def initialize(bookplate:)
+    super
+
+    @bookplate = bookplate
+  end
+
+  attr_reader :bookplate
+
+  delegate :text, :thumbnail_url, to: :bookplate
+
+  def render?
+    bookplate.present?
+  end
+end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -25,6 +25,7 @@
 <% end -%>
 
 <h1 class="visually-hidden">Search Results</h1>
+<%= render BookplateFundComponent.new(bookplate: bookplate_from_document_list) %>
 <% if has_search_parameters? && !hide_constraints %>
   <div class="row">
     <div class="constraints col d-flex">

--- a/lib/page_location.rb
+++ b/lib/page_location.rb
@@ -23,8 +23,6 @@ class PageLocation
                         :digital_collections
                       when dissertation_theses_parameters?
                         :dissertation_theses
-                      when bookplate_fund_parameters?
-                        :bookplate_fund
                       when government_documents_parameters?
                         :government_documents
                       when iiif_resources_parameters?

--- a/spec/features/bookplates_spec.rb
+++ b/spec/features/bookplates_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Bookplates' do
 
       click_link 'Susan and Ruth Sharp Fund'
 
-      within('.search-masthead') do
+      within('.bookplate-fund-masthead') do
         expect(page).to have_css('img')
         expect(page).to have_css('h1', text: 'Susan and Ruth Sharp Fund')
         expect(page).to have_content masthead_text
@@ -55,7 +55,7 @@ RSpec.describe 'Bookplates' do
 
       click_link 'The Edgar Amos Boyles Centennial Book Fund'
 
-      within('.search-masthead') do
+      within('.bookplate-fund-masthead') do
         expect(page).to have_css('img')
         expect(page).to have_css('h1', text: 'The Edgar Amos Boyles Centennial Book Fund')
         expect(page).to have_content masthead_text

--- a/spec/lib/page_location_spec.rb
+++ b/spec/lib/page_location_spec.rb
@@ -164,19 +164,6 @@ RSpec.describe PageLocation do
         end
       end
 
-      describe 'bookplate_fund' do
-        before { params[:f] = { fund_facet: ['ABC123'] } }
-
-        it 'is defined when the fund_facet is present' do
-          expect(access_point).to eq :bookplate_fund
-        end
-
-        it 'is defined when the fund_facet is empty' do
-          params[:f] = { fund_facet: [] }
-          expect(access_point).to be_nil
-        end
-      end
-
       describe 'government_documents' do
         before { params[:f] = { genre_ssim: ['Government document', 'Something else'] } }
 


### PR DESCRIPTION
Ref #5548 

Makes the requested masthead change (moved above the contraints in a Slack conversation) and pulls in the gallery styling. Widening the gallery view at XXL size and bringing back the view mode selection will be in subsequent PRs.

<img width="1156" height="752" alt="Screenshot 2025-07-14 at 3 21 22 PM" src="https://github.com/user-attachments/assets/a90ca8c5-ee29-4242-acbe-6853574aed4b" />
