### PR TITLE
fix alignment for in single online link

### DIFF
--- a/app/components/searchworks4/online_availability_component.html.erb
+++ b/app/components/searchworks4/online_availability_component.html.erb
@@ -3,7 +3,7 @@
 
   <ul class="list-unstyled mb-0" data-list-toggle-target="group">
     <% links.each do |link| %>
-      <li class="mb-1">
+      <li <% if links.many? %>class="mb-1"<% end %>>
         <%= link.html&.html_safe %>
         <%= render StanfordOnlyPopoverComponent.new if link.stanford_only? %>
       </li>


### PR DESCRIPTION
Before:
<img width="441" height="127" alt="Screenshot 2025-07-24 at 3 44 44 PM" src="https://github.com/user-attachments/assets/c794ab11-78be-4cbd-b88e-8b8dcfd23c1e" />

After:
<img width="394" height="78" alt="Screenshot 2025-07-24 at 3 45 30 PM" src="https://github.com/user-attachments/assets/65f23c14-12f5-4db5-b19a-fcdb2304595f" />
