### PR TITLE
Remove footer from modals that only have a close button

### DIFF
--- a/app/views/bound_with_children/modal.html.erb
+++ b/app/views/bound_with_children/modal.html.erb
@@ -14,8 +14,4 @@
       </div>
     </div>
   <% end %>
-  <% component.with_footer do %>
-    <button type="button" class="btn btn-outline-primary me-2 close" data-bl-dismiss="modal">Close</button>
-  <% end %>
-
 <% end %>

--- a/app/views/catalog/_grouped_citations.html.erb
+++ b/app/views/catalog/_grouped_citations.html.erb
@@ -4,8 +4,4 @@
   <% end %>
 
   <%= render Citations::MultipleCitationsComponent.new(documents: @documents) %>
-
-  <% component.with_footer do %>
-    <button type="button" class="btn btn-outline-primary" data-bl-dismiss="modal">Close</button>
-  <% end %>
 <% end %>

--- a/app/views/catalog/_single_citation_with_modal.html.erb
+++ b/app/views/catalog/_single_citation_with_modal.html.erb
@@ -4,8 +4,5 @@
   <% end %>
   <% component.with_body do %>
     <%= render Searchworks4::Citations::CitationComponent.new(presenter:) %>
-    <div class="modal-footer">
-      <button type="button" class="btn btn-outline-primary" data-bl-dismiss="modal">Close</button>
-    </div>
   <% end %>
 <% end %>

--- a/app/views/catalog/availability_modal.html.erb
+++ b/app/views/catalog/availability_modal.html.erb
@@ -18,8 +18,5 @@
       <%= render Searchworks4::AvailabilityAccordionComponent.new(library: @document.holdings.sal_libraries.first, document: @document, toggled_library: params[:library], libraries: @document.holdings.sal_libraries) %>
       <%= turbo_frame_tag "availability_#{dom_id(@document)}", src: availability_path(@document) %>
     </div>
-    <div class="modal-footer">
-      <button type="button" data-bl-dismiss="modal" class="btn btn-outline-primary">Close</button>
-    </div>
   <% end %>
 <% end %>

--- a/app/views/catalog/stackmap.html.erb
+++ b/app/views/catalog/stackmap.html.erb
@@ -7,8 +7,5 @@
     <div class="modal-body stackmap pb-2">
       <%= render StackmapComponent.new(items: @items, stackmap_api_url: @stackmap_api_url) %>
     </div>
-    <div class="modal-footer">
-      <button type="button" data-bl-dismiss="modal" class="btn btn-outline-primary">Close</button>
-    </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
Part of #5953

We likely will not need https://github.com/sul-dlss/SearchWorks/pull/6009 if this goes in