### PR TITLE
Provide a plain-text clipboard fallback

### DIFF
--- a/app/javascript/controllers/copy_text_controller.js
+++ b/app/javascript/controllers/copy_text_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   async copy(e) {
     try {
-        await navigator.clipboard.write([new ClipboardItem({ "text/html": this.textTarget.innerHTML })])
+        await navigator.clipboard.write([new ClipboardItem({ "text/html": this.textTarget.innerHTML, "text/plain": this.textTarget.innerText })])
         e.target.closest('button').innerHTML = '<i class="bi bi-check" aria-hidden="true"></i> Copied'
     } catch (err) {
         console.error('Failed to copy text: ', err);


### PR DESCRIPTION
I was having trouble copy + pasting into some apps without a `text/plain` fallback?