### PR TITLE
Use flex instead of floats for dl styling.

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -1,15 +1,38 @@
 @media (min-width: 520px) {
   .dl-horizontal {
+    & > div {
+      display: flex;
+      flex-wrap: wrap;
+    }
+
     dt {
-      float: left;
+      flex: 0 0 auto;
+      padding-right: 0.5rem;
       width: 9.5em;
-      margin-right: 0.5em;
       overflow-wrap: break-word;
       hyphens: auto;
     }
 
     dd {
-      margin-left: 10em;
+      flex: 0 0 auto;
+      margin-left: 9.5em;
+      width: calc(100% - 9.5em);
+    }
+
+    dd:first-of-type {
+      margin-left: 0;
+    }
+  }
+}
+
+@media (max-width: 1200px) {
+  .dl-text {
+    dt {
+      width: 100%;
+    }
+
+    dd {
+      width: 100%;
     }
   }
 }

--- a/app/components/record/marc_contents_summary_component.html.erb
+++ b/app/components/record/marc_contents_summary_component.html.erb
@@ -12,7 +12,7 @@
 
 <% toc = document.fetch(:toc_struct, []).first %>
 <% if toc.present? %>
-  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new(classes: ['my-3 dl-text']) do |component| %>
     <% component.with_label { toc[:label] } %>
     <% component.with_value data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-5'} do %>
       <div data-long-text-target="text">
@@ -49,7 +49,7 @@
 <% end %>
 
 <% summaries.each do |summary|%>
-  <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+  <%= render Searchworks4::MetadataFieldLayoutComponent.new(classes: 'my-3 dl-text') do |component| %>
     <% component.with_label { summary[:label] || 'Summary' } %>
     <% summary.fetch(:fields, []).each do |field| %>
       <% component.with_value data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-5'} do %>

--- a/app/components/record/marc_document_component.html.erb
+++ b/app/components/record/marc_document_component.html.erb
@@ -64,7 +64,7 @@
       <% end %>
     <% end %>
 
-    <%= render Searchworks4::DocumentSectionLayout.new(title: 'Contents/Summary', dl_classes: '') do %>
+    <%= render Searchworks4::DocumentSectionLayout.new(title: 'Contents/Summary') do %>
       <%= render Record::MarcContentsSummaryComponent.new(document: document) %>
     <% end %>
 

--- a/app/components/searchworks4/metadata_field_layout_component.html.erb
+++ b/app/components/searchworks4/metadata_field_layout_component.html.erb
@@ -1,6 +1,6 @@
-<div class="my-3 clearfix" data-list-toggle-target="group">
+<%= tag.div class: @classes, data: { 'list-toggle-target': 'group' } do %>
   <%= tag.dt label, title: (label if label.to_s.length > 20 )%>
   <% values.each do |v| %>
     <%= v %>
   <% end %>
-</div>
+<% end %>

--- a/app/components/searchworks4/metadata_field_layout_component.rb
+++ b/app/components/searchworks4/metadata_field_layout_component.rb
@@ -7,6 +7,11 @@ module Searchworks4
       tag.dd(**kwargs, &block)
     }
 
+    def initialize(classes: ['my-3'])
+      @classes = classes
+      super
+    end
+
     def render?
       values?
     end


### PR DESCRIPTION
... and have summary + tables on contents use the horizontal styling only at XXL viewports.