### PR TITLE
Allow selection tabs to wrap at extra small size

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,7 +1,7 @@
 <% @page_title = t 'blacklight.search.masthead_title', title: t('blacklight.bookmarks.page_heading'), application_name: "#{I18n.t('blacklight.application_name')} catalog" %>
 
 <div class="col-xl-9 col-md-12 mt-3" data-controller="saved-list" data-action="bookmark.blacklight->saved-list#bookmarksUpdated">
-  <div class="d-flex mb-2">
+  <div class="d-sm-flex mb-2">
     <h1 class="me-3">Saved Records</h1>
 
     <ul class="nav nav-tabs">
@@ -20,7 +20,7 @@
         <% end %>
       </li>
     </ul>
-    <div class="tab-underline-extend flex-grow-1 border-bottom">
+    <div class="tab-underline-extend flex-grow-1 border-bottom d-none d-sm-block">
     </div>
   </div>
 


### PR DESCRIPTION
Just an idea 🤷‍♂️ It looked awkward on my phone.

Before:
<img width="348" height="243" alt="Screenshot 2025-07-24 at 3 41 43 PM" src="https://github.com/user-attachments/assets/25894767-dba6-46ab-bc24-4c2bdc2a42e9" />

After:
<img width="350" height="217" alt="Screenshot 2025-07-24 at 3 41 51 PM" src="https://github.com/user-attachments/assets/f2571f06-2f63-4f6f-84ef-89a76c2b81f0" />

Extra small goes to 576px so maybe there's a better solution? Here it is at the boundary:
<img width="554" height="202" alt="Screenshot 2025-07-24 at 3 45 06 PM" src="https://github.com/user-attachments/assets/ebca2e7b-d666-4979-945b-1aa62be99955" />

