### PR TITLE
update bound with children view for searchworks4

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -162,6 +162,7 @@
 
 .show-more-button {
   margin-top: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .blacklight-catalog-show {
@@ -377,4 +378,8 @@
   .availability-library-location:has(mark) {
     display: flex !important;
   }
+}
+
+.bound-with .show-more-button {
+  margin-bottom: 0.1rem;
 }

--- a/app/components/access_panels/location_item_component.html.erb
+++ b/app/components/access_panels/location_item_component.html.erb
@@ -1,4 +1,4 @@
-<tr class="item-row pt-1 w-100 flex-wrap border-top fs-15">
+<tr class="item-row pt-1 w-100 flex-wrap border-top d-flex fs-15">
   <th scope="row" class="callnumber fw-normal flex-grow-1"><%= tag.span callnumber %></th>
   <td class="text-nowrap text-status">
     <%= render Searchworks4::ItemStatusComponent.new(item:) %>
@@ -16,7 +16,16 @@
         <div class="bound-with-callnumber"><%= bound_with_callnumber %></div>
       </div>
     <% elsif item.bound_with_principal? && item.id %>
-      <%= helpers.turbo_frame_tag [:item, item.id], src: bound_with_children_solr_document_path(document.id, item_id: item.id), loading: 'lazy' %>
+      <% if @modal %>
+        <%= helpers.turbo_frame_tag [:item, item.id], src: bound_with_children_solr_document_path(document.id, item_id: item.id), loading: 'lazy' %>
+      <% else %>
+        <div class="bound-with bg-light p-2 mt-2">
+          <div class="bound-with-type">Item is bound with other items</div>
+          <%= link_to bound_with_children_modal_solr_document_path(item_id: item.id), data: { turbo_frame: "blacklight-modal", blacklight_modal: "trigger" }, class: 'btn btn-link p-1 text-left' do %>
+             See items <i class="bi bi-chevron-double-right fs-14"></i>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </td>
 </tr>

--- a/app/components/access_panels/location_item_component.rb
+++ b/app/components/access_panels/location_item_component.rb
@@ -5,7 +5,7 @@ module AccessPanels
     with_collection_parameter :item
     attr_reader :item, :document, :classes
 
-    def initialize(item:, document:, item_counter: nil, classes: nil, consolidate_for_finding_aid: false)
+    def initialize(item:, document:, item_counter: nil, classes: nil, consolidate_for_finding_aid: false, modal: false)
       super
 
       @item = item
@@ -13,6 +13,7 @@ module AccessPanels
       @document = document
       @consolidate_for_finding_aid = consolidate_for_finding_aid
       @item_counter = item_counter
+      @modal = modal
     end
 
     delegate :bound_with_parent, to: :item

--- a/app/components/record/bound_with_children_component.html.erb
+++ b/app/components/record/bound_with_children_component.html.erb
@@ -1,5 +1,5 @@
-<div class="bound-with-type">Bound with:</div>
-<ul class="list-unstyled mb-0">
+<div class="bound-with-type fw-medium">Item is bound with other items</div>
+<ul class="list-unstyled mb-0" data-controller="list-toggle" data-list-toggle-expanded-value="true" data-list-toggle-target="group" data-list-toggle-list-item-selector-value="li" data-list-toggle-limit-value="0">
   <% bound_with_children.each do |child| %>
     <li class="pb-2">
       <div class="bound-with-title"><%= bound_with_title(child.document) %></div>

--- a/app/components/record/bound_with_children_table_component.html.erb
+++ b/app/components/record/bound_with_children_table_component.html.erb
@@ -1,11 +1,11 @@
-<div class="bound-with-type h3">Bound with:</div>
+<div class="bound-with-type fw-medium fs-14 mb-0">Bound with</div>
 <table class="mb-0">
   <th class="visually-hidden">Title</th>
   <th class="visually-hidden">Call Number</th>
   <% bound_with_children.each do |child| %>
-      <tr class="bound-with-item">
+      <tr class="bound-with-item border-top">
         <td class="bound-with-title align-top py-2"><%= bound_with_title(child.document) %></td>
-        <td class="bound-with-callnumber align-top py-2"><%= child.callnumber %></td>
+        <td class="bound-with-callnumber align-top py-2 text-nowrap"><%= child.callnumber %></td>
       </tr>
   <% end %>
 </table>

--- a/app/components/searchworks4/availability_modal_location_component.html.erb
+++ b/app/components/searchworks4/availability_modal_location_component.html.erb
@@ -32,7 +32,7 @@
         </tr>
       </thead>
       <tbody>
-        <%= render AccessPanels::LocationItemComponent.with_collection(display_items, document:, consolidate_for_finding_aid: consolidate_items?) %>
+        <%= render AccessPanels::LocationItemComponent.with_collection(display_items, document:, consolidate_for_finding_aid: consolidate_items?, modal: true) %>
       </tbody>
     </table>
   </div>

--- a/app/controllers/bound_with_children_controller.rb
+++ b/app/controllers/bound_with_children_controller.rb
@@ -22,17 +22,16 @@ class BoundWithChildrenController < ApplicationController
   def index
     @id = params.require(:id)
     @item_id = params.require(:item_id)
-    limit = params[:limit] ? params[:limit].to_i : 3
-    @response = search_results(@item_id, limit: limit)
+    @response = search_results(@item_id)
     @bound_with_children = filtered_children(@response.docs)
     @bound_with_parent = @bound_with_children.first&.bound_with_parent
   end
 
   private
 
-  def search_results(item_id, limit: 100)
+  def search_results(item_id)
     search_service.search_results do |builder|
-      builder.where(bound_with_parent_item_ids_ssim: item_id).rows(limit)
+      builder.where(bound_with_parent_item_ids_ssim: item_id)
     end
   end
 

--- a/app/javascript/controllers/show_more_button_controller.js
+++ b/app/javascript/controllers/show_more_button_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     this.element.textContent = 'Show more'
-    this.element.classList.add('btn', 'btn-link', 'p-0', 'mb-3', 'show-more-button')
+    this.element.classList.add('btn', 'btn-link', 'p-0', 'show-more-button')
     this.element.ariaDisabled = 'true'
     this.element.ariaExpanded = 'false'
     this.element.ariaLabel = "This button is disabled because assistive technologies already announced the content."

--- a/app/javascript/controllers/toast_message_listener_controller.js
+++ b/app/javascript/controllers/toast_message_listener_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="show-more-button"
+// Connects to data-controller="toast-message"
 export default class extends Controller {
   showToast(e) {
     const toast = document.getElementById('toast');

--- a/app/views/bound_with_children/index.html.erb
+++ b/app/views/bound_with_children/index.html.erb
@@ -2,9 +2,6 @@
   <% if @bound_with_children.present? %>
     <div class="bound-with bg-light p-2 mt-2">
       <%= render Record::BoundWithChildrenComponent.new(bound_with_children: @bound_with_children, item_id: @item_id, instance_id: @id) %>
-      <% if @response.total_pages > 1 %>
-        <%= link_to "See all items bound with #{@bound_with_parent['call_number']}", bound_with_children_modal_solr_document_path(item_id: @item_id), data: { turbo_frame: "blacklight-modal", blacklight_modal: "trigger" }, class: 'btn btn-outline-primary p-1 text-left' %>
-      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/bound_with_children/modal.html.erb
+++ b/app/views/bound_with_children/modal.html.erb
@@ -1,13 +1,21 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
   <% component.with_header do %>
-    <span class="d-flex flex-column">
-      <h2 class="modal-title">
-        <%= @bound_with_parent['title'] %>
-      </h2>
-      <%= @bound_with_parent['call_number'] %>
-    </span>
+    <h2 class="modal-title">
+      Items bound with
+    </h2>
   <% end %>
-  <div class="bound-with-modal">
-    <%= render Record::BoundWithChildrenTableComponent.new(bound_with_children: @bound_with_children, item_id: @item_id, instance_id: @id) %>
-  </div>
+  <% component.with_body do %>
+    <div class="bound-with bg-light w-100 px-3 py-2 h4">
+      <%= @bound_with_parent['call_number'] %> (<%= @bound_with_parent['title'] %>)
+    </div>
+    <div class="modal-body">
+      <div class="bound-with-modal">
+        <%= render Record::BoundWithChildrenTableComponent.new(bound_with_children: @bound_with_children, item_id: @item_id, instance_id: @id) %>
+      </div>
+    </div>
+  <% end %>
+  <% component.with_footer do %>
+    <button type="button" class="btn btn-outline-primary me-2 close" data-bl-dismiss="modal">Close</button>
+  <% end %>
+
 <% end %>

--- a/spec/components/record/bound_with_children_component_spec.rb
+++ b/spec/components/record/bound_with_children_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Record::BoundWithChildrenComponent, type: :component do
   end
 
   it "renders bounds with correctly" do
-    expect(page).to have_css('.bound-with-type', text: 'Bound with:')
+    expect(page).to have_css('.bound-with-type', text: 'Item is bound with other items')
     expect(page).to have_css('.bound-with-title', count: 2)
 
     expect(page).to have_link('987654 title', href: '/view/987654')

--- a/spec/features/bound_with_children_spec.rb
+++ b/spec/features/bound_with_children_spec.rb
@@ -3,23 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe 'Bound with children', :js do
-  describe 'visible on the record page' do
-    it 'has a clickable see all modal' do
-      visit bound_with_children_solr_document_path('5488000', item_id: 'f947bd93-a1eb-5613-8745-1063f948c461')
-
-      expect(page).to have_link("See all items bound with 630.654 .I39M")
-      click_link 'See all items bound with 630.654 .I39M'
+  describe 'visible on the avaliability modal' do
+    it 'has a modal' do
+      visit solr_document_path('5488000')
+      all(:link, 'See items').last.click
 
       expect(page).to have_css(".modal")
       expect(page.all('td.bound-with-title').size).to be 5
     end
 
-    it 'does not need a modal' do
+    it 'has a clickable show more button' do
+      visit bound_with_children_solr_document_path('5488000', item_id: 'f947bd93-a1eb-5613-8745-1063f948c461')
+
+      expect(page).to have_button('Show more')
+      click_button 'Show more'
+
+      expect(page).to have_button("Show less")
+      expect(page.all('li div.bound-with-title').size).to be 5
+    end
+
+    it 'still has a show more button' do
       visit bound_with_children_solr_document_path('5488000', item_id: '1193e6b3-3bfc-5c51-b1ac-7ef347cdc46f')
 
+      expect(page).to have_button('Show more')
+      click_button 'Show more'
+
+      expect(page).to have_button("Show less")
       expect(page.all('li div.bound-with-title').size).to be 1
-      expect(page).to have_no_link '630.654 .I39M V.4:NO.1,4'
-      expect(page).to have_no_css(".modal")
     end
   end
 end


### PR DESCRIPTION
closes #5676 

Figma:
<img width="447" height="268" alt="Screenshot 2025-07-22 at 5 11 57 PM" src="https://github.com/user-attachments/assets/573c6587-9d45-49b6-a16d-32082973a308" />

Pr:
<img width="862" height="667" alt="Screenshot 2025-07-22 at 5 47 18 PM" src="https://github.com/user-attachments/assets/0a3074e9-e633-4f8e-a930-553304acbc27" />


Figma:
<img width="256" height="454" alt="Screenshot 2025-07-22 at 5 12 26 PM" src="https://github.com/user-attachments/assets/05b61819-d5f0-4fc3-846b-0c7a19726678" />

PR:
<img width="350" height="676" alt="Screenshot 2025-07-22 at 5 16 33 PM" src="https://github.com/user-attachments/assets/1db864b9-7751-42c3-baa0-e5fa06079328" />

Figma:
<img width="460" height="486" alt="Screenshot 2025-07-22 at 5 17 21 PM" src="https://github.com/user-attachments/assets/945bcae2-5b2f-41af-805d-1b28a4ec829b" />

PR:
<img width="966" height="887" alt="Screenshot 2025-07-22 at 5 06 44 PM" src="https://github.com/user-attachments/assets/38a6a1a7-14da-4cf2-b155-b69ca0cee438" />

Not in Figma:
<img width="922" height="951" alt="Screenshot 2025-07-22 at 5 06 52 PM" src="https://github.com/user-attachments/assets/ef9eea14-9a0e-456a-8129-84d48612879b" />

