### PR TITLE
Add structured link information to the articles + catalog json respon…

### DIFF
--- a/app/models/json_results_document_presenter.rb
+++ b/app/models/json_results_document_presenter.rb
@@ -28,12 +28,10 @@ class JsonResultsDocumentPresenter
 
         "<span class=\"online-label\">Online</span> #{html}"
       end
-    }
+    }.merge('links' => online_links.map(&:as_json))
   end
 
   def online_links
-    return [] unless source_document&.preferred_online_links&.any?
-
-    source_document.preferred_online_links
+    source_document&.preferred_online_links || []
   end
 end

--- a/app/models/links/link.rb
+++ b/app/models/links/link.rb
@@ -88,5 +88,16 @@ class Links
                      end
       content_tag(:a, @link_text || link_host, href: @href, **tooltip_attr)
     end
+
+    def as_json(*)
+      {
+        type: @type,
+        href: @href,
+        stanford_only: @stanford_only,
+        link_text: @link_text || link_host,
+        source: casalini_text,
+        additional_text: @additional_text
+      }
+    end
   end
 end

--- a/app/views/articles/index.json.jbuilder
+++ b/app/views/articles/index.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This is consumed by Bento
-docs = @presenter.documents.collect do |document|
+docs = @presenter.documents.collect do |document| # rubocop:disable Metrics/BlockLength
   link = ArticleFulltextLinkPresenter.new(document:, context: self).links.first # top priority one only
   composed_title = document['eds_composed_title']
   data = {
@@ -14,6 +14,17 @@ docs = @presenter.documents.collect do |document|
   }
   data['source'] = document.to_h # avoids deprecation warning
   data['fulltext_link_html'] = link if link.present?
+  if document.preferred_online_links.first.present?
+    link = document.preferred_online_links.first
+    data['links'] = [link.as_json]
+    data['links'][0][:href] = article_fulltext_link_url(id: document.id, type: link.type) if link.href == 'detail'
+  elsif document.html_fulltext?
+    data['links'] = [{
+      type: 'detail',
+      href: eds_document_url(document),
+      link_text: 'View on detail page'
+    }]
+  end
   data['eds_composed_title'] = italicize_composed_title({ value: Array.wrap(composed_title) }) if composed_title.present?
 
   data

--- a/spec/models/json_results_document_presenter_spec.rb
+++ b/spec/models/json_results_document_presenter_spec.rb
@@ -23,10 +23,13 @@ RSpec.describe JsonResultsDocumentPresenter do
         }]
       end
 
+      let(:json) { presenter.as_json.with_indifferent_access }
+
       it 'includes the link wrapped in a span with a class to be styled by consumers' do
-        expect(presenter.as_json['fulltext_link_html'].length).to eq 1
-        expect(presenter.as_json['fulltext_link_html'].first).to include('<span class="stanford-only">')
-        expect(presenter.as_json['fulltext_link_html'].first).to match(/<a href=.*example.com.*>The Link<\/a>/)
+        expect(json['fulltext_link_html'].length).to eq 1
+        expect(json['fulltext_link_html'].first).to include('<span class="stanford-only">')
+        expect(json['fulltext_link_html'].first).to match(/<a href=.*example.com.*>The Link<\/a>/)
+        expect(json['links'].first).to include(href: 'https://example.com', link_text: 'The Link', stanford_only: true)
       end
     end
   end


### PR DESCRIPTION
…ses (e.g. for bento)

Replacement for #5125 that handles articles + catalog with the same data structure.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
