### PR TITLE
Remove copy citation toast

### DIFF
--- a/app/javascript/controllers/copy_text_controller.js
+++ b/app/javascript/controllers/copy_text_controller.js
@@ -4,10 +4,23 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ['text']
 
-  async copy() {
+  async copy(event) {
     try {
-        await navigator.clipboard.write([new ClipboardItem({ "text/html": this.textTarget.innerHTML, "text/plain": this.textTarget.innerText })])
-        window.dispatchEvent(new CustomEvent('show-toast', { detail: { html: '<i class="bi bi-check" aria-hidden="true"></i> Copied' } }));
+      await navigator.clipboard.write([new ClipboardItem({ "text/html": this.textTarget.innerHTML, "text/plain": this.textTarget.innerText })])
+      if (event.target.classList.contains('copied')) {
+        return
+      }
+
+      const originalCopyButtonText = event.target.innerHTML
+      event.target.classList.add('copied')
+      event.target.innerHTML = '<i class="bi bi-check" aria-hidden="true"></i>Copied'
+
+      setTimeout(() => {
+        if (event.target && event.target.isConnected) {
+          event.target.innerHTML = originalCopyButtonText
+          event.target.classList.remove('copied')
+        }
+      }, 8000)
     } catch (err) {
         console.error('Failed to copy text: ', err);
     }


### PR DESCRIPTION
Show the copied status in-place for the copy citation button for the citation modals.
<img width="263" height="139" alt="Screenshot 2025-08-26 at 1 53 39 PM" src="https://github.com/user-attachments/assets/dd3aa074-bf16-472d-ae36-5f08049993f6" />

Darcy voted for this when it looked like showing the toast above the dialog was hard. If somebody knows how to make that easy, we could do that 😄 