### PR TITLE
bug fix for online modal collapse

### DIFF
--- a/app/components/searchworks4/online_accordion_component.html.erb
+++ b/app/components/searchworks4/online_accordion_component.html.erb
@@ -1,6 +1,6 @@
 <div class="accordion-item mb-2">
   <h2 class="accordion-header" id="online-header">
-    <button class="accordion-button text-digital-green fw-semibold d-flex justify-content-between align-items-center py-2<% unless toggled_library? %>collapsed<% end %>" type="button" data-bs-toggle="collapse" data-bs-target="#online" aria-expanded="<%= toggled_library? %>" aria-controls="online">
+    <button class="accordion-button text-digital-green fw-semibold d-flex justify-content-between align-items-center py-2<% unless toggled_library? %> collapsed<% end %>" type="button" data-bs-toggle="collapse" data-bs-target="#online" aria-expanded="<%= toggled_library? %>" aria-controls="online">
       <% if document.is_a_database? %>
         Search this database
       <% elsif document.druid %>


### PR DESCRIPTION
Right now if you open the modal from a specific location the online modal looks like it is open
<img width="784" height="265" alt="Screenshot 2025-07-17 at 3 38 09 PM" src="https://github.com/user-attachments/assets/e2f8fb97-d4bd-41cb-b87a-6e8236642a69" />

This fixes that issue.
<img width="775" height="204" alt="Screenshot 2025-07-17 at 3 37 54 PM" src="https://github.com/user-attachments/assets/47c873b1-a064-4ab6-a5e1-ec1665e78598" />

The change looks big but it literally is just a space in front of collapsed
