### PR TITLE
Allow citation urls to break; fixes #6074

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -390,3 +390,9 @@
   list-style-position: inside;
   padding-left: 0.25rem;
 }
+
+.citations {
+  a {
+    word-break: break-word;
+  }
+}

--- a/app/components/searchworks4/citations/citation_component.html.erb
+++ b/app/components/searchworks4/citations/citation_component.html.erb
@@ -62,13 +62,13 @@
   <% end %>
 
   <% citations.each do |style, citation| %>
-    <div class="mb-4 bg-light p-2" data-citation-format-target="tab" data-controller="copy-text" id="citation-format-<%= style %>" <%= 'hidden' unless style == default_style %>>
+    <div class="mb-4 bg-light p-2 citations" data-citation-format-target="tab" data-controller="copy-text" id="citation-format-<%= style %>" <%= 'hidden' unless style == default_style %>>
       <% unless unavailable? %>
         <h5><%= t("searchworks.citations.styles.#{style}") %> <button type="button" class="btn btn-outline-primary btn-sm lh-1 ms-4" data-action="copy-text#copy">Copy</button></h5>
       <% end %>
       <% Array(citation).each do |cite| %>
         <div class="mb-2" data-copy-text-target="text">
-          <%= cite %>
+          <%= helpers.auto_link cite %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
<img width="511" height="343" alt="Screenshot 2025-08-27 at 14 31 39" src="https://github.com/user-attachments/assets/cd91d53c-d994-4ac7-b506-239403110318" />
