### PR TITLE
restyle digital collections purl part view

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -72,34 +72,11 @@
   }
 }
 
-.managed-purl-panel {
-  .card-body {
-    max-height: 430px;
-    overflow-y: scroll;
-  }
-}
-
 .managed-purl {
-  .managed-purl-heading {
-    background-color: var(--stanford-fog-light);
-    height: 40px;
-    padding: 10px;
-    border-radius: var(--bs-card-border-radius) var(--bs-card-border-radius) 0 0;
-  }
-
-  ul {
-    list-style: none;
-    padding-left: 0;
-  }
-
   li {
-    border: 1px solid var(--white);
-    display: flex;
-    gap: 8px;
-
     &.active {
-      background: var(--stanford-fog-light);
-      border: 1px solid var(--stanford-10-black);
+      --bs-border-color: var(--stanford-cardinal);
+      --bs-border-width: 2px;
     }
 
     &:hover,
@@ -109,20 +86,7 @@
     }
 
     img {
-      border: 1px solid transparent;
-      object-fit: contain;
-      align-self: flex-start;
-    }
-
-    button {
-      height: 100%;
-      width: 100%;
-      background: none !important;
-      border: 1px solid transparent;
-      color: var(--link);
-      cursor: pointer;
-      padding: 4px;
-      text-align: left;
+      background-color: var(--stanford-fog-light);
     }
   }
 }
@@ -236,18 +200,19 @@
       }
     }
   }
+}
 
-  .image-filmstrip,
-  .collection-members {
-    --bs-border-radius: 0.25rem;
-    --bs-border-color: var(--stanford-20-black);
+.collection-result-preview .image-filmstrip,
+.collection-result-preview .collection-members,
+.managed-purl .digital-viewer {
+  --bs-border-radius: 0.25rem;
+  --bs-border-color: var(--stanford-20-black);
 
-    margin-top: -1rem;
-    padding-top: 2rem;
+  margin-top: -1rem;
+  padding-top: 2rem;
 
-    svg {
-      vertical-align: inherit;
-    }
+  svg {
+    vertical-align: inherit;
   }
 }
 

--- a/app/models/concerns/stacks_images.rb
+++ b/app/models/concerns/stacks_images.rb
@@ -27,7 +27,8 @@ module StacksImages
       thumbnail: 'square/100,100/0/default.jpg',
       default: 'full/80,80/0/default.jpg',
       medium: 'full/125,125/0/default.jpg',
-      large: 'full/!400,400/0/default.jpg'
+      large: 'full/!400,400/0/default.jpg',
+      rect_thumbnail: 'full/,100/0/default.jpg'
     }
   end
 end

--- a/app/views/catalog/_managed_purl_embed.html.erb
+++ b/app/views/catalog/_managed_purl_embed.html.erb
@@ -1,36 +1,31 @@
-<div class="managed-purl row" data-controller="managed-purl">
-  <div class="col-md-12">
-    <h2>Digital content</h2>
+<div class="managed-purl" data-controller="managed-purl">
+  <div class="d-inline-flex bg-white ms-4 px-2">
+    <h2 class="mb-0">Digital content</h2><div class="ms-2 badge rounded-pill align-self-center text-black bg-light"><%= "#{document.managed_purls.count} parts" %></div>
   </div>
-  <div class="col-md-4">
-    <div class="card managed-purl-panel mb-3">
-      <div class="managed-purl-heading">
-        <%= "#{document.managed_purls.count} parts" %>
-      </div>
-      <div class="card-body">
-        <ul>
-          <% document.managed_purls.each_with_index do |purl, i| %>
-            <li data-managed-purl-target="item">
-              <%= button_tag data: {
-                  embed_target: "#{Settings.PURL_EMBED_RESOURCE}#{purl.druid}",
-                  embed_provider: Settings.PURL_EMBED_PROVIDER,
-                  managed_purl_target: 'button',
-                  action: 'click->managed-purl#switchItem'
-              } do %>
-                <% if purl.file_id %>
-                  <img src="<%= document.craft_image_url(image_id: purl.file_id, size: :thumbnail) %>">
-                <% end %>
-
-                <%= purl.part_label(index: i + 1) %>
+  <div class="border rounded px-3 pb-2 row digital-viewer">
+    <div class="col-4">
+      <ul class="list-unstyled overflow-scroll pe-3" style="height: 520px;">
+        <% document.managed_purls.each_with_index do |purl, i| %>
+          <li data-managed-purl-target="item" class="border mb-2">
+            <%= button_tag(data: {
+                embed_target: "#{Settings.PURL_EMBED_RESOURCE}#{purl.druid}",
+                embed_provider: Settings.PURL_EMBED_PROVIDER,
+                managed_purl_target: 'button',
+                action: 'click->managed-purl#switchItem'
+            }, class: 'p-0 btn w-100 h-100 text-start text-decoration-none')  do %>
+              <% if purl.file_id %>
+                <img src="<%= document.craft_image_url(image_id: purl.file_id, size: :rect_thumbnail) %>">
               <% end %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
+
+              <%= purl.part_label(index: i + 1) %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
     </div>
-  </div>
-  <div class="col-md-8">
-    <div class="managed-purl-embed" data-managed-purl-target="embed">
+    <div class="col-8">
+      <div class="managed-purl-embed" data-managed-purl-target="embed">
+      </div>
     </div>
   </div>
 </div>

--- a/spec/components/record/marc_document_component_spec.rb
+++ b/spec/components/record/marc_document_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Record::MarcDocumentComponent, type: :component do
   end
 
   it 'includes the managed purl panel and upper metadata elements' do
-    expect(page).to have_css('.managed-purl-panel')
+    expect(page).to have_css('.managed-purl .digital-viewer')
     expect(page).to have_css('.upper-record-metadata')
     expect(page).to have_css('li', text: 'Some Part Label')
     expect(page).to have_css('li', text: 'part 2')

--- a/spec/features/purl_embed_spec.rb
+++ b/spec/features/purl_embed_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe 'PURL Embed', :js do
       expect(page).to have_button('part 2')
 
       # Click the last item
-      within('.managed-purl-panel') do
+      within('.managed-purl .digital-viewer') do
         find('button[data-embed-target="https://purl.stanford.edu/zg338xh5248"]').click
       end
       expect(find('iframe')['src']).to include('purl.stanford.edu/zg338xh5248')
 
       # Click the first item
-      within('.managed-purl-panel') do
+      within('.managed-purl .digital-viewer') do
         find('button[data-embed-target="https://purl.stanford.edu/ct493wg6431"]').click
       end
       expect(find('iframe')['src']).to include('purl.stanford.edu/ct493wg6431')


### PR DESCRIPTION
closes #5644 
The gap at the top of the viewer will go away when we re-release sul-embed. I tried to get the dependency updates in but a rebase overwrote them and closed the pr and I can't figure out how to get them to run again with dependabot so I figure we wait until next week. 
<img width="969" height="640" alt="Screenshot 2025-07-17 at 11 55 46 AM" src="https://github.com/user-attachments/assets/93fc0a7c-a26c-4ae8-a47e-ec63cf0ce6e6" />



