### PR TITLE
Make the Stanford header link inline.

### DIFF
--- a/app/views/shared/searchworks4/_top_navbar.html.erb
+++ b/app/views/shared/searchworks4/_top_navbar.html.erb
@@ -2,7 +2,7 @@
       <div class="identity-bar">
         <div class="container-lg">
           <a
-            class="su-brand-bar__logo"
+            class="su-brand-bar__logo d-inline"
             href="https://www.stanford.edu"
             >Stanford University</a
           >


### PR DESCRIPTION
Maybe I'm just bad at clicking with my mouse, but I'm so tired of accidentally clicking somewhere in the red bar and going to the university homepage.