### PR TITLE
Make the online header padding match libraries, and remove the word '…

### DIFF
--- a/app/components/access_panels/online_component.html.erb
+++ b/app/components/access_panels/online_component.html.erb
@@ -2,13 +2,13 @@
 <%= tag.div class: "panel-online mb-3", hidden: !links.any? do %>
   <%= render @layout.new do |component| %>
     <% component.with_title(classes: 'h4') do %>
-      <div class="bg-light p-1 ms-n3 ps-3 text-digital-green">
+      <div class="bg-light p-1 py-2 ms-n3 ps-3 text-digital-green">
         <% if document.is_a_database? %>
           Search this database
         <% elsif document.druid %>
           Also available at
         <% else %>
-          Available online
+          Online
         <% end %>
       </div>
     <% end %>

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
       document = SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }])
       render_inline(described_class.new(document:))
       expect(page).to have_css(".panel-online")
-      expect(page).to have_css("h2", text: "Available online")
+      expect(page).to have_css("h2", text: "Online")
       expect(page).to have_css("ul.links li a", text: "Link text")
     end
     it 'adds the stanford-only icon to Stanford only resources' do

--- a/spec/features/access_panels/online_spec.rb
+++ b/spec/features/access_panels/online_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Online Access Panel" do
       visit solr_document_path('57')
 
       within('.panel-online') do
-        expect(page).to have_css('h2', text: 'Available online')
+        expect(page).to have_css('h2', text: 'Online')
 
         within('turbo-frame#sfx-data') do
           expect(page).to have_css('ul li a', text: 'TargetName')


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
<img width="292" height="160" alt="Screenshot 2025-07-15 at 12 41 43" src="https://github.com/user-attachments/assets/b5c4e75b-ae42-4a26-896c-a523cc7479dc" />
