### PR TITLE
Track stack map text directions usage

### DIFF
--- a/app/components/stackmap/map_component.html.erb
+++ b/app/components/stackmap/map_component.html.erb
@@ -1,13 +1,13 @@
-<div data-controller="stackmap" data-stackmap-api-url-value="<%= api_url %>" data-action="shown.bs.tab@window->stackmap#tabVisibility">
+<div data-controller="analytics stackmap" data-stackmap-api-url-value="<%= api_url %>" data-action="shown.bs.tab@window->stackmap#tabVisibility" data-analytics-category-value="stackmap">
   <p>Call number <span data-stackmap-target="callnumber" class="fw-bold"></span> is located in <span data-stackmap-target="library" class="fw-bold"></span>, <span data-stackmap-target="floorname" class="fw-bold"></span>.</p>
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item" role="presentation">
+    <li class="nav-item" role="presentation" data-action="shown.bs.tab->analytics#trackEvent">
       <button class="nav-link active" id="map-tab-<%= item.id %>" data-bs-toggle="tab" data-bs-target="#map-<%= item.id %>" type="button" role="tab" aria-controls="map-<%= item.id %>" aria-selected="true">
         <i class="bi bi-map me-1 align-middle"></i>Map
       </button>
     </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link show-description" id="directions-tab-<%= item.id %>" data-bs-toggle="tab" data-controller="analytics" data-bs-target="#directions-<%= item.id %>" data-action="reveal-text-directions" type="button" role="tab" aria-controls="directions-<%= item.id %>" aria-selected="false">
+    <li class="nav-item" role="presentation" data-action="shown.bs.tab->analytics#trackEvent">
+      <button class="nav-link show-description" id="directions-tab-<%= item.id %>" data-bs-toggle="tab" data-bs-target="#directions-<%= item.id %>" data-action="reveal-text-directions" type="button" role="tab" aria-controls="directions-<%= item.id %>" aria-selected="false">
         <i class="bi bi-list-task me-1 align-middle"></i>Text directions
       </button>
     </li>

--- a/app/javascript/controllers/analytics_controller.js
+++ b/app/javascript/controllers/analytics_controller.js
@@ -29,10 +29,11 @@ export default class extends Controller {
   trackEvent(event) {
     const eventName = this.categoryValue || "searchworks"
     const element = event.currentTarget
+    const link_text = element.innerText ? element.innerText.trim() : ''
     const dimensions = {
       link_classes: element.className,
       link_id: element.id,
-      link_text: element.innerText.trim()
+      link_text: link_text
     }
     gtag('event', eventName, dimensions)
   }


### PR DESCRIPTION
We were tracking this prior to SW 4.0. Now that we are using Bootstrap tabs, we can track usage via those tab events.

Event name with dimensions:
<img width="643" height="56" alt="Screenshot 2025-07-29 at 11 02 57 AM" src="https://github.com/user-attachments/assets/28d77f03-5b6c-4b18-8516-f0722c9e16f0" />
