### PR TITLE
Add the responsive search navbar designs

### DIFF
--- a/app/assets/stylesheets/searchworks4/search.css
+++ b/app/assets/stylesheets/searchworks4/search.css
@@ -61,18 +61,31 @@
 }
 
 #search-navbar search {
+  order: 2;
+  max-width: 38rem;
   width: 100%;
-}
 
-@media (width >= 767.98px) {
-  #search-navbar search {
-    width: 60%;
+  @media (width >= 575.98px) {
+    order: 3;
+    max-width: 100%;
+  }
+
+  @media (width >= 991.98px) {
+    order: 2;
+    max-width: 38rem;
   }
 }
 
-@media (width >= 1199.98px) {
-  #search-navbar search {
-    width: 50%;
+/* When search mode & the advanced search link are on the top row and search wraps to the next,
+ this provides a fixed width for both rows */
+#search-navbar {
+  search, .advanced-search-link {
+    @media (width >= 767.98px) {
+      margin-right: calc(100vw - 45rem);
+    }
+    @media (width >= 991.98px) {
+      margin-right: 0;
+    }
   }
 }
 

--- a/app/views/shared/searchworks4/_search_navbar.html.erb
+++ b/app/views/shared/searchworks4/_search_navbar.html.erb
@@ -4,9 +4,9 @@
             'aria-label': t('searchworks.navigation.search_bar'),
             data: { controller: 'search-navbar', 'search-navbar-additional-articles-params-value': addl_parameters&.to_json } do %>
   <turbo-frame id="search-navbar-frame" refresh="morph" data-search-navbar-target="container">
-    <div class="container-lg search-form d-flex align-items-center column-gap-3 flex-wrap">
-      <div class="text-nowrap">
-        <span class="fw-bold">Search mode:</span>
+    <div class="container-lg search-form d-flex align-items-center column-gap-3 flex-wrap flex-lg-nowrap">
+      <div class="text-nowrap order-1 py-2">
+        <span class="fw-bold me-2">Search mode:</span>
         <div class="form-check d-inline-block mx-1">
           <input class="form-check-input" type="radio" name="search-type" id="searchTypeCatalog" value="catalog" data-url="<%= search_bar_catalog_url %>" data-action="search-navbar#toggleMode" <% unless articles_checked %>checked<% end %>>
           <label class="form-check-label" for="searchTypeCatalog">Catalog</label>
@@ -20,7 +20,7 @@
                                             advanced_search_url: controller_name.in?(%w[article_selections articles]) ? nil : search_action_url(action: 'advanced_search'),
                                             params: search_state.params_for_search.except(:qt),
                                             autocomplete_path: suggest_index_catalog_path %>
-      <%= link_to_unless_current 'Advanced search', advanced_search_path(search_state.params_for_search), data: { turbo: false }, class: 'text-body' unless controller_name.in?(%w[article_selections articles]) %>
+      <%= link_to_unless_current 'Advanced search', advanced_search_path(search_state.params_for_search), data: { turbo: false }, class: 'advanced-search-link text-body text-nowrap order-3 order-sm-2 order-lg-3 ms-sm-auto ms-lg-0 py-2 py-lg-0' unless controller_name.in?(%w[article_selections articles]) %>
     </div>
   </turbo-frame>
 <% end %>


### PR DESCRIPTION
Search navbar portion of #5854

Search is slightly wider than in the designs because I don't think we'd like the select text to wrap.

<img width="1635" height="171" alt="Screenshot 2025-08-15 at 10 52 09 AM" src="https://github.com/user-attachments/assets/d44dfd6a-fa22-44a8-ae64-1ad6618368d8" />
<img width="1045" height="177" alt="Screenshot 2025-08-15 at 10 51 58 AM" src="https://github.com/user-attachments/assets/02a5552e-3f7e-41eb-94e6-4584ef5a1b36" />
<img width="866" height="220" alt="Screenshot 2025-08-15 at 10 51 41 AM" src="https://github.com/user-attachments/assets/44f1cec0-389b-43a9-8ef7-c5672cba7424" />
<img width="509" height="247" alt="Screenshot 2025-08-15 at 10 51 25 AM" src="https://github.com/user-attachments/assets/445e41d2-89b3-4a0d-81d8-bc2c783661c9" />
