### PR TITLE
Remove library borders from availability modal

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -347,11 +347,16 @@
     --bs-link-hover-color-rgb: var(--stanford-black-rgb);
     --bs-light-rgb: transparent;
     --bs-accordion-inner-border-radius: 0;
+    box-shadow: none;
+
     div {
       flex: 1;
     }
   }
 
+  .accordion-item {
+    border: none;
+  }
 
   .badge {
     background-color: var(--stanford-20-black);

--- a/app/components/searchworks4/availability_accordion_component.html.erb
+++ b/app/components/searchworks4/availability_accordion_component.html.erb
@@ -1,6 +1,6 @@
 <div class="accordion-item mb-2">
   <h2 class="accordion-header" id="library-<%= index %>">
-    <button class="accordion-button <% if index > 0 %>border-top<% end %> d-flex justify-content-between align-items-center <% unless toggled_library? %>collapsed<% end %>" type="button" data-bs-toggle="collapse" data-bs-target="#<%= library.code %>" aria-expanded="<%= toggled_library? %>" aria-controls="<%= library.code %>">
+    <button class="accordion-button d-flex justify-content-between align-items-center <% unless toggled_library? %>collapsed<% end %>" type="button" data-bs-toggle="collapse" data-bs-target="#<%= library.code %>" aria-expanded="<%= toggled_library? %>" aria-controls="<%= library.code %>">
       <%= render AccessPanels::LibraryHeaderComponent.new(document:, library:) %>
       <div class="text-end"><span class="badge rounded-pill"><%= pluralize(library.items.count, 'item') %></span></div>
     </button>


### PR DESCRIPTION
Ref #5447 

The designs don't want some of the default accordion styles.

After:
<img width="794" height="73" alt="Screenshot 2025-07-16 at 3 19 26 PM" src="https://github.com/user-attachments/assets/87c30256-ad5c-4c2f-a97d-465f676be106" />
