### PR TITLE
Axe test a search result with a request button

### DIFF
--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe 'Site Accessibility', :js do
       end
     end
 
+    context 'with results that display a request button' do
+      before { visit search_catalog_path q: 'soils' }
+
+      it 'is accessible' do
+        expect(page).to be_accessible.within('main')
+      end
+    end
+
     context 'with zero results' do
       before { visit search_catalog_path q: 'sdfsda', search_field: 'search_author' }
 


### PR DESCRIPTION
Looks like axe might not like links within a `summary` tag?