### PR TITLE
Push the link additional text into the component.

### DIFF
--- a/app/components/access_panels/online_link_list_component.html.erb
+++ b/app/components/access_panels/online_link_list_component.html.erb
@@ -8,7 +8,6 @@
       <div>
         <%= render Searchworks4::LinkComponent.new(link: link) %>
       </div>
-      <%= link.additional_text_html&.html_safe %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/searchworks4/link_component.html.erb
+++ b/app/components/searchworks4/link_component.html.erb
@@ -2,4 +2,4 @@
 <%= link_to link_text, href, **link_attr %>
 <%= stanford_only_icon if stanford_only? %>
 <%= casalini_text if casalini_text %>
-<%= tag.span additional_text, class: 'additional-link-text' if additional_text %>
+<%= tag.div additional_text, class: 'additional-link-text' if additional_text %>

--- a/spec/components/access_panels/online_component_spec.rb
+++ b/spec/components/access_panels/online_component_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe AccessPanels::OnlineComponent, type: :component do
       render_inline(described_class.new(document:))
       expect(page).to have_css(".panel-online")
       expect(page).to have_css("ul.links li .stanford-only")
-      expect(page).to have_css("span.additional-link-text", text: "4 at one time")
+      expect(page).to have_css("div.additional-link-text", text: "4 at one time")
     end
     it 'renders a different heading for SDR items' do
       document = SolrDocument.new(marc_links_struct: [{ href: '...', link_text: 'Link text', fulltext: true }], druid: 'ng161qh7958')


### PR DESCRIPTION
Fixes a regression from #5977 where we were doubling up on additional text.