### PR TITLE
Convert db_az_subject to a document attribute.

### DIFF
--- a/app/components/record/marc_document_component.html.erb
+++ b/app/components/record/marc_document_component.html.erb
@@ -76,12 +76,10 @@
       <%= render_if_present document.subjects('655') %>
       <%= render_if_present document.subjects('690') %>
 
-      <% if document.is_a_database? && document[:db_az_subject] %>
-        <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
-          <% component.with_label { 'Database topics' } %>
-          <% document[:db_az_subject].each do |subject| %>
-            <% component.with_value { helpers.link_to_database_search(subject) } %>
-          <% end %>
+      <%= render Searchworks4::MetadataFieldLayoutComponent.new do |component| %>
+        <% component.with_label { 'Database topics' } %>
+        <% document.db_az_subject.each do |subject| %>
+          <% component.with_value { helpers.link_to_database_search(subject) } %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -118,13 +118,10 @@ class SolrDocument
   attribute :oclc_number, :string, 'oclc'
   attribute :imprint_string, :string, :imprint_display
   attribute :vernacular_title, :string, :vern_title_display
+  attribute :db_az_subject, :array, :db_az_subject
 
   def document_formats
     format.presence || old_format.presence || []
-  end
-
-  def db_az_subject
-    self[:db_az_subject] if is_a_database?
   end
 
   def file_ids

--- a/spec/components/record/marc_document_component_spec.rb
+++ b/spec/components/record/marc_document_component_spec.rb
@@ -162,15 +162,8 @@ RSpec.describe Record::MarcDocumentComponent, type: :component do
     end
 
     it "displays for databases" do
-      allow(document).to receive(:is_a_database?).and_return(true)
       expect(page).to have_css("dd a", text: "DB Subject1")
       expect(page).to have_css("dd a", text: "DB Subject2")
-    end
-
-    it "does not display for non-databases" do
-      allow(document).to receive(:is_a_database?).and_return(false)
-      expect(page).to have_no_css("dd a", text: "DB Subject1")
-      expect(page).to have_no_css("dd a", text: "DB Subject2")
     end
   end
 


### PR DESCRIPTION
Only databases index into the `db_az_subject` field, so the `is_a_database?` is redundant:

https://github.com/sul-dlss/searchworks_traject_indexer/blob/main/lib/traject/config/folio_config.rb#L1460-L1473

Only `MetadataFieldLayoutComponent` with values render, so the additional condition isn't necessary