### PR TITLE
Apply focus visible style to index title link parent

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -396,3 +396,17 @@
     word-break: break-word;
   }
 }
+
+/* Show component library focus-visible styles on the parent element when the title link is active */
+.index_title:has(a:not(.btn):focus-visible) {
+  outline: 2px solid white;
+  box-shadow: 0 0 0 4px var(--stanford-black);
+  border-radius: 0.375rem;
+  outline-offset: 1px;
+}
+
+/* Hide the component library focus-visible styles on the title link when we show it on the parent element */
+.index_title a:not(.btn):focus-visible {
+  outline: none;
+  box-shadow: none;
+}


### PR DESCRIPTION
Part of #5627

Avoid wrapping the title link's `focus-visible` style by styling the truncated parent instead. Our truncation classes were causing part of the issue with the default component library styles.

<img width="638" height="275" alt="Screenshot 2025-08-27 at 5 07 36 PM" src="https://github.com/user-attachments/assets/547207ed-735f-4b05-aa51-225be4a51e33" />
<img width="167" height="360" alt="Screenshot 2025-08-27 at 5 07 13 PM" src="https://github.com/user-attachments/assets/b834f024-4cf9-492a-b2d6-a0af9e5f29a1" />
<img width="621" height="315" alt="Screenshot 2025-08-28 at 8 29 13 AM" src="https://github.com/user-attachments/assets/c0dc3412-cb10-4480-8f8e-d37314829583" />
