### PR TITLE
Adjust record view styles on smaller screens

### DIFF
--- a/app/components/articles/document_component.html.erb
+++ b/app/components/articles/document_component.html.erb
@@ -17,11 +17,11 @@
         <span itemprop="name"><%= @presenter.heading %></span>
       </h1>
 
-      <div class="mb-5">
+      <div class="mb-4 mb-lg-5">
         <span class="align-text-bottom me-1"><%= resource_icon %></span><%= @document.eds_publication_type || @document.eds_document_type %>
       </div>
 
-      <button class="btn btn-sm py-0 btn-secondary d-lg-none my-4" data-bs-toggle="offcanvas" data-bs-target="#aside" aria-controls="aside">See availability</button>
+      <button class="btn btn-secondary d-lg-none mb-4" data-bs-toggle="offcanvas" data-bs-target="#aside" aria-controls="aside">See availability</button>
 
       <%= document_metadata %>
     <% end %>

--- a/app/components/record/document_layout_component.html.erb
+++ b/app/components/record/document_layout_component.html.erb
@@ -15,7 +15,7 @@
 
     <%= header %>
 
-    <button class="btn btn-secondary d-lg-none my-3" data-bs-toggle="offcanvas" data-bs-target="#aside" aria-controls="aside">See availability</button>
+    <button class="btn btn-secondary d-lg-none mb-4" data-bs-toggle="offcanvas" data-bs-target="#aside" aria-controls="aside">See availability</button>
 
     <%= embed %>
 

--- a/app/components/record/marc_document_component.html.erb
+++ b/app/components/record/marc_document_component.html.erb
@@ -6,7 +6,7 @@
       <p class='vernacular-title h2 fw-normal mt-3'><%= presenter.vernacular_title %></p>
     <% end %>
 
-    <div class='upper-record-metadata mb-5'>
+    <div class='upper-record-metadata mb-4 mb-lg-5'>
       <div>
         <span class="me-1 align-text-bottom"><%= helpers.render_resource_icon presenter.formats %></span><%= presenter.document_format %>
         <% if presenter.document_format.present? && document.marc_field('3003abcefg').values.any? %>&mdash;<% end %> <%= safe_join(document.marc_field('3003abcefg').values, ' ').presence %>
@@ -19,22 +19,24 @@
   <% end %>
 
   <% component.with_embed do %>
-    <div class="mb-5">
-      <% if document.is_a_collection? %>
-        <%= render 'collection_members/placeholder', document: document %>
-      <% else %>
-        <%= case
-          when document.managed_purls.many?
-            render 'catalog/managed_purl_embed', document: document
-          when document.druid
-            render Record::Item::EmbedComponent.new(druid: document.druid)
-          end %>
-      <% end%>
-    </div>
+    <% if document.is_a_collection? || document.managed_purls.many? || document.druid %>
+      <div class="mb-4 mb-lg-5">
+        <% if document.is_a_collection? %>
+          <%= render 'collection_members/placeholder', document: document %>
+        <% else %>
+          <%= case
+            when document.managed_purls.many?
+              render 'catalog/managed_purl_embed', document: document
+            when document.druid
+              render Record::Item::EmbedComponent.new(druid: document.druid)
+            end %>
+        <% end%>
+      </div>
+    <% end %>
   <% end %>
 
   <% component.with_metadata do %>
-    <%= render Searchworks4::DocumentSectionLayout.new(title: 'Description', classes: 'mb-5') do %>
+    <%= render Searchworks4::DocumentSectionLayout.new(title: 'Description', classes: 'mb-4 mb-lg-5') do %>
       <%= render_if_present document.marc_field('245c') %>
 
       <%- uniform_title = helpers.get_uniform_title(document) -%>

--- a/app/components/record/mods_document_component.html.erb
+++ b/app/components/record/mods_document_component.html.erb
@@ -5,23 +5,27 @@
       <p class='vernacular-title h2 fw-normal mt-3'><%= presenter.vernacular_title %></p>
     <% end %>
 
-    <div class='upper-record-metadata mb-5'>
+    <div class='upper-record-metadata mb-4 mb-lg-5'>
       <div><%= helpers.render_resource_icon presenter.formats %> <%= presenter.document_format %></div>
     </div>
   <% end %>
 
   <% component.with_embed do %>
-    <div class="mb-5">
-      <%= case
-        when document.managed_purls.many?
-          render 'catalog/managed_purl_embed', document: document
-        when document.druid && (!document.mods? || document.published_content?)
-          render Record::Item::EmbedComponent.new(druid: document.druid)
-        end %>
-      <% if document.is_a_collection? %>
-        <%= render 'collection_members/placeholder', document: document %>
-      <% end %>
-    </div>
+    <% if document.managed_purls.many? ||
+          (document.druid && (!document.mods? || document.published_content?)) ||
+          document.is_a_collection? %>
+      <div class="mb-4 mb-lg-5">
+        <%= case
+          when document.managed_purls.many?
+            render 'catalog/managed_purl_embed', document: document
+          when document.druid && (!document.mods? || document.published_content?)
+            render Record::Item::EmbedComponent.new(druid: document.druid)
+          end %>
+        <% if document.is_a_collection? %>
+          <%= render 'collection_members/placeholder', document: document %>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 
   <% component.with_metadata do %>

--- a/app/components/searchworks4/document_section_layout.rb
+++ b/app/components/searchworks4/document_section_layout.rb
@@ -2,7 +2,7 @@
 
 module Searchworks4
   class DocumentSectionLayout < ViewComponent::Base
-    def initialize(title:, classes: ['mb-5'], heading_level: :h2, dl_classes: 'dl-horizontal')
+    def initialize(title:, classes: ['mb-4 mb-lg-5'], heading_level: :h2, dl_classes: 'dl-horizontal')
       @title = title
       @classes = classes
       @heading_level = heading_level


### PR DESCRIPTION
Fixes #6014 

Some ugliness to avoid rendering an empty embed container which makes it hard to have consistent spacing.

<img width="550" height="665" alt="Screenshot 2025-08-18 at 1 26 02 PM" src="https://github.com/user-attachments/assets/1654895d-b539-4e02-b5f2-d9f1373a20da" />
<img width="506" height="584" alt="Screenshot 2025-08-18 at 1 20 13 PM" src="https://github.com/user-attachments/assets/7f9d33fa-04c3-4d8c-9134-828cded2b084" />
