### PR TITLE
Persist the q parameter when toggling between different search modes (but don't persist it after searching)

### DIFF
--- a/app/components/homepage_search_component.html.erb
+++ b/app/components/homepage_search_component.html.erb
@@ -10,7 +10,7 @@
       <label class="form-check-label" for="searchTypeArticle">Articles+</label>
     </div>
   </div>
-  <%= form_with url: @url, local: true, method: @method, class: @classes.join(' '), scope: @prefix, role: 'search', **@form_options do |f| %>
+  <%= form_with url: @url, local: true, method: @method, class: @classes.join(' '), scope: @prefix, role: 'search', data: { action: 'home-page-search#submit' }, **@form_options do |f| %>
     <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
     <% if search_fields.length > 1 %>
       <%= f.label :search_field, scoped_t('search_field.label'), class: 'visually-hidden' %>
@@ -38,7 +38,7 @@
           <ul id="autocomplete-popup" class="dropdown-menu" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
         </auto-complete>
       <% else %>
-        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control #{rounded_border_class}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control #{rounded_border_class}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }, data: { 'turbo-permanent': true }  %>
       <% end %>
 
       <%= append %>

--- a/app/components/homepage_search_component.html.erb
+++ b/app/components/homepage_search_component.html.erb
@@ -1,0 +1,49 @@
+<search class="search-card px-4 py-3 rounded" data-controller="home-page-search">
+  <div class="mb-3">
+    <span class="fw-bold">Search mode:</span>
+    <div class="form-check form-check-inline mx-3">
+      <input class="form-check-input" type="radio" name="search-type" id="searchTypeCatalog" value="catalog" <%= 'checked' if current_page?(root_path) %> data-action="home-page-search#toggle" data-url="<%= root_path %>">
+      <label class="form-check-label" for="searchTypeCatalog">Catalog</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="radio" name="search-type" id="searchTypeArticle" value="articles" <%= 'checked' if current_page?(articles_path) %> data-action="home-page-search#toggle" data-url="<%= articles_path %>">
+      <label class="form-check-label" for="searchTypeArticle">Articles+</label>
+    </div>
+  </div>
+  <%= form_with url: @url, local: true, method: @method, class: @classes.join(' '), scope: @prefix, role: 'search', **@form_options do |f| %>
+    <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
+    <% if search_fields.length > 1 %>
+      <%= f.label :search_field, scoped_t('search_field.label'), class: 'visually-hidden' %>
+    <% end %>
+    <% before_input_groups.each do |input_group| %>
+      <%= input_group %>
+    <% end %>
+    <div class="input-group">
+      <%= prepend %>
+
+      <% if search_fields.length > 1 %>
+        <%= f.select(:search_field,
+                    options_for_select(search_fields, h(@search_field)),
+                    {},
+                    title: scoped_t('search_field.title'),
+                    class: "custom-select form-select search-field") %>
+      <% elsif search_fields.length == 1 %>
+        <%= f.hidden_field :search_field, value: search_fields.first.last %>
+      <% end %>
+
+      <%= f.label @query_param, scoped_t('search.label'), class: 'visually-hidden' %>
+      <% if autocomplete_path.present? %>
+        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper form-control <%= rounded_border_class %>">
+          <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control #{rounded_border_class}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
+          <ul id="autocomplete-popup" class="dropdown-menu" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
+        </auto-complete>
+      <% else %>
+        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control #{rounded_border_class}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+      <% end %>
+
+      <%= append %>
+      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
+    </div>
+  <% end %>
+  <p class="mt-3 mb-0"><%= footer %></p>
+</search>

--- a/app/components/masthead/layout_component.html.erb
+++ b/app/components/masthead/layout_component.html.erb
@@ -8,7 +8,7 @@
         <% if search? %>
           <%= search %>
         <% else %>
-          <%= render HomepageSearchComponent.new url: helpers.search_action_url,
+          <%= render MastheadSearchComponent.new url: helpers.search_action_url,
                                             advanced_search_url: helpers.search_action_url(action: 'advanced_search'),
                                             params: helpers.search_state.params_for_search.except(:qt),
                                             autocomplete_path: suggest_index_catalog_path %>

--- a/app/components/masthead_search_component.rb
+++ b/app/components/masthead_search_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class HomepageSearchComponent < Blacklight::SearchBarComponent
-  renders_one :footer
-
+class MastheadSearchComponent < Blacklight::SearchBarComponent
   def search_button
     render SearchButtonComponent.new(id: "#{@prefix}search", text: 'Search')
   end

--- a/app/javascript/controllers/home_page_search_controller.js
+++ b/app/javascript/controllers/home_page_search_controller.js
@@ -10,4 +10,8 @@ export default class extends Controller {
 
     Turbo.visit(url, { action: 'replace' });
   }
+
+  submit() {
+    delete this.element.querySelector('#q').dataset.turboPermanent;
+  }
 }

--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -2,22 +2,11 @@
 <% content_for(:search_navbar) do %>
   <div class="search-area-image-bg mb-3">
     <div class="container">
-      <search class="search-card px-4 py-3 rounded" data-controller="home-page-search">
-        <div class="mb-3">
-          <span class="fw-bold">Search mode:</span>
-          <div class="form-check form-check-inline mx-3">
-            <input class="form-check-input" type="radio" name="search-type" id="searchTypeCatalog" value="catalog" data-action="home-page-search#toggle" data-url="<%= root_path %>">
-            <label class="form-check-label" for="searchTypeCatalog">Catalog</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="search-type" id="searchTypeArticle" value="articles" checked>
-            <label class="form-check-label" for="searchTypeArticle">Articles+</label>
-          </div>
-        </div>
         <%= render HomepageSearchComponent.new url: search_action_url,
