### PR TITLE
Switch to scrollable modals

### DIFF
--- a/app/components/citations/multiple_citations_component.html.erb
+++ b/app/components/citations/multiple_citations_component.html.erb
@@ -1,6 +1,32 @@
-<h3>Copy citations</h3>
-
 <div data-controller="citation-format">
+  <% unless all_unavailable? %>
+  <h3 class="mb-3">Export citations</h3>
+  <ul class="list-unstyled d-flex gap-3 export-citations mb-4">
+    <% if @documents.any? {|d| d.export_formats.key?(:ris) } %>
+      <li>
+        <%= link_to 'In RIS format (Zotero)', bookmarks_path(:ris, search_state.params_for_search),
+                    download: ::File.basename(url_for(search_state.to_h.merge(format: 'ris'))) %>
+      </li>
+    <% end %>
+
+    <% if @documents.any? { |d| d.exports_as? :refworks_marc_txt } %>
+      <li>
+        <%= link_to "To RefWorks",
+                    refworks_export_url(url: bookmarks_export_url(:refworks_marc_txt, search_state.params_for_search))%>
+      </li>
+    <% end %>
+
+    <% if @documents.any? { |d| d.exports_as? :endnote } %>
+      <li>
+        <%= link_to 'To EndNote',
+                    bookmarks_path(:endnote, search_state.params_for_search),
+                    download: ::File.basename(bookmarks_path(:endnote, search_state.params_for_search)) %>
+      </li>
+    <% end %>
+  </ul>
+  <% end %>
+
+  <h3>Copy citations</h3>
   <% unless preferred_or_unavailable_citations_only? %>
   <div class="d-flex align-items-center gap-2 mb-3">
     <label for="citation-format" class="fw-bold">Select format</label>
@@ -45,30 +71,3 @@
   </div>
   <% end %>
 </div>
-
-<% unless all_unavailable? %>
-<h3 class="mt-4 mb-3">Export citations</h3>
-<ul class="list-unstyled d-flex gap-3 export-citations">
-  <% if @documents.any? {|d| d.export_formats.key?(:ris) } %>
-    <li>
-      <%= link_to 'In RIS format (Zotero)', bookmarks_path(:ris, search_state.params_for_search),
-                  download: ::File.basename(url_for(search_state.to_h.merge(format: 'ris'))) %>
-    </li>
-  <% end %>
-
-  <% if @documents.any? { |d| d.exports_as? :refworks_marc_txt } %>
-    <li>
-      <%= link_to "To RefWorks",
-                  refworks_export_url(url: bookmarks_export_url(:refworks_marc_txt, search_state.params_for_search))%>
-    </li>
-  <% end %>
-
-  <% if @documents.any? { |d| d.exports_as? :endnote } %>
-    <li>
-      <%= link_to 'To EndNote',
-                  bookmarks_path(:endnote, search_state.params_for_search),
-                  download: ::File.basename(bookmarks_path(:endnote, search_state.params_for_search)) %>
-    </li>
-  <% end %>
-</ul>
-<% end %>

--- a/app/components/searchworks4/citations/citation_component.html.erb
+++ b/app/components/searchworks4/citations/citation_component.html.erb
@@ -1,39 +1,9 @@
 <%= render Searchworks4::RecordSummaryComponent.new(presenter:) %>
 
 <div class="modal-body" data-controller="citation-format">
-  <h3>Copy citation</h3>
-
-  <% unless unavailable? || preferred_only? %>
-  <div class="row mb-3">
-    <div class="col-auto">
-      <label for="citation-format-select" class="col-form-label fw-bold">Select format</label>
-    </div>
-    <div class="col-auto">
-      <select id="citation-format-select" data-action="change->citation-format#reveal" class="form-select" style="width: unset;" aria-controls="<%= citations.keys.map { |style| "citation-format-#{style}" }.join(' ') %>">
-        <% citations.keys.each do |style| %>
-          <option value="citation-format-<%= style %>" ><%= t("searchworks.citations.styles.#{style}") %></option>
-        <% end %>
-      </select>
-    </div>
-  </div>
-  <% end %>
-
-  <% citations.each do |style, citation| %>
-    <div class="mb-4 bg-light p-2" data-citation-format-target="tab" data-controller="copy-text" id="citation-format-<%= style %>" <%= 'hidden' unless style == default_style %>>
-      <% unless unavailable? %>
-        <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm lh-1 ms-4" data-action="copy-text#copy">Copy</button></h5>
-      <% end %>
-      <% Array(citation).each do |cite| %>
-        <div class="mb-2" data-copy-text-target="text">
-          <%= cite %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-
   <% unless unavailable? %>
   <h3>Export citation</h3>
