### PR TITLE
Update disabled state color

### DIFF
--- a/app/assets/stylesheets/searchworks4/chat.css
+++ b/app/assets/stylesheets/searchworks4/chat.css
@@ -16,9 +16,8 @@
     color: rgb(var(--stanford-digital-blue-rgb));
   }
 
-  .bi-chat,
-  .disabled {
-    color: var(--stanford-40-black) !important;
+  .bi-chat {
+    color: var(--stanford-50-black) !important;
   }
 
   .placeholder {

--- a/app/assets/stylesheets/searchworks4/typography.css
+++ b/app/assets/stylesheets/searchworks4/typography.css
@@ -94,6 +94,10 @@ aside,
   --bs-link-hover-color: rgb(var(--bs-link-hover-color-rgb));
 }
 
+.disabled {
+  color: var(--stanford-50-black);
+}
+
 .text-digital-green {
   color: var(--stanford-digital-green);
 }

--- a/app/components/page_links_component.html.erb
+++ b/app/components/page_links_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.nav class: 'page_links' do %>
   <%= link_to_previous_page response, t('views.pagination.previous').html_safe, class: 'me-2' do %>
     <%# Display the disabled previous link if there is no previous page %>
-    <%= tag.span t('views.pagination.previous').html_safe, class: 'text-grey-50 me-2' if response.total_pages > 1 %>
+    <%= tag.span t('views.pagination.previous').html_safe, class: 'disabled me-2' if response.total_pages > 1 %>
   <% end %>
   <span class="page_entries">
     <% if response.total_count == 1 %>

--- a/app/components/toolbar_search_context_info_component.html.erb
+++ b/app/components/toolbar_search_context_info_component.html.erb
@@ -3,7 +3,7 @@
     <% if @search_context[:prev] %>
       <%= link_to_previous_document @search_context[:prev], classes: 'previous' %>
     <% else %>
-      <%= tag.span t('views.pagination.previous').html_safe, class: 'previous text-grey-50' %>
+      <%= tag.span t('views.pagination.previous').html_safe, class: 'previous disabled' %>
     <% end %>
     <span class="page-entries"><%= item_page_entry_info %></span>
     <%= link_to_next_document @search_context[:next], classes: 'next' if @search_context[:next] %>

--- a/app/javascript/controllers/course_reserves_controller.js
+++ b/app/javascript/controllers/course_reserves_controller.js
@@ -81,7 +81,7 @@ export default class extends Controller {
   drawTopResults() {
     const info = `<strong>${this.currentPage * this.pageRows + 1} - ${this.pageMax}</strong> of <strong>${this.total}</strong>`
     const nextButton = this.hasNext ? `<a class="ms-2" rel="next" href="#" data-action="course-reserves#nextPage">Next ${this.nextIcon}</a>` : ``
-    const prevButton = this.hasPrevious ? `<a class="me-2" rel="prev" href="#" data-action="course-reserves#prevPage">${this.prevIcon} Previous</a>` : `<span class="text-grey-50 me-2">${this.prevIcon} Previous</span>`
+    const prevButton = this.hasPrevious ? `<a class="me-2" rel="prev" href="#" data-action="course-reserves#prevPage">${this.prevIcon} Previous</a>` : `<span class="disabled me-2">${this.prevIcon} Previous</span>`
     this.resultsTarget.innerHTML = `<nav class="page_links page-entries-info">${prevButton}${info}${nextButton}</nav>`
   }
 

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Site Accessibility', :js do
       end
     end
 
-    context 'with zero results', skip: "Contrast issue for start-chat" do
+    context 'with zero results' do
       before { visit search_catalog_path q: 'sdfsda', search_field: 'search_author' }
 
       it 'is accessible' do
@@ -93,11 +93,6 @@ RSpec.describe 'Site Accessibility', :js do
     it 'is accessible' do
       expect(page).to be_accessible.within('main')
     end
-  end
-
-  it 'has an accessible advanced search page', skip: "Pending SearchWorks 4.0 designs" do
-    visit blacklight_advanced_search_engine.advanced_search_path
-    expect(page).to be_accessible.within('main')
   end
 
   describe 'the course reserves page' do

--- a/spec/support/accessibility_helpers.rb
+++ b/spec/support/accessibility_helpers.rb
@@ -3,13 +3,12 @@
 module AccessibilityHelpers
   # An alias so our tests are less coupled to the aXe implementation
   def be_accessible(...)
-    be_axe_clean(...).according_to(
-      :'best-practice',
-      :wcag2a,
-      :wcag2aa,
-      :wcag21a,
-      :wcag21aa
-    )
+    standards = [:'best-practice', :wcag2a, :wcag2aa, :wcag21a, :wcag21aa]
+
+    # Skip color contrast checks for '.disabled'
+    # See https://github.com/sul-dlss/SearchWorks/issues/5359
+    be_axe_clean(...).excluding('.disabled').according_to(standards)
+    be_axe_clean(...).according_to(standards).skipping('color-contrast')
   end
 end
 


### PR DESCRIPTION
Closes #5359

It was decided disable state text color should be `stanford-50-black` and excluded from our automated a11y checks.

Performing two a11y checks like this didn't add any significant additional time (< 250ms on my machine).

We had a duplicate advanced search test, I removed the pending one.
<img width="281" height="40" alt="Screenshot 2025-07-23 at 8 29 38 AM" src="https://github.com/user-attachments/assets/a5e01826-413a-42d0-b436-9c12bcde58ce" />
<img width="401" height="89" alt="Screenshot 2025-07-23 at 8 27 37 AM" src="https://github.com/user-attachments/assets/eb9602cc-bbfa-4b5f-99d0-c7de8c2726d2" />
<img width="322" height="59" alt="Screenshot 2025-07-23 at 8 27 19 AM" src="https://github.com/user-attachments/assets/175b7a75-2cce-4d43-ac73-4bb490aa6eb9" />
