### PR TITLE
Display numbers with delimiters.

### DIFF
--- a/app/components/searchworks4/availability_accordion_component.html.erb
+++ b/app/components/searchworks4/availability_accordion_component.html.erb
@@ -2,7 +2,7 @@
   <h2 class="accordion-header" id="library-<%= index %>">
     <button class="accordion-button d-flex justify-content-between align-items-center <% unless toggled_library? %>collapsed<% end %>" type="button" data-bs-toggle="collapse" data-bs-target="#<%= library.code %>" aria-expanded="<%= toggled_library? %>" aria-controls="<%= library.code %>">
       <%= render AccessPanels::LibraryHeaderComponent.new(document:, library:) %>
-      <div class="text-end"><span class="badge rounded-pill"><%= pluralize(library.items.count, 'item') %></span></div>
+      <div class="text-end"><span class="badge rounded-pill"><%= pluralize(number_with_delimiter(library.items.count), 'item') %></span></div>
     </button>
   </h2>
   <div id="<%= library.code %>" class="accordion-collapse collapse<% if toggled_library? %> show<% end %>" aria-labelledby="library-<%= index %>" data-bs-parent="#<%= library.code %>">

--- a/app/components/searchworks4/physical_availability_component.rb
+++ b/app/components/searchworks4/physical_availability_component.rb
@@ -99,7 +99,7 @@ module Searchworks4
       end
 
       def call
-        tag.span pluralize(@count, 'item'), class: 'bg-light rounded-pill small px-2 lh-sm text-nowrap'
+        tag.span pluralize(number_with_delimiter(@count), 'item'), class: 'bg-light rounded-pill small px-2 lh-sm text-nowrap'
       end
     end
   end

--- a/app/components/searchworks4/search_result/collection_info_component.html.erb
+++ b/app/components/searchworks4/search_result/collection_info_component.html.erb
@@ -14,7 +14,7 @@
     <% end %>
     <% if collection.collection_members.present? %>
       <div class="clearfix mb-1">
-        <b>Digital collection</b> <span class="badge badge-light rounded-pill"><%= pluralize(collection.collection_members.total, 'item') %></span>
+        <b>Digital collection</b> <span class="badge badge-light rounded-pill"><%= pluralize(number_with_delimiter(collection.collection_members.total), 'item') %></span>
       </div>
     <% end %>
     <% if collection.marc_links.finding_aid.present? %>

--- a/app/views/collection_members/_file_collection_members.html.erb
+++ b/app/views/collection_members/_file_collection_members.html.erb
@@ -10,7 +10,7 @@
         <h4 class="mb-0">Digital collection</h4>
       <% end %>
       <span class="ms-2 badge rounded-pill bookmark-counter align-self-center">
-        <%= pluralize(document.collection_members.total, 'item') %>
+        <%= pluralize(number_with_delimiter(document.collection_members.total), 'item') %>
       </span>
     </div>
     <div class="col-12 collection-members border rounded px-3 pb-2">
@@ -45,7 +45,7 @@
       </table>
       <div class="mt-1">
         <%= link_to(collection_members_path(document), class: 'text-decoration-none') do %>
-          Browse all <%= pluralize(document.collection_members.total, 'item') %> »
+          Browse all <%= pluralize(number_with_delimiter(document.collection_members.total), 'item') %> »
         <% end %>
       </div>
     </div>

--- a/app/views/collection_members/_image_collection_filmstrip.html.erb
+++ b/app/views/collection_members/_image_collection_filmstrip.html.erb
@@ -9,7 +9,7 @@
       <h4 class="mb-0">Digital collection</h4>
     <% end %>
     <span class="ms-2 badge rounded-pill bookmark-counter align-self-center">
-      <%= pluralize(collection_document.collection_members.total, 'item') %>
+      <%= pluralize(number_with_delimiter(collection_document.collection_members.total), 'item') %>
     </span>
     <%= link_to(collection_members_path(collection_document), class: 'ms-2 btn btn-outline-primary') do %>
       <i class="bi bi-search me-1"></i>Search collection


### PR DESCRIPTION
(I'm surprised `pluralize` works with numbers and strings, but I guess they've thought of everything)