### PR TITLE
handle ASCII characters in abstract

### DIFF
--- a/app/components/record/mods_document_component.html.erb
+++ b/app/components/record/mods_document_component.html.erb
@@ -90,7 +90,7 @@
     <%= render Searchworks4::DocumentSectionLayout.new(title: 'Abstract/Contents', dl_classes: 'dl-horizontal dl-text') do %>
       <% document.mods.abstract.each do |abstract| %>
         <div class="my-2">
-          <%= truncated_mods_record_field(abstract, value_transformer: ->(v) { tag.div v, data: { 'long-text-target' => 'text' } } ) %>
+          <%= truncated_mods_record_field(abstract, value_transformer: ->(v) { tag.div CGI.unescapeHTML(v), data: { 'long-text-target' => 'text' } } ) %>
         </div>
       <% end %>
 

--- a/spec/components/record/mods_document_component_spec.rb
+++ b/spec/components/record/mods_document_component_spec.rb
@@ -136,4 +136,13 @@ RSpec.describe Record::ModsDocumentComponent, type: :component do
       expect(page).to have_css("dd", text: "amazing")
     end
   end
+
+  describe 'when the abstract has ASCII characters' do
+    let(:document) { SolrDocument.new(modsxml: mods_ascii_abstract) }
+
+    it "translates or removes ASCII character encodings" do
+      expect(page).to_not have_content("&#13;")
+      expect(page).to have_css("dd", text: "This work was finished by January 2025.\n\nThis record is about this work.")
+    end
+  end
 end

--- a/spec/fixtures/mods_records/mods_fixtures.rb
+++ b/spec/fixtures/mods_records/mods_fixtures.rb
@@ -150,4 +150,16 @@ module ModsFixtures
       </mods>
     xml
   end
+
+  def mods_ascii_abstract
+    <<-xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+      <titleInfo>
+        <title>A record with ascii in abstract</title>
+      </titleInfo>
+      <abstract>This work was finished by January 2025.&#13;\n&#13;\nThis record is about this work.</abstract>
+    </mods>
+  xml
+  end
 end


### PR DESCRIPTION
Closes #6153 .

What this PR does:
Unescapes ASCII characters like $#13; (which is carriage return). 
The mods display gem has additional handling around dealing with HTML encoding, and the unescape method is called before the text is passed on to the Mods Display component(see https://github.com/sul-dlss/mods_display/blob/main/app/helpers/mods_display/record_helper.rb#L103 ). 



