### PR TITLE
Render linked serial links without injecting extra space.

### DIFF
--- a/app/models/marc_fields/linked_serials.rb
+++ b/app/models/marc_fields/linked_serials.rb
@@ -69,18 +69,13 @@ class LinkedSerials < MarcField
 
   def x_subfield(_, value)
     [
-      { text: '(' },
-      { text: 'ISSN' },
-      { link: value, search_field: 'isbn_search' },
-      { text: ')' }
+      { prepend: '(ISSN ', link: value, search_field: 'isbn_search', append: ')' }
     ]
   end
 
   def z_subfield(_, value)
     [
-      { text: '(' },
-      { link: value, search_field: 'isbn_search' },
-      { text: ')' }
+      { prepend: '(', link: value, search_field: 'isbn_search', append: ')' }
     ]
   end
 

--- a/app/views/marc_fields/_linked_serials.html.erb
+++ b/app/views/marc_fields/_linked_serials.html.erb
@@ -4,7 +4,7 @@
     <% component.with_value do %>
       <% value[:values].each do |val| %>
         <% if val[:link] %>
-          <%= link_to(val[:link], search_catalog_path(q: (val[:href] || val[:link]), search_field: val[:search_field])) %>
+          <%= val[:prepend]%><%= link_to(val[:link], search_catalog_path(q: (val[:href] || val[:link]), search_field: val[:search_field])) %><%= val[:append]%>
         <% else %>
           <%= val[:text] %>
         <% end %>

--- a/spec/models/marc_fields/linked_serials_spec.rb
+++ b/spec/models/marc_fields/linked_serials_spec.rb
@@ -81,11 +81,11 @@ RSpec.describe LinkedSerials do
       let(:marc) { main_entry_and_title_serial_fixture_with_issn }
 
       it 'has an ISSN prefix' do
-        expect(subject.values.last[:values][2][:text]).to eq 'ISSN'
+        expect(subject.values.last[:values].last).to include(prepend: '(ISSN ')
       end
 
       it 'links to the isbn_search search field' do
-        expect(subject.values.last[:values][3][:search_field]).to eq 'isbn_search'
+        expect(subject.values.last[:values].last).to include search_field: 'isbn_search'
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe LinkedSerials do
       let(:marc) { main_entry_and_title_serial_fixture }
 
       it 'links to the isbn_search search field' do
-        expect(subject.values.last[:values][2][:search_field]).to eq 'isbn_search'
+        expect(subject.values.last[:values].last).to include search_field: 'isbn_search'
       end
     end
 

--- a/spec/views/marc_fields/_linked_serials.html.erb_spec.rb
+++ b/spec/views/marc_fields/_linked_serials.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'marc_fields/_linked_serials' do
           values: [
             { link: 'Link Value1', href: '"Quoted Link Value"', search_field: 'the-search-field' },
             { text: 'Text Value2' },
-            { link: 'Link Value2', search_field: 'the-other-search-field' }
+            { prepend: '(', link: 'Link Value2', search_field: 'the-other-search-field', append: ')' }
           ]
         }
       ]
@@ -49,6 +49,7 @@ RSpec.describe 'marc_fields/_linked_serials' do
       expect(subject).to have_css('dd a', text: 'Link Value1')
       expect(subject).to have_content('Text Value2')
       expect(subject).to have_no_css('dd a', text: 'Text Value2')
+      expect(subject).to have_css('dd', text: '(Link Value2)')
       expect(subject).to have_css('dd a', text: 'Link Value2')
     end
 


### PR DESCRIPTION
E.g. https://searchworks.stanford.edu/view/in00000290510 happens to wrap a little funny in SW4.

Per Darcy: 
> Seems like there's a space after the ( and before the ). If we remove the space, it wraps a bit better... just not sure if there's a good reason why the space is there.
