### PR TITLE
We're no longer showing bound-with information in the search results

### DIFF
--- a/spec/features/request_link_spec.rb
+++ b/spec/features/request_link_spec.rb
@@ -17,20 +17,6 @@ RSpec.describe 'Request Links' do
         end
       end
     end
-
-    context 'with a bound-with record' do
-      it 'renders a link to the detail/record view instead of holdings' do
-        pending 'SW4.0 redesign in progress.'
-
-        visit search_catalog_path(q: '2279186')
-
-        within 'table.availability' do
-          expect(page).to have_content 'Some items are bound together - '
-          expect(page).to have_link 'see record for full details.'
-          expect(page).to have_link "Request"
-        end
-      end
-    end
   end
 
   context 'on the record view' do


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
