### PR TITLE
fix overflow for browse nearby

### DIFF
--- a/app/javascript/controllers/browse_nearby_controller.js
+++ b/app/javascript/controllers/browse_nearby_controller.js
@@ -32,8 +32,8 @@ export default class extends Controller {
 
   isAsideBlocking() {
     const aside = this.getAsideTarget()
-    if (!aside)
-      return false
+    if (!aside) return false
+    if (window.innerWidth < 992) return true
 
     const asideBottom = aside.getBoundingClientRect().bottom
     const browseNearbyTop = this.containerTarget.getBoundingClientRect().top - 32


### PR DESCRIPTION
On certain size screens breakout is being applied to the browse-nearby which is bad because it is going off the screen. There is never going to be an aside on smaller screens since we make the aside a drawer on smaller screens

Before:
<img width="1004" height="418" alt="Screenshot 2025-07-24 at 3 05 06 PM" src="https://github.com/user-attachments/assets/7f2181b5-95b4-4247-89b6-7af995353802" />

After:
<img width="1017" height="415" alt="Screenshot 2025-07-24 at 3 10 09 PM" src="https://github.com/user-attachments/assets/15221b6d-d023-4d8a-8c54-8abde02f788d" />

