### PR TITLE
Add preload link tag for the banner image

### DIFF
--- a/app/views/articles/_home_page.html.erb
+++ b/app/views/articles/_home_page.html.erb
@@ -1,4 +1,9 @@
 <% @page_title = t 'blacklight.articles.home.title' %>
+
+<% content_for :head do %>
+  <%= preload_link_tag 'searchworks4/research-papers-reading-v1.webp' %>
+<% end %>
+
 <% content_for(:search_navbar) do %>
   <div class="search-area-image-bg">
     <div class="container">

--- a/app/views/catalog/_home_page.html.erb
+++ b/app/views/catalog/_home_page.html.erb
@@ -1,4 +1,9 @@
 <% @page_title = t 'blacklight.home.title' %>
+
+<% content_for :head do %>
+  <%= preload_link_tag 'searchworks4/catalog-image.webp' %>
+<% end %>
+
 <% content_for(:search_navbar) do %>
   <div class="search-area-image-bg">
     <div class="container">


### PR DESCRIPTION
webpagetest.org found that Largest Contentful Paint is high (over 2.5s). The element driving your LCP is an image.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
