### PR TITLE
Remove link_to_collection_members

### DIFF
--- a/app/components/access_panels/collection_component.html.erb
+++ b/app/components/access_panels/collection_component.html.erb
@@ -16,7 +16,7 @@
       <% if @collection.collection_members.present? %>
         <div class="d-flex flex-wrap gap-2">
           <dt>Digital collection</dt>
-          <dd><%= helpers.link_to_collection_members(pluralize(@collection.collection_members.total, 'digital item'), @collection) %></dd>
+          <dd><%= link_to(pluralize(@collection.collection_members.total, 'digital item'), helpers.collection_members_path(@collection)) %></dd>
         </div>
       <% end %>
       <% if @collection.extent_sans_format.present? %>

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -5,10 +5,6 @@ module CollectionHelper
     collection_id.sub(/^a(\d+)$/, '\1')
   end
 
-  def link_to_collection_members(link_text, document, options = {})
-    link_to(link_text, collection_members_path(document), options)
-  end
-
   def collection_members_path(document, options = {})
     search_catalog_path(f: { collection: [document.collection_id] })
   end

--- a/app/views/collection_members/_placeholder.html.erb
+++ b/app/views/collection_members/_placeholder.html.erb
@@ -4,7 +4,7 @@
       <h2 class="mb-0">Digital collection</h2>
     </div>
     <div class="col-md-12 image-filmstrip border rounded p-4 pt-5">
-      <%= link_to_collection_members('View all items', document) %>
+      <%= link_to('View all items', collection_members_path(document)) %>
     </div>
   </div>
 </turbo-frame>

--- a/spec/helpers/collection_helper_spec.rb
+++ b/spec/helpers/collection_helper_spec.rb
@@ -3,17 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe CollectionHelper do
-  describe "#link_to_collection_members" do
-    let(:document) { instance_double(SolrDocument, id: '1234', collection_id: 'a1234') }
-
-    it "links to the given text" do
-      expect(link_to_collection_members("LinkText", document)).to match /<a href.*>LinkText<\/a>/
-    end
-    it "links the collection id with prefix" do
-      expect(link_to_collection_members("LinkText", document)).to match /<a href=\".*collection.*=a1234\".*/
-    end
-  end
-
   describe "#collections_search_params" do
     it "is the collection_type facet value of 'Digital Collection" do
       expect(collections_search_params).to have_key(:f)


### PR DESCRIPTION
This doesn't seem like a very useful helper method (and we used `link_to` just as much as `link_to_collection_members` 🤷‍♂️ )