### PR TITLE
Bookmark/gallery view accessibility changes

### DIFF
--- a/app/assets/stylesheets/searchworks4/gallery-view.css
+++ b/app/assets/stylesheets/searchworks4/gallery-view.css
@@ -26,6 +26,10 @@
       --bs-border-color: var(--stanford-cardinal);
     }
 
+    .bookmark-toggle .bookmark-text {
+      display: none;
+    }
+
     .caption {
       display: flex;
       height: calc(var(--gallery-document-total-height) - var(--gallery-document-thumbnail-height));

--- a/app/components/document/tracking_bookmark_component.html.erb
+++ b/app/components/document/tracking_bookmark_component.html.erb
@@ -3,8 +3,8 @@
              authenticity_token: false,
              method:  bookmarked? ? :delete : :put,
              class: "bookmark-toggle btn nav-link",
-             aria: { label: (bookmarked? ? "Remove from saved records" : "Save record"),
-                    labelledby: "bookmark-#{@document.id}" },
+             title: tooltip_label,
+             aria: { label: aria_label },
              data: {
                controller: 'bookmark tooltip',
                document_id: @document.id.to_s.parameterize,
@@ -20,8 +20,7 @@
     <label id="bookmark-<%= @document.id %>" class="toggle-bookmark-label" data-checkboxsubmit-target="label" tabindex="0">
       <input type="checkbox" class="toggle-bookmark-input <%= bookmark_icon ? 'd-none' : '' %>" data-action="click->analytics#trackBookmark" data-checkboxsubmit-target="checkbox" <%= 'checked="checked"' if bookmarked? %>>
       <%= bookmark_icon %>
-      <span class="visually-hidden"><%= @document.id %>: </span>
-      <span class="bookmark-text align-middle" data-checkboxsubmit-target="span"><%= bookmarked? ? t('blacklight.search.bookmarks.present') : t('blacklight.search.bookmarks.absent') %></span>
+      <span class="bookmark-text align-middle" data-checkboxsubmit-target="span"><%= bookmark_state_label %></span>
     </label>
   </div>
   <% if article? %>

--- a/app/components/document/tracking_bookmark_component.html.erb
+++ b/app/components/document/tracking_bookmark_component.html.erb
@@ -3,7 +3,6 @@
              authenticity_token: false,
              method:  bookmarked? ? :delete : :put,
              class: "bookmark-toggle btn nav-link",
-             title: tooltip_label,
              aria: { label: aria_label },
              data: {
                controller: 'bookmark tooltip',
@@ -14,7 +13,8 @@
                       "update-tooltip->tooltip#updatePopper bookmark.blacklight->bookmark#bookmarkUpdated",
                present: t('blacklight.search.bookmarks.present'),
                absent: t('blacklight.search.bookmarks.absent'),
-               inprogress: t('blacklight.search.bookmarks.inprogress')
+               inprogress: t('blacklight.search.bookmarks.inprogress'),
+               tooltip: tooltip_label
             }) do %>
   <div class="toggle-bookmark" data-controller="analytics">
     <label id="bookmark-<%= @document.id %>" class="toggle-bookmark-label" data-checkboxsubmit-target="label" tabindex="0">

--- a/app/components/document/tracking_bookmark_component.rb
+++ b/app/components/document/tracking_bookmark_component.rb
@@ -10,5 +10,23 @@ module Document
     def article?
       @document.eds?
     end
+
+    def aria_label
+      [tooltip_label, bookmark_subject_label].join(' ')
+    end
+
+    def tooltip_label
+      bookmarked? ? "Remove from saved records" : "Save record"
+    end
+
+    def bookmark_state_label
+      bookmarked? ? t('blacklight.search.bookmarks.present') : t('blacklight.search.bookmarks.absent')
+    end
+
+    private
+
+    def bookmark_subject_label
+      helpers.document_presenter(@document)&.heading || @document.id
+    end
   end
 end

--- a/app/components/search_result/document_gallery_component.html.erb
+++ b/app/components/search_result/document_gallery_component.html.erb
@@ -37,6 +37,7 @@
   <% # bookmark functions for items/docs and preview button %>
   <div class="gallery-buttons d-flex justify-content-end">
     <button class="btn btn-xs btn-preview preview-button bi-chevron-down documentid-<%= document.id %>"
+            aria-label="preview"
             data-behavior="preview-button-trigger"
             data-preview-embed-browse-target="button"
             data-gallery-preview-target="button"

--- a/app/javascript/controllers/bookmark_controller.js
+++ b/app/javascript/controllers/bookmark_controller.js
@@ -23,13 +23,14 @@ export default class extends Controller {
   bookmarkUpdated(event) {
     const toast = document.getElementById('toast-template').content.cloneNode(true).querySelector('.toast');
     const toastText = toast.querySelector('.toast-text')
-
-    if (event.detail.checked){
-      this.element.ariaLabel = 'Remove from saved records';
+    if (event.detail.checked) {
+      this.element.dataset.tooltip = 'Remove from saved records'
+      this.element.ariaLabel = this.element.ariaLabel.replace('Save record', 'Remove from saved records')
       toastText.innerHTML = '<i class="bi bi-check-circle-fill pe-1" aria-hidden="true"></i> Record saved'
       if (this.element.matches(':hover')) this.hover()
     } else {
-      this.element.ariaLabel = 'Save record';
+      this.element.dataset.tooltip = 'Save record'
+      this.element.ariaLabel = this.element.ariaLabel.replace('Remove from saved records', 'Save record')
       toastText.innerHTML =  '<i class="bi bi-trash-fill pe-1" aria-hidden="true"></i> Record removed'
     }
 

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -24,7 +24,7 @@ export default class extends Controller {
   }
 
   tooltipText() {
-    return this.element.getAttribute('data-tooltip') || this.element.getAttribute('aria-label')
+    return this.element.dataset.tooltip || this.element.ariaLabel
   }
 
   hide() {

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,12 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
 import { createPopper }  from '@popperjs/core'
 
-// Must be instantiated on an element with an aria-label attribute
+// Must be instantiated on an element with a title OR an aria-label attribute
 export default class extends Controller {
   connect () {
     this.tooltip = document.createElement("div")
     this.tooltip.classList.add('tooltip')
-    this.tooltip.innerHTML = this.element.getAttribute('aria-label')
+    this.tooltip.innerHTML = this.tooltipText()
     this.tooltip.ariaHidden = 'true'
     this.element.appendChild(this.tooltip)
 
@@ -19,8 +19,12 @@ export default class extends Controller {
   }
 
   updatePopper() {
-    this.tooltip.innerHTML = this.element.getAttribute('aria-label')
+    this.tooltip.innerHTML = this.tooltipText()
     this.popperInstance.update()
+  }
+
+  tooltipText() {
+    return this.element.title || this.element.getAttribute('aria-label')
   }
 
   hide() {

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { createPopper }  from '@popperjs/core'
 
-// Must be instantiated on an element with a title OR an aria-label attribute
+// Must be instantiated on an element with a data-tooltip OR an aria-label attribute
 export default class extends Controller {
   connect () {
     this.tooltip = document.createElement("div")
@@ -24,7 +24,7 @@ export default class extends Controller {
   }
 
   tooltipText() {
-    return this.element.title || this.element.getAttribute('aria-label')
+    return this.element.getAttribute('data-tooltip') || this.element.getAttribute('aria-label')
   }
 
   hide() {

--- a/spec/components/document/tracking_bookmark_component_spec.rb
+++ b/spec/components/document/tracking_bookmark_component_spec.rb
@@ -19,6 +19,6 @@ RSpec.describe Document::TrackingBookmarkComponent, type: :component do
 
   it 'has tooltip and bookmark attributes' do
     expect(page).to have_css '[data-controller="bookmark tooltip"]'
-    expect(page).to have_css '[title="Save record"]'
+    expect(page).to have_css '[data-tooltip="Save record"]'
   end
 end

--- a/spec/components/document/tracking_bookmark_component_spec.rb
+++ b/spec/components/document/tracking_bookmark_component_spec.rb
@@ -16,4 +16,9 @@ RSpec.describe Document::TrackingBookmarkComponent, type: :component do
     expect(page).to have_css '[data-controller="analytics"]'
     expect(page).to have_css '[data-action^="click->analytics#trackBookmark"]'
   end
+
+  it 'has tooltip and bookmark attributes' do
+    expect(page).to have_css '[data-controller="bookmark tooltip"]'
+    expect(page).to have_css '[title="Save record"]'
+  end
 end

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe 'Site Accessibility', :js do
       visit solr_document_path('34')
       expect(page).to be_accessible.within('main')
     end
+
+    context 'when in gallery view' do
+      it 'has an accessible view' do
+        visit solr_document_path('1391872')
+        within '.record-browse-nearby' do
+          click_link 'Full page'
+        end
+        expect(page).to have_text 'Browse related items'
+        expect(page).to be_accessible.within('main')
+      end
+    end
   end
 
   describe 'advanced search', :js do

--- a/spec/features/callnumber_browse_spec.rb
+++ b/spec/features/callnumber_browse_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Callnumber Browse', :js do
         find('.toggle-bookmark').click
       end
 
-      expect(page).to have_css('[aria-label="Remove from saved records"]')
+      expect(page).to have_css('[title="Remove from saved records"]')
 
       page.driver.browser.navigate.refresh
 

--- a/spec/features/callnumber_browse_spec.rb
+++ b/spec/features/callnumber_browse_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Callnumber Browse', :js do
         find('.toggle-bookmark').click
       end
 
-      expect(page).to have_css('[title="Remove from saved records"]')
+      expect(page).to have_css('[data-tooltip="Remove from saved records"]')
 
       page.driver.browser.navigate.refresh
 

--- a/spec/support/stub_article_service.rb
+++ b/spec/support/stub_article_service.rb
@@ -71,7 +71,7 @@ module StubArticleService # rubocop:disable Metrics/ModuleLength
           'BibRecord' => {
             'BibEntity' => {
               'Titles' => [
-                { 'Type' => 'main', 'TitleFull' => 'Another title for the document' }
+                { 'Type' => 'main', 'TitleFull' => 'Another title for the fulltext document' }
               ]
             }
           }
@@ -97,7 +97,7 @@ module StubArticleService # rubocop:disable Metrics/ModuleLength
           'BibRecord' => {
             'BibEntity' => {
               'Titles' => [
-                { 'Type' => 'main', 'TitleFull' => 'Another title for the document' }
+                { 'Type' => 'main', 'TitleFull' => 'Another title for the non-fulltext document' }
               ]
             }
           }


### PR DESCRIPTION
This was all in service to get rid of this extra "Save" text in gallery view:
<img width="686" height="380" alt="Screenshot 2025-07-23 at 2 49 29 PM" src="https://github.com/user-attachments/assets/ce10fe9c-c877-4b5d-a7d5-a463bdd8edfb" />

This:
* Hides that text
* Changes our toolip controller to allow the use of `data-tooltip` so we're not forced into this situation of needing both `aria-label` and `aria-labelledby`. This stops the macos screenreader from reading the label twice.
* Prefers using the document heading over the ID for building the unique aria label. Technically we could still have duplicate headings, but I think this is more in the spirit of accessibility than reading the ID.
* Adds an aria-label onto the preview button
* Adds the accessibility test for the gallery view