### PR TITLE
Style error pages for smaller screens

### DIFF
--- a/app/components/status/error_page_component.html.erb
+++ b/app/components/status/error_page_component.html.erb
@@ -1,9 +1,9 @@
-<div class="d-flex justify-content-center align-items-center" style="padding: 80px;">
-  <div style="font-size: 160px; font-weight: 800; line-height: 100%; letter-spacing: 0%; color: var(--stanford-10-black)">
+<div class="d-flex justify-content-center align-items-center p-4 p-md-5">
+  <div class="d-none d-md-block" style="font-size: 160px; font-weight: 800; line-height: 100%; letter-spacing: 0%; color: var(--stanford-10-black)">
     <%= code %>
   </div>
-  <div class="ms-4 fw-600 mt-4">
-    <h2 class="h3"><%= header %> (<%= code %>)</h2>
+  <div class="ms-md-4 fw-600 mt-4">
+    <h2 class="h3 mb-4"><%= header %> (<%= code %>)</h2>
     <%= message %>
   </div>
 </div>


### PR DESCRIPTION
Closes #5424 
<img width="1025" height="388" alt="Screenshot 2025-09-12 at 4 05 56 PM" src="https://github.com/user-attachments/assets/7f409d8d-d850-4bce-8704-68fc6d88393e" />
<img width="406" height="419" alt="Screenshot 2025-09-12 at 4 05 44 PM" src="https://github.com/user-attachments/assets/9a1081be-9e1b-42ea-820d-3ab082b02694" />
