### PR TITLE
Permit more single leading term matches for alphanum call numbers

### DIFF
--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -754,11 +754,11 @@
       </analyzer>
     </fieldType>
 
-    <!-- field designed for ALPHANUM (and CALDOC) call number searching -->
+    <!-- field designed for ALPHANUM (including CALDOC) call number searching -->
     <fieldType name="callnumAlphanum" class="solr.TextField" omitNorms="true" omitTermFreqAndPositions="true">
       <analyzer type="index">
-        <!-- Remove space between the first two terms, we want two or more terms to match -->
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^(\w+)\s+(\w+)" replacement="$1$2"/>
+        <!-- Remove space between the first two terms only if first term is 5 alpha characters or less -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([A-Za-z]{1,5})\s+(\w+)" replacement="$1$2"/>
         <!-- Replace punctuation with a space -->
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{Punct}])" replacement=" "/>
         <!-- Normalize whitespace -->
@@ -767,7 +767,7 @@
         <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
       <analyzer type="query">
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^(\w+)\s+(\w+)" replacement="$1$2"/>
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([A-Za-z]{1,5})\s+(\w+)" replacement="$1$2"/>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{Punct}])" replacement=" "/>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s{2,}" replacement=" "/>
         <tokenizer class="solr.KeywordTokenizerFactory" />

--- a/spec/features/callnum_search_spec.rb
+++ b/spec/features/callnum_search_spec.rb
@@ -89,20 +89,40 @@ RSpec.describe 'Call num search', :js do
     end
 
     context 'when the item is not from SPEC' do
-      it 'matches searches with at least the first two terms' do
-        visit search_catalog_path
-        fill_in 'q', with: 'ZVC 12345'
-        select 'Call number', from: 'search_field'
-        click_button 'search'
-        expect(page).to have_text 'An object'
+      context 'when the first term has five or fewer alpha characters' do
+        it 'matches the first two terms' do
+          visit search_catalog_path
+          fill_in 'q', with: 'ZVC 12345'
+          select 'Call number', from: 'search_field'
+          click_button 'search'
+          expect(page).to have_text 'An object'
+        end
+
+        it 'does not match a search for the first term' do
+          visit search_catalog_path
+          fill_in 'q', with: 'ZVC'
+          select 'Call number', from: 'search_field'
+          click_button 'search'
+          expect(page).to have_text 'No results found'
+        end
       end
 
-      it 'does not match a search with only the first term' do
-        visit search_catalog_path
-        fill_in 'q', with: 'ZVC'
-        select 'Call number', from: 'search_field'
-        click_button 'search'
-        expect(page).to have_text 'No results found'
+      context 'when the first term is more than five alpha characters or is numeric' do
+        it 'matches a single leading numeric term' do
+          visit search_catalog_path
+          fill_in 'q', with: '3781'
+          select 'Call number', from: 'search_field'
+          click_button 'search'
+          expect(page).to have_text 'An object'
+        end
+
+        it 'matches a single leading alpha term' do
+          visit search_catalog_path
+          fill_in 'q', with: 'vrooman'
+          select 'Call number', from: 'search_field'
+          click_button 'search'
+          expect(page).to have_text 'An object'
+        end
       end
 
       it 'matches call numbers that look like ETDs' do

--- a/spec/fixtures/solr_documents/1.yml
+++ b/spec/fixtures/solr_documents/1.yml
@@ -18,6 +18,7 @@ alphanum_callnum_search:
   - 3781 2009 K
   - 3781 S78 M
   - CALIF E3000.S26 L3 2025
+  - VROOMAN COLLECTION L 2025
 spec_callnum_search: SC1003A BOX 1
 sudoc_callnum_search: Y 4.AP 6/2:S.HRG.98-413
 undoc_callnum_search:


### PR DESCRIPTION
This addresses the reported `82070 BOX 1` issue, where a call number search for `82070` didn't return the expected record.

I think consolidating the first two terms only when the first term is a common/often repeated alpha string that might dilute the search pool (e.g., `calif`, `zdvd`) would be an improvement.