### PR TITLE
Don't save space for hours if we're not fetching them.

### DIFF
--- a/app/components/access_panels/library_header_component.html.erb
+++ b/app/components/access_panels/library_header_component.html.erb
@@ -2,11 +2,13 @@
   <h3 class="h4 p-0 m-0 fw-semibold">
     <%= link_to_library_about_page class: 'fw-semibold icon-link icon-link-hover stretched-link' %>
   </h3>
-  <div class="small" data-location-hours-target="hours">
-    <% if library.holding_library? %>
-      <div class="placeholder col-5"></div>
-    <% else %>
-      (no holding library)
-    <% end %>
-  </div>
+  <% if fetch_hours? %>
+    <div class="small" data-location-hours-target="hours">
+      <% if library.holding_library? %>
+        <div class="placeholder col-5"></div>
+      <% else %>
+        (no holding library)
+      <% end %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
E.g. this isn't great:

<img width="783" height="305" alt="Screenshot 2025-08-20 at 08 39 17" src="https://github.com/user-attachments/assets/6a921236-6e38-4e93-b504-778d620258a0" />
https://searchworks.stanford.edu/view/686777/availability