### PR TITLE
Set dynamics margins for the embed browse preview

### DIFF
--- a/app/javascript/controllers/preview_embed_browse_controller.js
+++ b/app/javascript/controllers/preview_embed_browse_controller.js
@@ -31,6 +31,71 @@ export default class extends Controller {
     this.buttonTarget.classList.add('preview-open', 'bi-chevron-up')
     this.attachPreviewEvents()
     this.hideDocumentActions()
+    this.adjustPreviewMargins()
+  }
+
+  adjustPreviewMargins() {
+    // This is assuming the preview is styled for 100% width
+    this.previewTarget.style.marginLeft = 0
+    this.previewTarget.style.marginRight = 0
+    const maxPreviewWidth = 800
+    const galleryGapWidth = 16
+    const galleryRect = this.element.getBoundingClientRect()
+    const previewRect = this.previewTarget.getBoundingClientRect()
+    const galleryDocumentWidth = galleryRect.width + galleryGapWidth
+    const previewWidth = previewRect.width
+    const leftBound = previewRect.left
+    const rightBound = leftBound + previewWidth
+    const minMargin = 8 // Not tied to anything, it just looks nice and leaves space for the drop shadow.
+    const galleryCenterDistanceFromLeftBound = (galleryRect.left + (galleryDocumentWidth / 2)) - leftBound
+    const galleryCenterDistanceFromRightBound = rightBound - (galleryRect.left + (galleryDocumentWidth / 2))
+
+    if (previewWidth <= maxPreviewWidth) {
+      // The potential max width of the preview is smaller than our specified max width, so add our minimum padding.
+      this.previewTarget.style.marginLeft = `${minMargin}px`
+      this.previewTarget.style.marginRight = `${minMargin}px`
+      this.movePointer(galleryCenterDistanceFromLeftBound, leftBound, leftBound + previewWidth - (2 * minMargin))
+      return
+    }
+
+    if (galleryCenterDistanceFromLeftBound <= (maxPreviewWidth/2)) {
+      // If the center of the element is too close to the left to center, max the right margin
+      const marginRight = Math.ceil(previewWidth - maxPreviewWidth) - minMargin
+      this.previewTarget.style.marginLeft = `${minMargin}px`
+      this.previewTarget.style.marginRight = `${marginRight}px`
+      this.movePointer(galleryCenterDistanceFromLeftBound, leftBound, leftBound + maxPreviewWidth)
+      return
+    }
+
+    if (galleryCenterDistanceFromRightBound <= (maxPreviewWidth/2)) {
+      // If the center of the element is too close to the right to center, max the left margin
+      const marginLeft = Math.ceil(previewWidth - maxPreviewWidth) - minMargin
+      this.previewTarget.style.marginLeft = `${marginLeft}px`
+      this.previewTarget.style.marginRight = `${minMargin}px`
+      this.movePointer(galleryCenterDistanceFromLeftBound - marginLeft, leftBound, leftBound + maxPreviewWidth)
+      return
+    }
+
+    // Otherwise we need to balance the left and right margins to center the preview
+    const marginLeft = Math.ceil(galleryCenterDistanceFromLeftBound - (maxPreviewWidth / 2))
+    const marginRight = Math.ceil(previewWidth - maxPreviewWidth - marginLeft)
+    this.previewTarget.style.marginLeft = `${marginLeft}px`
+    this.previewTarget.style.marginRight = `${marginRight}px`
+    this.movePointer(galleryCenterDistanceFromLeftBound - marginLeft, leftBound, leftBound + maxPreviewWidth)
+  }
+
+  movePointer(targetCenter, leftBound, rightBound) {
+    const pointerWidth = 21
+    const arrowLeft = targetCenter - pointerWidth
+
+    if (arrowLeft > 0 && leftBound + targetCenter < rightBound) {
+      this.arrow.style.left = arrowLeft + 'px'
+      this.arrow.classList.add('d-block')
+      this.arrow.classList.remove('d-none')
+    } else {
+      this.arrow.classList.add('d-none')
+      this.arrow.classList.remove('d-block')
+    }
   }
 
   appendPointer(target) {
@@ -74,7 +139,22 @@ export default class extends Controller {
     return this.buttonTarget.classList.contains('preview-open')
   }
 
+  scrollContainerTarget() {
+    const container = this.previewTarget.closest('.embed-callnumber-browse-container')
+    if (!container) return null
+    return container.querySelector('.embedded-items')
+  }
+
   attachPreviewEvents() {
+    const scrollContainer = this.scrollContainerTarget()
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', () => {
+        this.adjustPreviewMargins()
+      })
+    }
+    window.addEventListener('resize', () => {
+      this.adjustPreviewMargins()
+    })
     this.previewTarget.addEventListener('turbo:frame-load', () => {
       this.hideDocumentActions()
     })


### PR DESCRIPTION
Closes #5485 

Sets a max width and applies dynamic margins to the embed browse nearby preview:

<img width="1600" height="799" alt="Screenshot 2025-07-25 at 2 52 51 PM" src="https://github.com/user-attachments/assets/210a3e0e-02af-499e-88e3-3ed621f3f4ba" />

You should see:
* The preview & pointer arrow moving with scroll, respecting boundaries
* The preview having ~800px max width

Originally I thought to merge this with https://github.com/sul-dlss/SearchWorks/blob/6be8da83a799a3e1c16395c8e8a0648c9427a959/app/javascript/controllers/gallery_preview_controller.js#L44 They are similar but given the major differences (multi-row flex box with unused column space versus a single row with overflow) I found it less confusing to keep them separate.