### PR TITLE
uniq eds_authors

### DIFF
--- a/app/components/searchworks4/record_summary_component.rb
+++ b/app/components/searchworks4/record_summary_component.rb
@@ -10,7 +10,7 @@ module Searchworks4
     end
 
     def authors
-      return presenter.document.eds_authors&.uniq if presenter.document.eds?
+      return presenter.document.eds_authors if presenter.document.eds?
 
       sum = []
       %i[creator corporate_author meeting].each do |target|

--- a/app/models/eds_document.rb
+++ b/app/models/eds_document.rb
@@ -135,7 +135,7 @@ class EdsDocument # rubocop:disable Metrics/ClassLength
   end
 
   def eds_authors
-    deep_find_all(dig(*bib_relationshps_path), 'NameFull')&.to_a
+    deep_find_all(dig(*bib_relationshps_path), 'NameFull')&.to_a&.uniq
   end
 
   def eds_publication_date


### PR DESCRIPTION
Since we are getting data from three different "nodes" for eds_author (RecordInfo BibRecord BibRelationships) we can have repeats of the same data. This makes sure we aren't repeating author data to the user.

Before:
<img width="768" height="555" alt="Screenshot 2025-08-04 at 1 02 03 PM" src="https://github.com/user-attachments/assets/2c3fdd54-58c5-4cd1-876c-e874bdacdb06" />

After:
<img width="760" height="832" alt="Screenshot 2025-08-04 at 1 02 13 PM" src="https://github.com/user-attachments/assets/948c6ae2-9888-4b97-a733-9f016646f2fe" />
