### PR TITLE
Use the Articles+ option in search types spec

### DIFF
--- a/spec/features/blacklight_customizations/search_types_spec.rb
+++ b/spec/features/blacklight_customizations/search_types_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Search types" do
       end
     end
 
-    click_link 'Articles+'
+    choose 'Articles+'
 
     aggregate_failures('has article search types') do
       within('#search_field') do


### PR DESCRIPTION
`click_link` is hitting the link in the footer