### PR TITLE
Hide the date facet chart for a blank search

### DIFF
--- a/app/assets/stylesheets/searchworks4/facets.css
+++ b/app/assets/stylesheets/searchworks4/facets.css
@@ -166,3 +166,7 @@ label[for="facet_option_stanford_only"] > a {
     display: none;
   }
 }
+
+.blacklight-catalog:not(:has(.constraints .constraint)) #facet-pub_year_tisim .chart-wrapper {
+  display: none !important; /* important needed to override the inline style that chartjs inserts */
+}

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -81,4 +81,31 @@ RSpec.describe 'Facets' do
       end
     end
   end
+
+  context 'Range facet', :js do
+    context 'has no selection' do
+      it 'does not show the distribution range chart' do
+        visit search_catalog_path(q: '', search_field: 'search')
+
+        click_button 'Show all filters'
+        click_button 'Date'
+
+        within('#facet-pub_year_tisim') do
+          expect(page).to have_field('range[pub_year_tisim][begin]')
+          expect(page).to have_field('range[pub_year_tisim][end]')
+          expect(page).to have_no_css('.chart-wrapper')
+        end
+      end
+    end
+
+    context 'has a selection' do
+      it 'shows the distribution range chart' do
+        visit search_catalog_path(range: { pub_year_tisim: { begin: '1999', end: '2025' } })
+
+        within('#facet-pub_year_tisim') do
+          expect(page).to have_css('.chart-wrapper')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #6048 

<img width="365" height="261" alt="Screenshot 2025-09-12 at 11 30 42 AM" src="https://github.com/user-attachments/assets/9fb3ec1c-48a3-4f87-881e-2435c1b57f04" />
<img width="366" height="449" alt="Screenshot 2025-09-12 at 11 30 25 AM" src="https://github.com/user-attachments/assets/d4fca66b-ac05-4f3c-8829-39c13dc70c00" />
