### PR TITLE
passing along EzProxy as part of the links through the JSON API

### DIFF
--- a/app/models/json_results_document_presenter.rb
+++ b/app/models/json_results_document_presenter.rb
@@ -24,8 +24,7 @@ class JsonResultsDocumentPresenter
 
     links = online_links.map do |online_link|
       # Include EZProxy links where applicable
-      online_link.href = Searchworks4::LinkComponent.new(link: online_link, document: @source_document).href
-      online_link.as_json
+      online_link.as_json.merge(href: href(online_link))
     end
 
     { 'links' => links }
@@ -33,5 +32,13 @@ class JsonResultsDocumentPresenter
 
   def online_links
     source_document&.preferred_online_links || []
+  end
+
+  def href(online_link)
+    proxied_url(online_link) || online_link.href
+  end
+
+  def proxied_url(link)
+    Links::Ezproxy.new(link: link, document: @source_document).to_proxied_url
   end
 end

--- a/app/models/json_results_document_presenter.rb
+++ b/app/models/json_results_document_presenter.rb
@@ -22,7 +22,13 @@ class JsonResultsDocumentPresenter
   def fulltext_link_html
     return {} if online_links.blank?
 
-    { 'links' => online_links.map(&:as_json) }
+    links = online_links.map do |online_link| 
+      # Include EZProxy links where applicable
+      online_link.href = Searchworks4::LinkComponent.new(link: online_link, document: @source_document).href
+      online_link.as_json
+    end
+
+    { 'links' => links} 
   end
 
   def online_links

--- a/app/models/json_results_document_presenter.rb
+++ b/app/models/json_results_document_presenter.rb
@@ -22,13 +22,13 @@ class JsonResultsDocumentPresenter
   def fulltext_link_html
     return {} if online_links.blank?
 
-    links = online_links.map do |online_link| 
+    links = online_links.map do |online_link|
       # Include EZProxy links where applicable
       online_link.href = Searchworks4::LinkComponent.new(link: online_link, document: @source_document).href
       online_link.as_json
     end
 
-    { 'links' => links} 
+    { 'links' => links }
   end
 
   def online_links

--- a/spec/models/json_results_document_presenter_spec.rb
+++ b/spec/models/json_results_document_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe JsonResultsDocumentPresenter do
     context 'when the source document is available online to only Stanford users' do
       before do
         document_data['marc_links_struct'] = [{
-          "href": "https://example.com",
+          "href": "https://sciendo.com",
           "link_text": "The Link",
           "fulltext": true,
           "stanford_only": true
@@ -25,8 +25,8 @@ RSpec.describe JsonResultsDocumentPresenter do
 
       let(:json) { presenter.as_json.with_indifferent_access }
 
-      it 'includes the link wrapped in a span with a class to be styled by consumers' do
-        expect(json['links'].first).to include(href: 'https://example.com', link_text: 'The Link', stanford_only: true)
+      it 'includes the link wrapped in a span with a class to be styled by consumers and uses EzProxy for the link' do
+        expect(json['links'].first).to include(href: 'https://stanford.idm.oclc.org/login?qurl=https%3A%2F%2Fsciendo.com', link_text: 'The Link', stanford_only: true)
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/sul-dlss/sul-bento-app/issues/968 (or should - once the links are passed on through the JSON API request that bento uses)