### PR TITLE
Restore focus box shadow to availability accordion

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -299,7 +299,10 @@
     --bs-link-hover-color-rgb: var(--stanford-black-rgb);
     --bs-light-rgb: transparent;
     --bs-accordion-inner-border-radius: 0;
-    box-shadow: none;
+
+    &:not(:focus-visible) {
+      box-shadow: none;
+    }
 
     div {
       flex: 1;


### PR DESCRIPTION
After:
<img width="751" height="157" alt="Screenshot 2025-08-25 at 4 58 52 PM" src="https://github.com/user-attachments/assets/b0b21e79-f43d-4e29-bd88-ad9895cfc67d" />
