### PR TITLE
Do static analysis of erb files using herb

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,5 +21,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Herb analyze
+        run: bundle exec herb analyze app --non-interactive --no-log-file
       - name: Run tests
         run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'capybara', '~> 3.0'
+  gem "herb", "~> 0.4.3"
   gem 'launchy' # useful for debugging rspec/capybara integration tests -- put "save_and_open_page" in your test to debug
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,14 @@ GEM
       activesupport (>= 6.1)
     hashdiff (1.2.0)
     hashie (5.0.0)
+    herb (0.4.3-aarch64-linux-gnu)
+    herb (0.4.3-aarch64-linux-musl)
+    herb (0.4.3-arm-linux-gnu)
+    herb (0.4.3-arm-linux-musl)
+    herb (0.4.3-arm64-darwin)
+    herb (0.4.3-x86_64-darwin)
+    herb (0.4.3-x86_64-linux-gnu)
+    herb (0.4.3-x86_64-linux-musl)
     honeybadger (6.0.2)
       logger
       ostruct
@@ -753,6 +761,7 @@ DEPENDENCIES
   faraday
   faraday-follow_redirects
   global_alerts
+  herb (~> 0.4.3)
   honeybadger
   jbuilder (~> 2.7)
   jsbundling-rails (~> 1.2)


### PR DESCRIPTION
This helps us find malformed html in our ERB files

See https://github.com/marcoroth/herb\?tab\=readme-ov-file

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->

This is what allowed me to catch https://github.com/sul-dlss/SearchWorks/pull/5925 (among others), whereas #5879 does not catch that.
