### PR TITLE
Round the borders of all gallery documents

### DIFF
--- a/app/assets/stylesheets/searchworks4/gallery-view.css
+++ b/app/assets/stylesheets/searchworks4/gallery-view.css
@@ -13,8 +13,7 @@
   }
 
   .gallery-document {
-    --bs-border-radius: 0.25rem;
-    --bs-border-color: var(--stanford-20-black);
+    border-radius: 0.25rem;
     height: var(--gallery-document-total-height);
     width: var(--gallery-document-width);
     padding: 0;

--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -282,7 +282,6 @@
   .embed-callnumber-browse-container {
     .gallery {
       .gallery-document {
-        border-radius: 0.25rem;
         margin-left: 0.375rem;
         margin-right: 0.375rem;
         margin-bottom: 0;


### PR DESCRIPTION
Full page browse nearby was not getting the border radius correctly before.

After:
<img width="992" height="502" alt="Screenshot 2025-07-23 at 4 54 31 PM" src="https://github.com/user-attachments/assets/99f0585d-0fdb-4a43-83fb-0a22dee11211" />
<img width="896" height="382" alt="Screenshot 2025-07-23 at 4 54 14 PM" src="https://github.com/user-attachments/assets/e84be0bc-54de-4236-adbc-7dabebb136ca" />
