### PR TITLE
Use json format in mini-bento URLs

### DIFF
--- a/app/components/search_result/mini_bento/layout_component.html.erb
+++ b/app/components/search_result/mini_bento/layout_component.html.erb
@@ -53,14 +53,14 @@
           </div>
         </div>
 
-        <div class="mb-2" data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= archive_search_url %>">
+        <div class="mb-2" data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= archive_search_json_url %>">
           <%= link_to archive_search_url, class: 'pe-2' do %>
             Archival Collections at Stanford
           <% end %>
           <span class="badge rounded-pill bento-count" data-blacklight-result-count-target="count"></span>
         </div>
 
-        <div class="mb-2" data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= geo_search_url %>">
+        <div class="mb-2" data-controller="blacklight-result-count" data-blacklight-result-count-url-value="<%= geo_search_json_url %>">
           <%= link_to geo_search_url,  class: 'pe-2' do %>
             EarthWorks for geospatial data and maps
           <% end %>

--- a/app/components/search_result/mini_bento/layout_component.rb
+++ b/app/components/search_result/mini_bento/layout_component.rb
@@ -28,12 +28,20 @@ module SearchResult
         "https://archives.stanford.edu/catalog?group=true&q=#{params[:q]}"
       end
 
+      def archive_search_json_url
+        "https://archives.stanford.edu/catalog?group=true&q=#{params[:q]}&format=json"
+      end
+
       def exhibits_search_url
         "https://exhibits.stanford.edu/search?q=#{params[:q]}"
       end
 
       def geo_search_url
         "https://earthworks.stanford.edu/?q=#{params[:q]}"
+      end
+
+      def geo_search_json_url
+        "https://earthworks.stanford.edu/?q=#{params[:q]}&format=json"
       end
 
       def name


### PR DESCRIPTION
`headers: { 'accept': 'application/json' }` doesn't appear to trigger `controller.params[:format] == 'json'` for the remote apps. Doing it this way does, letting non-VPN users get mini-bento results for our apps that use our current bot challenge gem config.

Better ideas? 🤷‍♂️ 