### PR TITLE
Remove .no-js class

### DIFF
--- a/app/assets/stylesheets/searchworks4/bookmarks.css
+++ b/app/assets/stylesheets/searchworks4/bookmarks.css
@@ -20,16 +20,6 @@
   --bl-icon-color: var(--bs-primary);
   color: var(--stanford-80-black);
 
-  .no-js & {
-    input[type="submit"] {
-      display: inline;
-    }
-
-    .toggle-bookmark {
-      display: none;
-    }
-  }
-
   input[type="submit"] {
     display: none;
   }

--- a/app/javascript/controllers/record_print_controller.js
+++ b/app/javascript/controllers/record_print_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="record-print"
+export default class extends Controller {
+  connect() {
+  }
+
+  print() {
+    if(window.print) window.print()
+  }
+
+  cleanup() {
+  }
+}

--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="description" content="Stanford Libraries' official online search tool for books, media, journals, databases, government documents and more." />


### PR DESCRIPTION
We're not un-setting it, and the only style rule I saw doesn't seem like it's applicable to us.