### PR TITLE
Hide the modal close button outside of the modal

### DIFF
--- a/app/assets/stylesheets/searchworks4/modal.css
+++ b/app/assets/stylesheets/searchworks4/modal.css
@@ -8,6 +8,11 @@
   }
 }
 
+/* Hide the modal footer close button for modal content being viewed as a page. */
+#main-container .modal-footer button[data-bl-dismiss="modal"] {
+  display: none;
+}
+
 .modal:has(.feedback-form) {
   /* This footer padding value is not affected by or the same as --bs-modal-padding */
   .modal-footer {


### PR DESCRIPTION
Fixes #5993 

I didn't hide the full footer because the cite tool can also be viewed as a page, and it seems useful to keep the "Send" button in that case.