### PR TITLE
Convert EDS fields to use `Searchworks4::MetadataFieldLayoutComponent` …

### DIFF
--- a/app/components/articles/article_component.rb
+++ b/app/components/articles/article_component.rb
@@ -18,7 +18,7 @@ module Articles
 
     def metadata_sections
       sections.keys.index_with do |section_name|
-        collection = Blacklight::MetadataFieldComponent.with_collection(metadata_fields_for_section(section_name), layout: MetadataFieldLayoutComponent)
+        collection = Articles::EdsMetadataFieldComponent.with_collection(metadata_fields_for_section(section_name), layout: Searchworks4::MetadataFieldLayoutComponent)
 
         collection if collection.any?(&:render?)
       end.compact

--- a/app/components/articles/eds_metadata_field_component.html.erb
+++ b/app/components/articles/eds_metadata_field_component.html.erb
@@ -1,0 +1,12 @@
+<%= render @layout.new do |component| %>
+  <% component.with_label { label } %>
+  <% Array(render_field).each do |value| %>
+    <% component.with_value(**value_attr) do %>
+      <% if truncate? %>
+        <%= tag.div value, data: { 'long-text-target' => "text" } %>
+      <% else %>
+        <%= value %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/articles/eds_metadata_field_component.rb
+++ b/app/components/articles/eds_metadata_field_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Articles
+  class EdsMetadataFieldComponent < Blacklight::MetadataFieldComponent
+    def truncate?
+      @field.field_config.truncate
+    end
+
+    def value_attr
+      return { class: "blacklight-#{@field.key}" } unless truncate?
+
+      { class: "blacklight-#{@field.key}", data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-5' } }
+    end
+  end
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -145,21 +145,21 @@ class ArticlesController < ApplicationController
         eds_html_fulltext: { label: 'Full Text', helper_method: :sanitize_fulltext }
       },
       'Description' => {
-        eds_authors:              { label: 'Authors', separator_options: BREAKS, helper_method: :link_authors },
-        eds_author_affiliations:  { label: 'Author Affiliations', separator_options: BREAKS, helper_method: :clean_affiliations },
+        eds_authors:              { label: 'Authors', helper_method: :link_authors },
+        eds_author_affiliations:  { label: 'Author Affiliations', helper_method: :clean_affiliations },
         eds_composed_title:       { label: 'Source', helper_method: :italicize_composed_title },
         eds_publication_date:     { label: 'Publication Date' },
         eds_languages:            { label: 'Language', helper_method: :mark_html_safe }
       },
       'Contents/Summary' => {
-        eds_abstract: { label: 'Abstract', helper_method: :mark_html_safe },
-        eds_notes:    { label: 'Notes' }
+        eds_abstract: { label: 'Abstract', helper_method: :mark_html_safe, truncate: true },
+        eds_notes:    { label: 'Notes', truncate: true }
       },
       'Subjects' => {
-        eds_subjects:                 { label: 'Subjects', separator_options: BREAKS, helper_method: :link_subjects },
-        eds_subjects_geographic:      { label: 'Geography', separator_options: BREAKS, helper_method: :link_subjects },
-        eds_subjects_person:          { label: 'Person Subjects', separator_options: BREAKS, helper_method: :link_subjects },
-        eds_author_supplied_keywords: { label: 'Author Supplied Keywords', separator_options: BREAKS, helper_method: :link_subjects }
+        eds_subjects:                 { label: 'Subjects', helper_method: :link_subjects },
+        eds_subjects_geographic:      { label: 'Geography', helper_method: :link_subjects },
+        eds_subjects_person:          { label: 'Person Subjects', helper_method: :link_subjects },
+        eds_author_supplied_keywords: { label: 'Author Supplied Keywords', helper_method: :link_subjects }
       },
       'Details' => {
         eds_publication_type:     { label: 'Format' },

--- a/spec/features/article_display_spec.rb
+++ b/spec/features/article_display_spec.rb
@@ -22,10 +22,8 @@ RSpec.feature 'Article Record Display' do
     it 'are linked' do
       visit article_path(document[:id])
 
-      within 'dd.blacklight-eds_subjects_person' do
-        expect(page).to have_link 'Person1'
-        expect(page).to have_link 'Person2'
-      end
+      expect(page).to have_css('dd.blacklight-eds_subjects_person a', text: 'Person1')
+      expect(page).to have_css('dd.blacklight-eds_subjects_person a', text: 'Person2')
     end
   end
 


### PR DESCRIPTION
…so we're rendering consistent markup, get the benefit of automatic long-list behavior, etc.

Fixes #5717

<img width="441" height="718" alt="Screenshot 2025-07-23 at 08 12 09" src="https://github.com/user-attachments/assets/1c225a0d-8663-42d6-bd0e-1464c60e6e09" />
