### PR TITLE
Use default style for mobile "See availability" button

### DIFF
--- a/app/components/record/document_layout_component.html.erb
+++ b/app/components/record/document_layout_component.html.erb
@@ -15,7 +15,7 @@
 
     <%= header %>
 
-    <button class="btn btn-sm py-0 btn-secondary d-lg-none my-3" data-bs-toggle="offcanvas" data-bs-target="#aside" aria-controls="aside">See availability</button>
+    <button class="btn btn-secondary d-lg-none my-3" data-bs-toggle="offcanvas" data-bs-target="#aside" aria-controls="aside">See availability</button>
 
     <%= embed %>
 


### PR DESCRIPTION
Part of #6014 

Changes button from small with no padding to the default component library button.

After:
<img width="162" height="73" alt="Screenshot 2025-08-18 at 9 09 23 AM" src="https://github.com/user-attachments/assets/29707c7b-3e63-401f-b15f-1f0b39f7c4c6" />
