### PR TITLE
Remove row markup from access conditions

### DIFF
--- a/app/components/access_panels/access_conditions_component.html.erb
+++ b/app/components/access_panels/access_conditions_component.html.erb
@@ -2,7 +2,7 @@
   <% component.with_title(classes: 'h3 text-secondary') { 'Access conditions' } %>
   <% component.with_body do %>
     <% document.mods.accessCondition.each do |accessCondition| %>
-      <%= render ModsDisplay::FieldComponent.new(field: accessCondition, label_html_attributes: { class: 'col-md-3' }, value_html_attributes: { class: 'col-md-9' }) %>
+      <%= render ModsDisplay::FieldComponent.new(field: accessCondition) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
E.g. https://searchworks-uat.stanford.edu/view/qc847wy9606 

Before:
<img width="457" height="562" alt="Screenshot 2025-07-17 at 08 29 33" src="https://github.com/user-attachments/assets/0de27b9b-933c-4022-b7af-78d77e59ed17" />

After:
<img width="418" height="465" alt="Screenshot 2025-07-17 at 08 29 43" src="https://github.com/user-attachments/assets/04fc5139-215d-412b-b29e-be62e3e3be65" />
