### PR TITLE
remove padding on flash messages if there are no flash messages

### DIFF
--- a/app/components/main_container_component.html.erb
+++ b/app/components/main_container_component.html.erb
@@ -3,7 +3,7 @@
   <main id="main-container" data-controller="google-cover-image" class="mb-5">
 
     <% # The quick report javascript requires this node to be on the page %>
-    <div class="flash_messages mx-auto my-3" style="max-width: 1000px;">
+    <div class="flash_messages<% if flash.any? %> mx-auto my-3<% end %>" style="max-width: 1000px;">
       <% FLASH_TYPES_WITH_LEVEL.each do |type, alert_level| %>
         <%= render AlertComponent.new(level: alert_level, message: flash[type].html_safe) if flash[type] %>
       <% end %>


### PR DESCRIPTION
Before:
<img width="1326" height="962" alt="Screenshot 2025-07-24 at 12 30 15 PM" src="https://github.com/user-attachments/assets/24c04633-0772-41bc-9438-94b11be94327" />

After:
<img width="1307" height="950" alt="Screenshot 2025-07-24 at 12 30 04 PM" src="https://github.com/user-attachments/assets/3ed81bd2-e3a5-4826-be97-64c2e2d2e72b" />
