### PR TITLE
Mark toasts as data-turbo-permanent.

### DIFF
--- a/app/components/main_container_component.html.erb
+++ b/app/components/main_container_component.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <%= content %>
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" data-controller="toast-message-listener" data-action="show-toast@window->toast-message-listener#showToast">
+    <div data-turbo-permanent class="toast-container position-fixed bottom-0 end-0 p-3" data-controller="toast-message-listener" data-action="show-toast@window->toast-message-listener#showToast">
       <div id="toast" class="toast d-block" role="alert" aria-live="assertive" aria-atomic="true" data-bs-config='{ "delay": 8000 }'>
         <div class="toast-body d-flex justify-content-between">
           <div id="toast-text" class="toast-text"></div>

--- a/app/javascript/controllers/saved_list_controller.js
+++ b/app/javascript/controllers/saved_list_controller.js
@@ -13,12 +13,5 @@ export default class extends Controller {
     record.addEventListener('transitionend', () => {
       Turbo.visit(document.baseURI, { action: 'replace' })
     }, { once: true });    
-
-    document.addEventListener('turbo:load', (turbo_event) => {
-      if (turbo_event.detail.url.includes('selections')){
-        var e = new CustomEvent('bookmark.blacklight', { detail: event.detail });
-        window.dispatchEvent(e)
-      }
-    });
   }
 }


### PR DESCRIPTION
... so they carry over across turbo visits.