### PR TITLE
Handle rendering the google books link in javascript

### DIFF
--- a/app/components/access_panels/google_books_preview_component.html.erb
+++ b/app/components/access_panels/google_books_preview_component.html.erb
@@ -1,4 +1,3 @@
 <div class="google-preview mt-2 <%= classes %>" hidden>
   <%= image_tag "gbs_preview_button.gif", alt:"" %>
-  <a href="" class="<%= @link_text.parameterize %>">(<%= @link_text %>)</a>
 </div>

--- a/app/components/access_panels/google_books_preview_component.rb
+++ b/app/components/access_panels/google_books_preview_component.rb
@@ -2,12 +2,6 @@
 
 module AccessPanels
   class GoogleBooksPreviewComponent < AccessPanels::Base
-    def initialize(document:, link_text: 'Limited preview')
-      super(document:)
-
-      @link_text = link_text
-    end
-
     def book_ids
       helpers.get_book_ids(document)
     end

--- a/app/javascript/controllers/google_cover_image_controller.js
+++ b/app/javascript/controllers/google_cover_image_controller.js
@@ -99,17 +99,27 @@ export default class extends Controller {
   }
 
   renderAccessPanel(bibkey, data) {
-    if (typeof data.info_url !== 'undefined') {
-      const listGoogleBooks = this.element.querySelectorAll(`.google-books.${bibkey}`)
+    if (typeof data.info_url == 'undefined' || !['full', 'partial', 'noview'].includes(data.preview)) return;
 
-      listGoogleBooks.forEach((googleBooks) => {
-        if (data.preview === 'partial' || data.preview === 'noview') {
-          const $limitedView = googleBooks.querySelector('.limited-preview')
-          $limitedView.href = data.preview_url;
-        }
-        this.checkAndEnableAccessPanel(googleBooks, '.access-panel');
-      })
+    const listGoogleBooks = this.element.querySelectorAll(`.google-books.${bibkey}`)
+
+    const labels = {
+      full: 'Full view',
+      partial: 'Limited preview',
+      noview: 'Limited preview'
     }
+
+    listGoogleBooks.forEach((googleBooks) => {
+      if (googleBooks.querySelector('a')) return;
+
+      const link = document.createElement('a')
+      link.href = data.preview_url;
+      link.innerHTML = `(${labels[data.preview]})`;
+
+      googleBooks.appendChild(link);
+
+      this.checkAndEnableAccessPanel(googleBooks, '.access-panel');
+    })
   }
 
   // Return a comma delimited string of identifiers


### PR DESCRIPTION
Fixes #5684 

It looks like we dropped handling for full text links when we converted this to stimulus (compare
https://github.com/sul-dlss/SearchWorks/commit/cb7bf1c95ef7a5d68b07c218db8d796fcb0ebaa3#diff-0471cbe78c253480fe7ae77cb64ae426a35f42f4ea0e29e7235b9f1f0687d69fL127
+https://github.com/sul-dlss/SearchWorks/commit/cb7bf1c95ef7a5d68b07c218db8d796fcb0ebaa3#diff-878a83bbaa344f0733cd01319f912c65b36ecd41ae870c150c7238e0a6eebed9R107)

This PR restores that case, and moves all the link rendering into the javascript instead of messing around with class selectors 🤷 
