### PR TITLE
Don't use the default text label for callnumbers to figure out if som…

### DIFF
--- a/app/components/searchworks4/physical_availability_component.rb
+++ b/app/components/searchworks4/physical_availability_component.rb
@@ -89,7 +89,7 @@ module Searchworks4
       end
 
       def stackmappable?
-        location.stackmapable? && location.items.first&.callnumber.present?
+        location.stackmapable? && location.items.first&.callnumber(default: nil).present?
       end
 
       def call

--- a/lib/holdings/item.rb
+++ b/lib/holdings/item.rb
@@ -70,8 +70,8 @@ class Holdings
       item_display[:lopped_callnumber]
     end
 
-    def callnumber
-      item_display[:callnumber].presence || '(no call number)'
+    def callnumber(default: '(no call number)')
+      item_display[:callnumber].presence || default
     end
 
     def full_shelfkey(default: MAX_SHELFKEY)

--- a/spec/components/searchworks4/availability_component_spec.rb
+++ b/spec/components/searchworks4/availability_component_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe Searchworks4::AvailabilityComponent, type: :component do
     end
   end
 
+  context 'with an item without a call number' do
+    let(:document) { SolrDocument.from_fixture("1391872.yml") }
+
+    before do
+      document[:item_display_struct][0].delete 'callnumber'
+    end
+
+    it 'renders the item without the stackmaps link' do
+      render_inline(described_class.new(document: document))
+
+      aggregate_failures do
+        expect(page).to have_no_link 'Stacks', href: "/view/1391872/GRE-STACKS/stackmap"
+        expect(page).to have_css('.callnumber', text: '(no call number)')
+      end
+    end
+  end
+
   context 'with multiple items all in Green Stacks' do
     let(:document) { SolrDocument.from_fixture("10678312.yml") }
 


### PR DESCRIPTION
…ething is stackmappable.


Fixes #5030 

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
