### PR TITLE
allow italics/bold to be copied from cite

### DIFF
--- a/app/javascript/controllers/copy_text_controller.js
+++ b/app/javascript/controllers/copy_text_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   async copy(e) {
     try {
-        await navigator.clipboard.writeText(this.textTarget.innerText)
+        await navigator.clipboard.write([new ClipboardItem({ "text/html": this.textTarget.innerHTML })])
         e.target.closest('button').innerHTML = '<i class="bi bi-check" aria-hidden="true"></i> Copied'
     } catch (err) {
         console.error('Failed to copy text: ', err);


### PR DESCRIPTION
Right now when you click on the copy link in the cite modal the citation is copied in plain text. This change makes it rich text change.