### PR TITLE
Restore thumbnails to the record summary component.

### DIFF
--- a/app/components/searchworks4/record_summary_component.html.erb
+++ b/app/components/searchworks4/record_summary_component.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-light p-4 border-top border-bottom record-summary">
   <div class="d-flex gap-3">
-    <%= presenter.thumbnail.render %>
+    <%= thumbnail %>
     <div>
       <div class="fw-semibold"><%= presenter.heading %></div>
       <div><%= resource_icon %> <%= presenter.document_format %> <%= presenter.main_title_date %></div>

--- a/app/components/searchworks4/record_summary_component.rb
+++ b/app/components/searchworks4/record_summary_component.rb
@@ -4,6 +4,8 @@ module Searchworks4
   class RecordSummaryComponent < ViewComponent::Base
     attr_reader :presenter
 
+    renders_one :thumbnail
+
     def initialize(presenter:)
       @presenter = presenter
       super()
@@ -21,6 +23,12 @@ module Searchworks4
 
     def resource_icon
       helpers.render_resource_icon(presenter.formats)
+    end
+
+    def default_thumbnail
+      return nil if presenter.document.eds? || presenter.document.managed_purls.many? || presenter.document.druid
+
+      Searchworks4::ThumbnailComponent.new(presenter: presenter, counter: nil, classes: %w[document-thumbnail float-end mt-1])
     end
   end
 end

--- a/spec/components/searchworks4/record_summary_component_spec.rb
+++ b/spec/components/searchworks4/record_summary_component_spec.rb
@@ -11,12 +11,20 @@ RSpec.describe Searchworks4::RecordSummaryComponent, type: :component do
   end
 
   context 'with no authors' do
-    let(:document) { SolrDocument.find('2') }
+    let(:document) { SolrDocument.from_fixture('2.yml') }
 
     it "renders the description" do
       expect(page).to have_content "Another object"
       expect(page).to have_css "ul"
       expect(page).to have_no_content "ul li"
+    end
+  end
+
+  context 'with a thumbnail' do
+    let(:document) { SolrDocument.from_fixture('in00000053236.yml') }
+
+    it "renders the thumbnail" do
+      expect(page).to have_css ".document-thumbnail"
     end
   end
 end


### PR DESCRIPTION
I think this was a regression introduced in [#5947](https://github.com/sul-dlss/SearchWorks/pull/5947) (Blacklight only uses the thumbnail component configuration in the document component, the thumbnail presenter doesn't do anything with it at all)