### PR TITLE
Add a tiny margin to the search field select so it's focus state(?) d…

### DIFF
--- a/app/assets/stylesheets/searchworks4/search.css
+++ b/app/assets/stylesheets/searchworks4/search.css
@@ -33,6 +33,7 @@
   .search-field {
     width: 7rem;
     --bs-border-width: 0;
+    margin-right: 1px;
   }
 
   .search-q {


### PR DESCRIPTION
…oesn't block the little vertical divider.

Sometimes it disappears when the select is focused:
<img width="349" height="99" alt="Screenshot 2025-07-25 at 07 07 13" src="https://github.com/user-attachments/assets/a10940ed-7847-4a65-a4de-54e20d38aeaa" />