-                                              params: search_state.params_for_search.except(:qt),
-                                              autocomplete_path: suggest_index_catalog_path %>
-        <p class="mt-3">Search over two billion resources from Stanford University Libraries’ digital subscriptions, including articles, eBooks, eNewspapers, and other electronic resources.</p>
+                                               params: search_state.params_for_search.except(:qt),
+                                               autocomplete_path: suggest_index_catalog_path do |component| %>
+          <% component.with_footer { 'Search over two billion resources from Stanford University Libraries’ digital subscriptions, including articles, eBooks, eNewspapers, and other electronic resources.' } %>
+        <% end %>
       </search>
     </div>
   </div>

--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -2,24 +2,12 @@
 <% content_for(:search_navbar) do %>
   <div class="search-area-image-bg mb-3">
     <div class="container">
-      <search class="search-card px-4 py-3 rounded" data-controller="home-page-search">
-        <div class="mb-3">
-          <span class="fw-bold">Search mode:</span>
-          <div class="form-check form-check-inline mx-3">
-            <input class="form-check-input" type="radio" name="search-type" id="searchTypeCatalog" value="catalog" checked>
-            <label class="form-check-label" for="searchTypeCatalog">Catalog</label>
-          </div>
-          <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="search-type" id="searchTypeArticle" value="articles" data-action="home-page-search#toggle" data-url="<%= articles_path %>">
-            <label class="form-check-label" for="searchTypeArticle">Articles+</label>
-          </div>
-        </div>
         <%= render HomepageSearchComponent.new url: search_action_url,
                                               advanced_search_url: search_action_url(action: 'advanced_search'),
                                               params: search_state.params_for_search.except(:qt),
-                                              autocomplete_path: suggest_index_catalog_path %>
-        <p class="mt-3 mb-0">Search over twelve million resources from Stanford University Libraries’ physical and digital collections, including books, journals, maps, media, government documents, databases, datasets, and more.</p>
-      </search>
+                                              autocomplete_path: suggest_index_catalog_path do |component| %>
+          <% component.with_footer { 'Search over twelve million resources from Stanford University Libraries’ physical and digital collections, including books, journals, maps, media, government documents, databases, datasets, and more.' } %>
+        <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/catalog/mastheads/_digital_collections.html.erb
+++ b/app/views/catalog/mastheads/_digital_collections.html.erb
@@ -2,7 +2,7 @@
   <% component.with_header { 'Stanford digital collections' } %>
 
   <% component.with_search do %>
-    <%= render HomepageSearchComponent.new url: search_action_url,
+    <%= render MastheadSearchComponent.new url: search_action_url,
                                       advanced_search_url: search_action_url(action: 'advanced_search'),
                                       params: search_state.params_for_search.except(:qt),
                                       autocomplete_path: suggest_index_catalog_path %>

--- a/app/views/catalog/mastheads/_government_documents.html.erb
+++ b/app/views/catalog/mastheads/_government_documents.html.erb
@@ -2,7 +2,7 @@
   <% component.with_header { 'Government documents' } %>
 
   <% component.with_search do %>
-    <%= render HomepageSearchComponent.new url: search_action_url,
+    <%= render MastheadSearchComponent.new url: search_action_url,
                                       advanced_search_url: search_action_url(action: 'advanced_search'),
                                       params: search_state.params_for_search.except(:qt),
                                       autocomplete_path: suggest_index_catalog_path %>

--- a/app/views/catalog/mastheads/_sdr.html.erb
+++ b/app/views/catalog/mastheads/_sdr.html.erb
@@ -3,7 +3,7 @@
 
   <% component.with_search do %>
     <div class="fs-5 mb-2">Search by title, author or format</div>
-    <%= render HomepageSearchComponent.new url: search_action_url,
+    <%= render MastheadSearchComponent.new url: search_action_url,
                                       advanced_search_url: search_action_url(action: 'advanced_search'),
                                       params: search_state.params_for_search.except(:qt),
                                       autocomplete_path: suggest_index_catalog_path %>

--- a/app/views/databases/_header.html.erb
+++ b/app/views/databases/_header.html.erb
@@ -3,7 +3,7 @@
 
   <% component.with_search do %>
     <div class="fs-5 mb-2">Search for databases by title or subject area</div>
-    <%= render HomepageSearchComponent.new url: search_action_url,
+    <%= render MastheadSearchComponent.new url: search_action_url,
                                             params: search_state.params_for_search.except(:qt),
                                             autocomplete_path: suggest_index_catalog_path %>
   <% end %>

--- a/app/views/shared/searchworks4/_search_navbar.html.erb
+++ b/app/views/shared/searchworks4/_search_navbar.html.erb
@@ -12,7 +12,7 @@
         <label class="form-check-label" for="searchTypeArticle">Articles+</label>
       </div>
     </div>
-    <%= render HomepageSearchComponent.new url: search_action_url,
+    <%= render MastheadSearchComponent.new url: search_action_url,
                                           advanced_search_url: controller_name.in?(%w[article_selections articles]) ? nil : search_action_url(action: 'advanced_search'),
                                           params: search_state.params_for_search.except(:qt),
                                           autocomplete_path: suggest_index_catalog_path %>


### PR DESCRIPTION
Fixes #5616 