### PR TITLE
Uniq the EDS metadata before display

### DIFF
--- a/app/components/articles/eds_metadata_field_component.html.erb
+++ b/app/components/articles/eds_metadata_field_component.html.erb
@@ -1,6 +1,6 @@
 <%= render @layout.new do |component| %>
   <% component.with_label { label } %>
-  <% Array(render_field).each do |value| %>
+  <% Array(render_field).uniq.each do |value| %>
     <% component.with_value(**value_attr) do %>
       <% if truncate? %>
         <%= tag.div value, data: { 'long-text-target' => "text" } %>


### PR DESCRIPTION
... ideally, it'd happen sooner, but that's historically been hard or confusing (maybe there's some hope now with `EdsDocument`?)