### PR TITLE
Use friendly library names in page title

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -10,6 +10,16 @@ module CatalogHelper
     document_index_view_type.to_s
   end
 
+  def format_constraints_page_title(search_state)
+    text = render_search_to_page_title(search_state)
+    return text unless text.present? && search_state.filter('library').present?
+
+    library_code = search_state.filter('library').values.first
+    library_name = translate_library_code(library_code)
+
+    text.sub(/Library:\s*.*/, "Library: #{library_name}")
+  end
+
   # override upstream so we don't check the session for the last view type.
   def document_index_view_type(query_params = params || {})
     view_param = query_params[:view]

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -8,7 +8,7 @@
     <% @page_title = t 'blacklight.search.masthead_title', title: page_location.access_point.to_s.gsub(/_/, ' ').capitalize.pluralize, application_name: "#{I18n.t('blacklight.application_name')} catalog" %>
   <% end %>
 <% else %>
-  <% constraints_text = render_search_to_page_title(search_state) %>
+  <% constraints_text = format_constraints_page_title(search_state) %>
   <% if constraints_text.present? %>
     <% @page_title = t('blacklight.search.page_title.title', constraints: constraints_text, application_name: application_name) %>
   <% else %>

--- a/spec/features/results_page_spec.rb
+++ b/spec/features/results_page_spec.rb
@@ -46,6 +46,26 @@ RSpec.feature "Search Results Page" do
     end
   end
 
+  context 'with a library filter applied' do
+    before do
+      visit search_catalog_path f: { library: ['HILA'] }
+    end
+
+    it 'uses the friendly library name rather than the code' do
+      expect(page).to have_title "SearchWorks catalog, Library: Hoover Institution Library & Archives"
+    end
+  end
+
+  context 'with a library filter and search term applied' do
+    before do
+      visit search_catalog_path f: { library: ['HILA'] }, q: 'book'
+    end
+
+    it 'uses the friendly library name rather than the code' do
+      expect(page).to have_title "SearchWorks catalog, book, Library: Hoover Institution Library & Archives"
+    end
+  end
+
   context 'when clicking clear all' do
     it 'takes the user to a blank search' do
       visit search_catalog_path f: { access_facet: ['Online'] }, q: 'book'


### PR DESCRIPTION
Fixes #5825
