### PR TITLE
Move #search-navbar styles to search.css

### DIFF
--- a/app/assets/stylesheets/searchworks4/blacklight.css
+++ b/app/assets/stylesheets/searchworks4/blacklight.css
@@ -138,9 +138,8 @@
   }
 }
 
-
 .modal {
-  --bl-modal-backdrop-bg: rgba(var(--stanford-black-rgb), 0.4)
+  --bl-modal-backdrop-bg: rgba(var(--stanford-black-rgb), 0.4);
 }
 
 .modal-dialog {
@@ -187,21 +186,5 @@ dialog.modal[open] {
 
   &::backdrop {
     background-color: var(--bl-modal-backdrop-bg);
-  }
-}
-
-#search-navbar search {
-  width: 100%;
-}
-
-@media (width >= 767.98px) {
-  #search-navbar search {
-    width: 60%;
-  }
-}
-
-@media (width >= 1199.98px) {
-  #search-navbar search {
-    width: 50%;
   }
 }

--- a/app/assets/stylesheets/searchworks4/search.css
+++ b/app/assets/stylesheets/searchworks4/search.css
@@ -57,6 +57,22 @@
   }
 }
 
+#search-navbar search {
+  width: 100%;
+}
+
+@media (width >= 767.98px) {
+  #search-navbar search {
+    width: 60%;
+  }
+}
+
+@media (width >= 1199.98px) {
+  #search-navbar search {
+    width: 50%;
+  }
+}
+
 #advanced-search-form {
   input:focus-visible {
     box-shadow: none;


### PR DESCRIPTION
These are not styles provided by blacklight, so it's a bit confusing to have them in the blacklight stylesheet

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
