### PR TITLE
Add the rosette to the header 

### DIFF
--- a/app/assets/stylesheets/searchworks4.scss
+++ b/app/assets/stylesheets/searchworks4.scss
@@ -3,7 +3,7 @@
 layer(framework);
 @import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css")
 layer(framework);
-@import url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-07-28/styles/sul.css")
+@import url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-08-14/styles/sul.css")
 layer(components);
 
 @import url("https://cdn.jsdelivr.net/npm/blacklight-hierarchy@6.7.1/app/assets/stylesheets/blacklight/hierarchy/hierarchy.css")

--- a/app/assets/stylesheets/searchworks4/masthead.css
+++ b/app/assets/stylesheets/searchworks4/masthead.css
@@ -8,6 +8,12 @@
     --bs-link-color-rgb: var(--stanford-cardinal-rgb);
     --bs-link-hover-color-rgb: var(--stanford-cardinal-rgb);
   }
+
+  .navbar-nav {
+    @media (width >= 768px) {
+      margin-bottom: -0.5rem;
+    }
+  }
 }
 
 #user-util-collapse .dropdown-menu {

--- a/app/views/catalog/opensearch.xml.builder
+++ b/app/views/catalog/opensearch.xml.builder
@@ -4,7 +4,7 @@ xml.instruct! :xml, :version=>'1.0'
 xml.OpenSearchDescription(:xmlns=>'http://a9.com/-/spec/opensearch/1.1/') {
   xml.ShortName application_name
   xml.Description "#{application_name} Search"
-  xml.Image "https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-07-28/styles/icon.png", height: 512, width: 512, type: 'image/png'
+  xml.Image "https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-08-14/styles/icon.png", height: 512, width: 512, type: 'image/png'
   xml.Contact
   xml.Url :type=>'text/html', :method=>'get', :template=>"#{url_for :controller=>'catalog', :only_path => false}?q={searchTerms}&amp;page={startPage?}"
   xml.Url :type=>'application/rss+xml', :method=>'get', :template=>"#{url_for :controller=>'catalog', :only_path => false}.rss?q={searchTerms}&amp;page={startPage?}"

--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -18,9 +18,9 @@
 
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag I18n.t('blacklight.application_name'), opensearch_catalog_path(format: 'xml') %>
-    <link rel="icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-07-28/styles/icon.png" type="image/png">
-    <link rel="icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-07-28/styles/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-07-28/styles/icon.png">
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-08-14/styles/icon.png" type="image/png">
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-08-14/styles/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-08-14/styles/icon.png">
     <%= stylesheet_link_tag "searchworks4", media: "all", 'data-turbo-track' => true %>
     <%= stylesheet_link_tag "print", media: "print", 'data-turbo-track' => true %>
 

--- a/app/views/shared/searchworks4/_top_navbar.html.erb
+++ b/app/views/shared/searchworks4/_top_navbar.html.erb
@@ -37,15 +37,18 @@
       <div class="masthead">
         <div class="container-lg">
           <div
-            class="d-flex flex-wrap align-items-end justify-content-between pt-3 pb-1 pb-md-3 gap-3"
+            class="d-flex flex-wrap align-items-center pt-3 pb-1 pb-md-3 gap-2"
           >
-            <div>
-              <div class="h1 my-0">
-                <% if controller.is_a? ArticlesController %>
-                  <a href="/articles">SearchWorks <span class="fw-semibold">Articles+</span></a>
-                <% else %>
-                  <a href="/">SearchWorks <span class="fw-semibold">Catalog</span></a>
-                <% end %>
+          <div class="d-flex align-items-center gap-2 flex-grow-1">
+              <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden></span>
+              <div class="me-1 flex-grow-1">
+                <div class="h1 my-0">
+                  <% if controller.is_a? ArticlesController %>
+                    <a href="/articles">SearchWorks <span class="fw-semibold">Articles+</span></a>
+                  <% else %>
+                    <a href="/">SearchWorks <span class="fw-semibold">Catalog</span></a>
+                  <% end %>
+                </div>
               </div>
             </div>
             <div class="navbars ms-md-auto">


### PR DESCRIPTION
Part of #5854
<img width="866" height="167" alt="Screenshot 2025-08-14 at 3 36 43 PM" src="https://github.com/user-attachments/assets/74307ca6-f30d-48f9-af0d-ecb733346540" />

I'd appreciate another set of eyes on the positioning of the masthead navbar links, trying to match [the designs](https://www.figma.com/design/rphRL8X4aDjBf4OaOFZCYl/SearchWorks-4.0--WC2-3-?node-id=276-69779&t=zBbgf3IzhUHA8cOl-4)