### PR TITLE
Restore headings for document gallery titles

### DIFF
--- a/app/components/search_result/document_gallery_component.html.erb
+++ b/app/components/search_result/document_gallery_component.html.erb
@@ -9,12 +9,12 @@
   <div class="caption">
     <% # header bar for doc items in index view gallery %>
     <div class="documentHeader">
-      <div class="index_title">
+      <h3 class="index_title mb-0">
         <span class="two-lines">
           <%= helpers.link_to_document document, class: 'fw-semibold', counter: counter, data: { action: "click->analytics#trackLink"} %>
         </span>
-      </div>
-      <div class="location one-line py-1">
+      </h3>
+      <div class="location one-line pb-1">
         <% if document.items.present? %>
           <% if document.holdings.libraries.length == 1 %>
             <%= document.holdings.libraries.first.name %>

--- a/spec/features/callnumber_browse_spec.rb
+++ b/spec/features/callnumber_browse_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Callnumber Browse', :js do
       expect(page).to have_css(
         ".fake-cover", text: 'Book cover not available', visible: :hidden
       )
-      expect(page).to have_css '.gallery-document .index_title', text: 'Studies in old Ottoman criminal law'
+      expect(page).to have_css '.gallery-document h3.index_title', text: 'Studies in old Ottoman criminal law'
 
       expect(page).to have_css '.toggle-bookmark'
       expect(page).to have_button 'preview'


### PR DESCRIPTION
Somehow I switched these to divs during the SW4 work.

The default `h3` style tightens up the line height, which I think looks nice, but I'm open to suggestions.

<img width="1008" height="501" alt="Screenshot 2025-07-25 at 3 31 35 PM" src="https://github.com/user-attachments/assets/fd54df4a-57f1-41b4-8ab0-ed315f20a758" />
