### PR TITLE
Use a separate label for date in advanced search; fixes #5729

### DIFF
--- a/app/components/searchworks4/advanced_search_form_component.rb
+++ b/app/components/searchworks4/advanced_search_form_component.rb
@@ -24,7 +24,8 @@ module Searchworks4
           [key, label]
         end.compact_blank
 
-        { field: config.key, label: facet_presenter.label, limit: config.limit, range: config.range, top: config.key.in?(blacklight_config.top_filters[:advanced_search]),
+        { field: config.key, label: config.advanced_search_label || facet_presenter.label,
+          limit: config.limit, range: config.range, top: config.key.in?(blacklight_config.top_filters[:advanced_search]),
           values: values, value_labels: value_labels }
       end
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -180,7 +180,7 @@ class CatalogController < ApplicationController
                             component: Searchworks4::LibraryFacetComponent
     config.add_facet_field "genre_ssim", label: "Genre", limit: 6, suggest: true,
                            component: Searchworks4::FacetSearchComponent
-    config.add_facet_field "pub_year_tisim", label: "Date", range: true
+    config.add_facet_field "pub_year_tisim", label: "Date", range: true, advanced_search_label: 'Publication year'
 
     config.add_facet_field "language", label: "Language", limit: 6, suggest: true, component: Searchworks4::FacetSearchComponent
     config.add_facet_field "author_person_facet", label: "Author", limit: 6, suggest: true, component: Searchworks4::FacetSearchComponent

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Advanced Search" do
     expect(page).to have_css('.search-field', count: 2)
 
     expect(page).to have_css(".flex-row", text: "Access")
-    expect(page).to have_css(".flex-row", text: "Date")
+    expect(page).to have_css(".flex-row", text: "Publication year")
     expect(page).to have_css(".flex-row", text: "Format")
     expect(page).to have_css(".flex-row", text: "Language")
 


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
