### PR TITLE
Preserve border spacing between input and search button

### DIFF
--- a/app/assets/stylesheets/searchworks4/search.css
+++ b/app/assets/stylesheets/searchworks4/search.css
@@ -36,7 +36,7 @@
   }
 
   .search-q {
-    border: 0;
+    border: 1px solid transparent;
     border-inline-start: var(--search-q-border);
     outline: none;
   }


### PR DESCRIPTION
Right now when you enter text in the search bar the edge of the button gets cut off. This is a fix.

<img width="459" height="92" alt="Screenshot 2025-07-24 at 12 09 43 PM" src="https://github.com/user-attachments/assets/f4cff876-a7b2-4727-bec7-7cd34358adab" />
<img width="194" height="81" alt="Screenshot 2025-07-24 at 12 09 47 PM" src="https://github.com/user-attachments/assets/8a180ac2-3e08-4e61-9624-9bcd9738f9e5" />
