### PR TITLE
Gather analytics for full page button in related items

### DIFF
--- a/app/components/record/item/marc/callnumber_browse_component.html.erb
+++ b/app/components/record/item/marc/callnumber_browse_component.html.erb
@@ -2,7 +2,7 @@
 <div class="section record-browse-nearby p-4 border" id="<%= t('record_side_nav.browse_nearby.id') %>" data-side-nav-class="<%= t('record_side_nav.browse_nearby.id') %>" data-controller="analytics browse-nearby" data-action="resize@window->browse-nearby#resizeWithAside turbo:frame-load@window->browse-nearby#resizeWithAside show.bs.tab->browse-nearby#markActive" data-analytics-category-value="browse-nearby" data-browse-nearby-target="container">
   <div class="heading view-full-page ps-2 d-flex me-auto justify-content-start">
     <h2 class="m-0 pe-3">Related items</h2>
-    <%= link_to "Full page", "#", class: 'btn btn-primary bi bi-arrows-angle-expand fw-normal', hidden: true%>
+    <%= link_to "Full page", "#", class: 'btn btn-primary bi bi-arrows-angle-expand fw-normal', data: { action: "click->analytics#trackLink" }, hidden: true %>
   </div>
   <div class="row mt-4 ps-2 tabs" data-browse-nearby-target="tabs">
     <div class="col mb-3">


### PR DESCRIPTION
We can somewhat infer this in GA, but I think we had specific tracking of this prior to the redesign.

<img width="278" height="50" alt="Screenshot 2025-07-25 at 4 01 42 PM" src="https://github.com/user-attachments/assets/b092c827-8bed-44ac-8c28-f37a2853805d" />
