### PR TITLE
Include the reCAPTCHA privacy policy

### DIFF
--- a/app/assets/stylesheets/searchworks4.scss
+++ b/app/assets/stylesheets/searchworks4.scss
@@ -61,6 +61,6 @@ layer(framework);
   }
 
   .grecaptcha-badge {
-    display: none;
+    visibility: hidden;
   }
 }

--- a/app/components/recaptcha_component.html.erb
+++ b/app/components/recaptcha_component.html.erb
@@ -1,3 +1,4 @@
 <div class="recaptcha" data-recaptcha-target="tags" data-recaptcha-action-value="<%= action %>" data-recaptcha-site-key-value="<%= site_key %>">
+  This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
   <%= recaptcha_v3 action:, inline_script:, site_key: %>
 </div>

--- a/spec/components/recaptcha_component_spec.rb
+++ b/spec/components/recaptcha_component_spec.rb
@@ -11,5 +11,8 @@ RSpec.describe RecaptchaComponent, type: :component do
     expect(page).to have_css '[data-recaptcha-target="tags"]'
     expect(page).to have_css '[data-recaptcha-action-value="feedback"]'
     expect(page).to have_css '[data-recaptcha-site-key-value]'
+    expect(page).to have_text 'This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply'
+    expect(page).to have_link href: 'https://policies.google.com/privacy'
+    expect(page).to have_link href: 'https://policies.google.com/terms'
   end
 end


### PR DESCRIPTION
For compliance with: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed

Feedback modal, form, and the email modal will all have text like this:
<img width="789" height="241" alt="Screenshot 2025-07-15 at 3 04 56 PM" src="https://github.com/user-attachments/assets/31d37242-9612-4327-a045-75d658fb2bea" />
