### PR TITLE
Remove trailing colon from articles+ field labels

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -24,7 +24,9 @@ en:
         submit: ''
       form_label: 'search for'
       filters:
-          title: 'Your selections: '
+        title: 'Your selections: '
+      index:
+        label: '%{label}'
       start_over: 'Clear all'
       librarian_view:
         empty: 'No librarian view available'


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
