### PR TITLE
Remove SolrDocument#id override.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,11 +34,6 @@ class SolrDocument
   delegate :empty?, :blank?, to: :to_h
   delegate :managed_purls, to: :marc_links
 
-  # TODO: change this to #to_param when we have upgraded to Blacklight 6.11.1
-  def id
-    (super || '').to_s.gsub('/', '%2F')
-  end
-
   def eds_ris_export?
     false
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -123,12 +123,6 @@ RSpec.describe SolrDocument do
     end
   end
 
-  describe '#id' do
-    it 'escapes slashes' do
-      expect(SolrDocument.new(id: 'abc/123').id).to eq 'abc%2F123'
-    end
-  end
-
   describe '#eresources_library_display_name' do
     let(:eresource_bus_library) { { id: 30, holdings_library_code_ssim: 'BUSINESS', item_display_struct: [] } }
 


### PR DESCRIPTION
I don't think `id `can contain a `/` 🤷‍♂️ 