### PR TITLE
Remove online label from document gallery component

### DIFF
--- a/app/components/search_result/document_gallery_component.html.erb
+++ b/app/components/search_result/document_gallery_component.html.erb
@@ -11,7 +11,6 @@
     <div class="documentHeader">
       <div class="index_title">
         <span class="two-lines">
-          <%= document.online_label %>
           <%= helpers.link_to_document document, class: 'fw-semibold', counter: counter, data: { action: "click->analytics#trackLink"} %>
         </span>
       </div>


### PR DESCRIPTION
Current designs do not use this. We can add it back in later if Darcy includes it.

Before:
<img width="151" height="363" alt="Screenshot 2025-07-15 at 3 39 23 PM" src="https://github.com/user-attachments/assets/4ff9b843-c3e0-49c8-ad5a-1f9205a22807" />

After:
<img width="152" height="360" alt="Screenshot 2025-07-15 at 3 39 51 PM" src="https://github.com/user-attachments/assets/29f1e582-77a7-4b32-8c4b-eddab0943aa3" />
