### PR TITLE
Style the articles+ full text button a little bit, and default to closed

### DIFF
--- a/app/components/articles/article_component.html.erb
+++ b/app/components/articles/article_component.html.erb
@@ -1,12 +1,12 @@
 <div class="article-record-metadata row align-items-start">
   <div class="article-record-sections record-sections">
     <% if @document.html_fulltext? %>
-      <div class="html-fulltext-container">
+      <div class="html-fulltext-container mb-5">
         <% if helpers.on_campus_or_su_affiliated_user? %>
-          <button class="section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-bs-toggle="collapse" href="#toggleFulltext" aria-expanded="true" aria-controls="toggleFulltext">
-            <h2>Hide full text <i class='bi bi-chevron-down'></i></h2>
+          <button class="btn btn-secondary mb-3 section-container-heading fulltext-toggle-bar" id="fulltextToggleBar" data-bs-toggle="collapse" href="#toggleFulltext" aria-expanded="false" aria-controls="toggleFulltext">
+            <h2 class="mb-0">Show full text <i class='bi bi-chevron-right'></i></h2>
           </button>
-          <div class='eds-full-text-section section-body collapse show' id="toggleFulltext">
+          <div class='eds-full-text-section section-body collapse' id="toggleFulltext">
             <% metadata_fields_for_section('Fulltext').each do |field_presenter| -%>
               <% if field_presenter.render_field? %>
                 <div class="blacklight-<%= field_presenter.key %>"><%= field_presenter.render %></div>

--- a/app/javascript/article.js
+++ b/app/javascript/article.js
@@ -3,9 +3,9 @@ import Blacklight from 'blacklight-frontend'
 Blacklight.onLoad(() => {
   const fullText = document.querySelector('#toggleFulltext')
   fullText?.addEventListener('show.bs.collapse', () => {
-    document.querySelector('#fulltextToggleBar').innerHTML = '<h2>Hide full text <i class="bi bi-chevron-down"></i></h2>'
+    document.querySelector('#fulltextToggleBar h2').innerHTML = 'Hide full text <i class="bi bi-chevron-down"></i>'
   })
   fullText?.addEventListener('hide.bs.collapse', () => {
-    document.querySelector('#fulltextToggleBar').innerHTML = '<h2>Show full text <i class="bi bi-chevron-right"></i></h2>'
+    document.querySelector('#fulltextToggleBar h2').innerHTML = 'Show full text <i class="bi bi-chevron-right"></i>'
   })
 })

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -50,19 +50,21 @@ RSpec.feature 'Article Record Display' do
 
       it 'toggled via panel heading' do
         visit article_path(document[:id])
-        expect(page).to have_css('.fulltext-toggle-bar', text: 'Hide full text')
-        expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
-        expect(page).to have_content('This Journal')
-
-        find_by_id('fulltextToggleBar').click
         expect(page).to have_css('.fulltext-toggle-bar', text: 'Show full text')
         expect(page).to have_no_css('div.blacklight-eds_html_fulltext', visible: true)
         expect(page).to have_no_content('This Journal')
+
+        find_by_id('fulltextToggleBar').click
+
+        expect(page).to have_css('.fulltext-toggle-bar', text: 'Hide full text')
+        expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
+        expect(page).to have_content('This Journal')
       end
 
       it 'renders HTML' do
         visit article_path(document[:id])
 
+        find_by_id('fulltextToggleBar').click
         expect(page).to have_css('div.blacklight-eds_html_fulltext', visible: true)
         within('div.blacklight-eds_html_fulltext') do
           expect(page).to have_no_content('<anid>')


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
