### PR TITLE
Also use EDS smart links for article fulltext

### DIFF
--- a/app/models/concerns/eds_links.rb
+++ b/app/models/concerns/eds_links.rb
@@ -30,7 +30,7 @@ module EdsLinks
     end
 
     def present?
-      %w[customlink-fulltext pdf ebook-pdf ebook-epub].include?(type) && label.present?
+      %w[customlink-fulltext pdf ebook-pdf ebook-epub other].include?(type) && label.present?
     end
 
     def type
@@ -72,7 +72,7 @@ module EdsLinks
         sfx:       sfx?,
         ill:       ill?,
         type:,
-        stanford_only: pdf?
+        stanford_only: pdf? || type == 'other'
       )
     end
 
@@ -101,6 +101,7 @@ module EdsLinks
       'HTML full text'.downcase =>           { label: 'View full text', category: 1 },
       'PDF full text'.downcase =>            { label: 'View/download PDF', category: 2 },
       'PDF eBook Full Text'.downcase =>      { label: 'View/download PDF', category: 2 },
+      'Full text'.downcase =>                { label: 'View on content provider\'s site', category: 3 },
       'Check SFX for full text'.downcase =>  { label: 'View on content provider\'s site', category: 3 },
       :open_access_link =>                   { label: :as_is, category: 4 },
       'View request options'.downcase =>     { label: 'Find full text or request', category: 5 }

--- a/app/models/eds_document.rb
+++ b/app/models/eds_document.rb
@@ -95,9 +95,13 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
       when 'ebook-epub'
         link_label = 'ePub eBook Full Text'
         link_icon = 'ePub eBook Full Text Icon'
+      when 'other'
+        link_label = 'Full Text'
       end
 
       link_url = link['Url'] || 'detail'
+      link_url = "#{Settings.libraries.default.ezproxy_host}#{{ qurl: link['Url'] }.to_param}" if link['Type'] == 'other' && link['Url'].present?
+
       { url: link_url, label: link_label, icon: link_icon, type: link['Type'], expires: true } if link_label
     end
 

--- a/app/presenters/article_fulltext_link_presenter.rb
+++ b/app/presenters/article_fulltext_link_presenter.rb
@@ -58,7 +58,7 @@ class ArticleFulltextLinkPresenter
     <<-HTML
       #{online_label}
       #{(link_to('View on detail page', eds_document_url(document)) if document_has_fulltext?)}
-      #{image_tag(image_url('pdf-icon.svg'), height: '20px', alt: 'PDF')}
+      #{image_tag(image_url('pdf-icon.svg'), height: '20px', alt: 'PDF') unless link.type == 'other'}
       #{link_to(link.text, article_fulltext_link_url(id: document.id, type: link.type), data: { turbo: false })}
       #{stanford_only_icon}
     HTML

--- a/spec/models/concerns/eds_links_spec.rb
+++ b/spec/models/concerns/eds_links_spec.rb
@@ -60,6 +60,44 @@ RSpec.describe EdsLinks do
     end
   end
 
+  context 'with a "smart" link with a URL' do
+    let(:document) do
+      EdsDocument.new({
+                        'FullText' => {
+                          'Links' => [
+                            {
+                              'Type' => 'other',
+                              'Url' => 'https://some.ebsco.url/'
+                            }
+                          ]
+                        }
+                      })
+    end
+
+    it 'has a fulltext link prefixed by ezproxy' do
+      expect(document.eds_links.all.first).to have_attributes(href: 'https://stanford.idm.oclc.org/login?qurl=https%3A%2F%2Fsome.ebsco.url%2F', text: 'View on content provider&#39;s site',
+                                                              stanford_only?: true)
+    end
+  end
+
+  context 'with a "smart" link without a URL' do
+    let(:document) do
+      EdsDocument.new({
+                        'FullText' => {
+                          'Links' => [
+                            {
+                              'Type' => 'other'
+                            }
+                          ]
+                        }
+                      })
+    end
+
+    it 'has a fulltext link' do
+      expect(document.eds_links.all.first).to have_attributes(href: 'detail', text: 'View on content provider&#39;s site', stanford_only?: true)
+    end
+  end
+
   context 'with a HTML full text link' do
     let(:document) do
       EdsDocument.new({


### PR DESCRIPTION
E.g. searching for "Nonholonomic Trajectory Planning of Postcapture Space" on -stage.