### PR TITLE
Add padding to missing cover image text

### DIFF
--- a/app/assets/stylesheets/searchworks4/gallery-view.css
+++ b/app/assets/stylesheets/searchworks4/gallery-view.css
@@ -78,4 +78,5 @@
 div.fake-cover-text {
   color: var(--stanford-70-black);
   font-size: 0.875rem;
+  padding: 1rem;
 }


### PR DESCRIPTION
The text was styled prior to my PR that made the gallery preview wider. This brings it back to the design.

Before:
<img width="162" height="182" alt="Screenshot 2025-07-16 at 4 09 56 PM" src="https://github.com/user-attachments/assets/3a94dd7d-891e-43df-8a69-f0bc01f513c4" />

After:
<img width="157" height="177" alt="Screenshot 2025-07-16 at 4 10 35 PM" src="https://github.com/user-attachments/assets/e2ca37cd-b527-40fb-9496-5f3a8886f325" />
