### PR TITLE
Remove pending file collection search view spec

### DIFF
--- a/spec/features/merged_file_collection_spec.rb
+++ b/spec/features/merged_file_collection_spec.rb
@@ -7,27 +7,19 @@ RSpec.feature "Merged File Collections", :js do
     stub_article_service(docs: [])
   end
 
-  scenario "in search results" do
-    pending 'SW4.0 redesign in progress.'
-    visit root_path
-    fill_in 'q', with: '38'
-    find('button#search').click
+  context "when on the record view" do
+    it "displays metadata and file list" do
+      visit solr_document_path('38')
 
-    within('.file-collection-members') do
-      expect(page).to have_css("a", text: /File Item/, count: 4)
+      expect(page).to have_css('h1', text: 'Merged File Collection1')
+
+      within('.file-collection-members') do
+        expect(page).to have_css("a", text: /File Item/, count: 4)
+      end
+
+      expect(page).to have_css('h2', text: 'Contents/Summary')
+      expect(page).to have_css('h2', text: 'Subjects')
+      expect(page).to have_css('h2', text: 'Bibliographic information')
     end
-  end
-  scenario "record view should display metadata and file list" do
-    visit solr_document_path('38')
-
-    expect(page).to have_css('h1', text: 'Merged File Collection1')
-
-    within('.file-collection-members') do
-      expect(page).to have_css("a", text: /File Item/, count: 4)
-    end
-
-    expect(page).to have_css('h2', text: 'Contents/Summary')
-    expect(page).to have_css('h2', text: 'Subjects')
-    expect(page).to have_css('h2', text: 'Bibliographic information')
   end
 end


### PR DESCRIPTION
There is no plan to reimplement the collection preview in the search results. (per Darcy)

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
