### PR TITLE
Add better handling of null citation display

### DIFF
--- a/app/components/citations/multiple_citations_component.html.erb
+++ b/app/components/citations/multiple_citations_component.html.erb
@@ -16,6 +16,7 @@
     <div class="bg-light p-3"<%= ' hidden' if index != 0 %> data-citation-format-target="panel"
       data-controller="copy-text" id="citation-format-<%= format %>">
       <div class="d-flex align-items-center gap-2 mb-2">
+      <% unless all_unavailable? %>
         <h4 class="mb-0 me-3">
           <% if preferred_or_unavailable_citations_only? %>
             Preferred citations
@@ -24,8 +25,11 @@
           <% end %>
         </h4>
         <button class="btn btn-outline-primary" data-action="click->copy-text#copy">Copy</button>
+      <% end %>
       </div>
-      <% if unavailable_citation_count(format).positive? %>
+      <% if all_unavailable? %>
+        <div class="alert citations-alert bi bi-exclamation-circle-fill p-2 my-3"><span class="ms-2">All citations are unavailable for the saved records.</span></div>
+      <% elsif unavailable_citation_count(format).positive? %>
         <div class="alert citations-alert bi bi-exclamation-circle-fill p-2 my-3"><span class="ms-2">Citations are unavailable for <%= unavailable_citation_count(format) %> of the <%= all_citations.count %> saved records.</span></div>
       <% end %>
       <ol class="mb-3 ps-3" data-copy-text-target="text">
@@ -42,6 +46,7 @@
   <% end %>
 </div>
 
+<% unless all_unavailable? %>
 <h3 class="mt-4 mb-3">Export citations</h3>
 <ul class="list-unstyled d-flex gap-3 export-citations">
   <% if @documents.any? {|d| d.export_formats.key?(:ris) } %>
@@ -66,3 +71,4 @@
     </li>
   <% end %>
 </ul>
+<% end %>

--- a/app/components/citations/multiple_citations_component.rb
+++ b/app/components/citations/multiple_citations_component.rb
@@ -34,6 +34,10 @@ module Citations
       citations_for_document.one? && citations_for_document.keys.first == preferred_key
     end
 
+    def all_unavailable?
+      all_citations.all?(Citation::NULL_CITATION)
+    end
+
     def preferred_citation(citations_for_document)
       citations_for_document[preferred_key]
     end

--- a/app/components/searchworks4/citations/citation_component.html.erb
+++ b/app/components/searchworks4/citations/citation_component.html.erb
@@ -3,7 +3,9 @@
 <div class="modal-body" data-controller="citation-style-picker">
   <h4 class="fs-5">Copy citation</h4>
 
-  <% if preferred_only? %>
+  <% if unavailable? %>
+    <input type="hidden" data-citation-style-picker-target="select" value="tab-<%= null_key %>" />
+  <% elsif preferred_only? %>
     <input type="hidden" data-citation-style-picker-target="select" value="tab-<%= preferred_key %>" />
   <% else %>
 
@@ -23,7 +25,9 @@
 
   <% citations.each do |style, citation| %>
     <div class="mb-4 bg-light p-2" data-citation-style-picker-target="tab" data-controller="copy-text" id="tab-<%= style %>" hidden>
-      <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm lh-1 ms-4" data-action="copy-text#copy">Copy</button></h5>
+      <% unless unavailable? %>
+        <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm lh-1 ms-4" data-action="copy-text#copy">Copy</button></h5>
+      <% end %>
       <% Array(citation).each do |cite| %>
         <div class="mb-2" data-copy-text-target="text">
           <%= cite %>
@@ -32,7 +36,7 @@
     </div>
   <% end %>
 
-
+  <% unless unavailable? %>
   <h4 class="fs-5">Export citation</h4>
   <ul class="list-unstyled">
     <% if exports_ris? %>
@@ -69,4 +73,5 @@
       </li>
     <% end %>
   </ul>
+  <% end %>
 </div>

--- a/app/components/searchworks4/citations/citation_component.rb
+++ b/app/components/searchworks4/citations/citation_component.rb
@@ -17,8 +17,16 @@ module Searchworks4
         citations.present?
       end
 
+      def unavailable?
+        citations.present? && citations == Citation::NULL_CITATION
+      end
+
       def preferred_only?
         citations.one? && citations.keys.first == preferred_key
+      end
+
+      def null_key
+        Citation::NULL_CITATION.keys.first
       end
 
       def preferred_key

--- a/spec/components/citations/multiple_citations_component_spec.rb
+++ b/spec/components/citations/multiple_citations_component_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe Citations::MultipleCitationsComponent, type: :component do
     end
   end
 
+  context 'when all citations are null' do
+    let(:documents) { [SolrDocument.find('1'), SolrDocument.find('4')] }
+    let(:request_url) { "/view/citation?id%5B%5D=1&id%5B%5D=4" }
+
+    it 'does not offer any options' do
+      expect(page).to have_text 'All citations are unavailable for the saved records.'
+      expect(page).to have_no_text 'Null'
+      expect(page).to have_no_text 'Export citations'
+    end
+  end
+
   context 'when some items have only preferred citations (mods)' do
     let(:documents) { [SolrDocument.find('in00000053236'), SolrDocument.find('nj140cs3237')] }
     let(:request_url) { "/view/citation?id%5B%5D=in00000053236&id%5B%5D=nj140cs3237" }


### PR DESCRIPTION
Additional bits for #5625

I don't love either of these. I think ideally the tool isn't even presented in these cases but this is better than displaying "Null" in places in the meantime. I'm also assuming there's no reason to provide "Copy" or "Export" in these situations.


Multiple citation tool with a single item with a null citation (which renders the single citation component). "No citation available for this record" is the default null citation text:
<img width="839" height="417" alt="Screenshot 2025-07-22 at 11 38 01 AM" src="https://github.com/user-attachments/assets/08203bf3-6cb5-4218-be35-084d5b63c521" />

Multiple citation tool with a multiple items all having null citations:
<img width="835" height="408" alt="Screenshot 2025-07-22 at 11 35 19 AM" src="https://github.com/user-attachments/assets/8007c0cb-53e5-42a3-bac0-2c8175a6c7a8" />
