### PR TITLE
Stop replacing date hyphens in catalog fields presenter

### DIFF
--- a/app/presenters/concerns/catalog_fields.rb
+++ b/app/presenters/concerns/catalog_fields.rb
@@ -12,8 +12,8 @@ module CatalogFields
 
     year = document.first('pub_year_ss')
 
-    if year.match?(/[u-]$/)
-      "#{year.gsub(/[u-]/, '0')}s"
+    if year.match?(/u$/)
+      "#{year.tr('u', '0')}s"
     else
       "(#{year})"
     end


### PR DESCRIPTION
Before:
<img width="391" height="136" alt="Screenshot 2025-09-09 at 12 13 45 PM" src="https://github.com/user-attachments/assets/182f2292-37d1-4770-80f5-2f068c837470" />

After:
<img width="382" height="130" alt="Screenshot 2025-09-09 at 12 15 20 PM" src="https://github.com/user-attachments/assets/f5964ed1-81be-402b-9fe0-ebcca18811f1" />
