### PR TITLE
fix advanced search link not working

### DIFF
--- a/app/views/shared/searchworks4/_search_navbar.html.erb
+++ b/app/views/shared/searchworks4/_search_navbar.html.erb
@@ -19,7 +19,7 @@
                                             advanced_search_url: controller_name.in?(%w[article_selections articles]) ? nil : search_action_url(action: 'advanced_search'),
                                             params: search_state.params_for_search.except(:qt),
                                             autocomplete_path: suggest_index_catalog_path %>
-      <%= link_to_unless_current 'Advanced search', advanced_search_path(search_state.params_for_search), class: 'text-body' unless controller_name.in?(%w[article_selections articles]) %>
+      <%= link_to_unless_current 'Advanced search', advanced_search_path(search_state.params_for_search), data: { turbo: false }, class: 'text-body' unless controller_name.in?(%w[article_selections articles]) %>
     </div>
   </turbo-frame>
 <% end %>


### PR DESCRIPTION
Before:
<img width="1037" height="908" alt="Screenshot 2025-07-24 at 4 21 58 PM" src="https://github.com/user-attachments/assets/1333f1f1-e47e-4eb5-9455-6f874a659ca9" />
