### PR TITLE
Move list-toggle down to the right level.

### DIFF
--- a/app/components/searchworks4/document_section_layout.html.erb
+++ b/app/components/searchworks4/document_section_layout.html.erb
@@ -1,4 +1,4 @@
-<%= tag.section class: @classes, data: { controller: "list-toggle" }  do %>
+<%= tag.section class: @classes  do %>
   <%= content_tag @heading_level, @title, class: 'mb-3' %>
   <%= tag.dl content, class: @dl_classes %>
 <% end %>

--- a/app/components/searchworks4/metadata_field_layout_component.html.erb
+++ b/app/components/searchworks4/metadata_field_layout_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: @classes, data: { 'list-toggle-target': 'group' } do %>
+<%= tag.div class: @classes, data: { controller: "list-toggle", 'list-toggle-target': 'group' } do %>
   <%= tag.dt label, title: (label if label.to_s.length > 20 )%>
   <% values.each do |v| %>
     <%= v %>


### PR DESCRIPTION
`DocumentSectionLayout` wraps a number of fields. I think we want `list-toggle` on the container for the specific field?