### PR TITLE
Fix dataset icon alignment on the record view page

### DIFF
--- a/app/assets/stylesheets/searchworks4/sul-icons.css
+++ b/app/assets/stylesheets/searchworks4/sul-icons.css
@@ -1,7 +1,4 @@
 /* Chart icons aligns weird because it is only ~10px tall */
-.results-metadata-sections .blacklight-icons-business_chart1 {
-  svg { vertical-align: inherit; }
-  svg g {
-    vertical-align: middle;
-  }
+article .blacklight-icons-business_chart1 svg {
+  vertical-align: -1px;
 }


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before
<img width="1177" height="135" alt="Screenshot 2025-07-16 at 11 58 27 AM" src="https://github.com/user-attachments/assets/d97431f0-6cef-414e-a95e-e77b6f76aaeb" />

After
<img width="1110" height="173" alt="Screenshot 2025-07-16 at 11 58 20 AM" src="https://github.com/user-attachments/assets/0fbf2b05-9e64-40ba-a3c0-597bd2b8f6c4" />
