### PR TITLE
Update home page and masthead search styles at XS size

### DIFF
--- a/app/assets/stylesheets/searchworks4/homepage.css
+++ b/app/assets/stylesheets/searchworks4/homepage.css
@@ -5,21 +5,28 @@
   --banner-image: url(/searchworks4/research-papers-reading-v1.webp);
 }
 .search-area-image-bg {
-  &::before {
-    content: "";
-    position: absolute;
-    opacity: 80%;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-image: var(--banner-image);
-    z-index: -1;
+  .container {
+    --bs-gutter-x: 0;
   }
 
-  position: relative;
-  height: 350px;
-  padding-block: 80px;
+  @media (min-width: 576px) {
+    --bs-gutter-x: 1.5rem;
+    &::before {
+      content: "";
+      position: absolute;
+      opacity: 80%;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-image: var(--banner-image);
+      z-index: -1;
+    }
+
+    position: relative;
+    height: 350px;
+    padding-block: 80px;
+  }
 
   .search-card {
     background-color: white;

--- a/app/assets/stylesheets/searchworks4/search.css
+++ b/app/assets/stylesheets/searchworks4/search.css
@@ -33,15 +33,23 @@
   }
 
   .search-field {
+    display: none;
     width: 7rem;
     --bs-border-width: 0;
     margin-right: 1px;
+
+    @media (min-width: 576px) {
+      display: block;
+    }
   }
 
   .search-q {
     border: 1px solid transparent;
-    border-inline-start: var(--search-q-border);
+    border-inline-start: none;
     outline: none;
+    @media (min-width: 576px) {
+      border-inline-start: var(--search-q-border);
+    }
   }
 }
 

--- a/app/components/homepage_search_component.html.erb
+++ b/app/components/homepage_search_component.html.erb
@@ -1,7 +1,7 @@
 <search class="search-card d-flex position-relative flex-column px-4 py-3 rounded" data-controller="home-page-search">
   <div class="mb-3">
     <span class="fw-bold">Search mode:</span>
-    <div class="form-check form-check-inline mx-3">
+    <div class="form-check form-check-inline ms-3 me-2">
       <input class="form-check-input" type="radio" name="search-type" id="searchTypeCatalog" value="catalog" <%= 'checked' if current_page?(root_path) %> data-action="home-page-search#toggle" data-url="<%= root_path %>">
       <label class="form-check-label" for="searchTypeCatalog">Catalog</label>
     </div>


### PR DESCRIPTION
Closes #6110 

<img width="483" height="243" alt="Screenshot 2025-09-12 at 9 50 40 AM" src="https://github.com/user-attachments/assets/b89bec8b-9064-4578-8558-5ba6849b79bf" />
<img width="355" height="394" alt="Screenshot 2025-09-12 at 9 50 07 AM" src="https://github.com/user-attachments/assets/6972a3ca-5e76-4fb4-987a-ce76ab13b527" />
