### PR TITLE
Really get the bookmark label to have a cursor icon.

### DIFF
--- a/app/assets/stylesheets/searchworks4/bookmarks.css
+++ b/app/assets/stylesheets/searchworks4/bookmarks.css
@@ -38,6 +38,7 @@
     cursor: pointer;
 
     .toggle-bookmark-label {
+      cursor: pointer;
       font-weight: inherit;
       --bookmark-width-height: 1rem;
 
@@ -52,6 +53,10 @@
         &.bookmark-checked {
           display: none;
         }
+      }
+
+      .bookmark-text {
+        cursor: pointer;
       }
     }
 


### PR DESCRIPTION
Different browsers seem to want `cursor: pointer` on different elements?