### PR TITLE
Quote each individual subject term in search link on mods records

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -10,7 +10,7 @@ module RecordHelper
         link_to(
           subject_text,
           search_catalog_path(
-            q: "\"#{[buffer, subject_text.strip].flatten.join(' ')}\"",
+            q: [buffer, subject_text.strip].flatten.map { |term| "\"#{term}\"" }.join(' '),
             search_field: 'subject_terms'
           )
         )


### PR DESCRIPTION
Subject (not genre) portion of #5016

Given a mods record (e.g., `vd347dk2145`) with subject `Transportation > Bikes`
Before: subject search for "Transportation Bikes"
After: subject search for "Transportation" "Bikes"

Example flat structure from stanford-mods
```
record.subject_all_search
=>
["Design features",
 "Black and White",
 "デザインの特徴",
 "モノクロ",
 "Districts",
 "Commercial district",
 "Ethnic street",
 "地区",
 "商業地区",
 "エスニック通り",
 "Transportation",
 "Bikes",
 "交通手段",
 "自転車",
 "Transportation",
 "Rickshaws",
 "交通手段",
 "人力車",
 "Manchuria",
 "Anto-ken"]
```