### PR TITLE
Update folio course facet item presenter

### DIFF
--- a/app/presenters/folio_course_facet_item_presenter.rb
+++ b/app/presenters/folio_course_facet_item_presenter.rb
@@ -3,7 +3,7 @@
 # The facet value here is a UUID for a folio course.  We overide to show a label that a user
 # can read.
 class FolioCourseFacetItemPresenter < Blacklight::FacetItemPresenter
-  def constraint_label
+  def label
     CourseReserve.find(value)&.course_number || value
   end
 end


### PR DESCRIPTION
Closes #6067 

Blacklight 9 removed `constraint_label` in favor of `label`.