-  <ul class="list-unstyled d-flex gap-3 export-citations">
+  <ul class="list-unstyled d-flex gap-3 export-citations mb-4">
     <% if exports_ris? %>
       <% if eds_ris_export? %>
         <li>
@@ -73,4 +43,35 @@
     <% end %>
   </ul>
   <% end %>
+
+  <h3>Copy citation</h3>
+
+  <% unless unavailable? || preferred_only? %>
+  <div class="row mb-3">
+    <div class="col-auto">
+      <label for="citation-format-select" class="col-form-label fw-bold">Select format</label>
+    </div>
+    <div class="col-auto">
+      <select id="citation-format-select" data-action="change->citation-format#reveal" class="form-select" style="width: unset;" aria-controls="<%= citations.keys.map { |style| "citation-format-#{style}" }.join(' ') %>">
+        <% citations.keys.each do |style| %>
+          <option value="citation-format-<%= style %>" ><%= t("searchworks.citations.styles.#{style}") %></option>
+        <% end %>
+      </select>
+    </div>
+  </div>
+  <% end %>
+
+  <% citations.each do |style, citation| %>
+    <div class="mb-4 bg-light p-2" data-citation-format-target="tab" data-controller="copy-text" id="citation-format-<%= style %>" <%= 'hidden' unless style == default_style %>>
+      <% unless unavailable? %>
+        <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm lh-1 ms-4" data-action="copy-text#copy">Copy</button></h5>
+      <% end %>
+      <% Array(citation).each do |cite| %>
+        <div class="mb-2" data-copy-text-target="text">
+          <%= cite %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
 </div>

--- a/app/views/catalog/availability_modal.html.erb
+++ b/app/views/catalog/availability_modal.html.erb
@@ -3,8 +3,8 @@
     <h2 class="modal-title">Availability</h2>
   <% end %>
   <% component.with_body do %>
-    <%= render Searchworks4::RecordSummaryComponent.new(presenter: document_presenter(@document)) %>
-
+  <%= render Searchworks4::RecordSummaryComponent.new(presenter: document_presenter(@document)) %>
+  <div class="modal-body">
     <div class="accordion availability-modal px-3 mt-3" data-controller="availability-search">
       <div class="input-group my-3">
         <label class="input-group-text bg-body border-end-0 pe-0" for="availability-search-input">
@@ -18,5 +18,6 @@
       <%= render Searchworks4::AvailabilityAccordionComponent.new(library: @document.holdings.sal_libraries.first, document: @document, toggled_library: params[:library], libraries: @document.holdings.sal_libraries) %>
       <%= turbo_frame_tag "availability_#{dom_id(@document)}", src: availability_path(@document) %>
     </div>
+  </div>
   <% end %>
 <% end %>

--- a/app/views/catalog/email.html.erb
+++ b/app/views/catalog/email.html.erb
@@ -6,7 +6,5 @@
     </div>
   <% end %>
 
-  <% component.with_body do %>
-    <%= render 'email_form' %>
-  <% end %>
+  <%= render 'email_form' %>
 <% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,5 +1,5 @@
 <dialog id="blacklight-modal" class="modal" data-controller="modal" data-action="cancel->modal#fixupBackdrop">
-  <div class="modal-dialog modal-lg modal-dialog-centered">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
     <div class="modal-content">
     </div>
   </div>

--- a/spec/features/bound_with_availability_spec.rb
+++ b/spec/features/bound_with_availability_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Bound with availability', :js do
       visit solr_document_path('5488000')
       click_link 'Expand'
 
+      find('.modal-body').scroll_to(:center)
       within 'dialog' do
         expect(page).to have_text 'Bound and shelved with:'
         expect(page).to have_text 'Item is bound with other items'


### PR DESCRIPTION
Scrollable modal portion of https://github.com/sul-dlss/SearchWorks/issues/5953

This switches the order of the cite tools. @dbranchini suggested this as a way to stay within Bootstrap's default `modal-dialog-scrollable` behavior (The entire `modal-content` being scrollable). If we don't like how this looks, we definitely can implement the original design, it'll just take a bit more planning to work out the specific behaviors at smaller heights.

<img width="824" height="887" alt="Screenshot 2025-08-25 at 12 58 45 PM" src="https://github.com/user-attachments/assets/a8d6ca6a-ee01-4f0c-aa22-b117fbe112f7" />
<img width="825" height="653" alt="Screenshot 2025-08-25 at 1 00 53 PM" src="https://github.com/user-attachments/assets/ebd6c18a-9ddc-4b30-af69-8fac0e2a51ca" />
