### PR TITLE
Move the finding aid link into the document header.

### DIFF
--- a/app/components/access_panels/additional_info_component.html.erb
+++ b/app/components/access_panels/additional_info_component.html.erb
@@ -1,9 +1,3 @@
-<% if document.marc_links.finding_aid.present? %>
-    <div class='access-panel-subsection flex-wrap flex-xl-nowrap d-flex row-gap-0 gap-3 align-items-baseline mt-3'>
-      <h4 class="fs-15 text-nowrap text-uppercase text-secondary mb-0">Finding aid</h4>
-      <%= render Searchworks4::LinkComponent.new(link: document.preferred_finding_aid, document: document) %>
-    </div>
-<% end %>
 <% if library.library_instructions.present? %>
   <div class='access-panel-subsection alert alert-warning border-0 d-flex align-items-center mt-3 mb-0'>
     <div class="bi bi-exclamation-circle-fill fs-5 me-3"></div>

--- a/app/components/record/marc_document_component.html.erb
+++ b/app/components/record/marc_document_component.html.erb
@@ -12,6 +12,15 @@
         <% if presenter.document_format.present? && document.marc_field('3003abcefg').values.any? %>&mdash;<% end %> <%= safe_join(document.marc_field('3003abcefg').values, ' ').presence %>
       </div>
 
+      <% if document.marc_links.finding_aid.present? %>
+        <dl class="mt-4">
+          <div class="d-flex justify-content-start gap-3">
+            <dt>Finding aid</dt>
+            <dd><%= render Searchworks4::LinkComponent.new(link: document.preferred_finding_aid, document: document) %></dd>
+          </div>
+        </dl>
+      <% end %>
+
       <div class='mt-3'>
         <%= render Record::MarcContentAdviceComponent.new(document: document) %>
       </div>

--- a/spec/components/access_panels/at_the_library_component_spec.rb
+++ b/spec/components/access_panels/at_the_library_component_spec.rb
@@ -376,24 +376,6 @@ RSpec.describe AccessPanels::AtTheLibraryComponent, type: :component do
     end
   end
 
-  describe 'finding aid' do
-    before do
-      document = SolrDocument.new(
-        id: '123',
-        item_display_struct: [
-          { barcode: '123', library: 'SPEC-COLL', effective_permanent_location_code: 'STACKS', callnumber: 'ABC' }
-        ],
-        marc_links_struct: [{ href: "http://oac.cdlib.org/findaid/ark:/something-else", note: 'something something Finding aid' }]
-      )
-      render_inline(described_class.new(document:))
-    end
-
-    it 'displays finding aid sections with link' do
-      expect(page).to have_css('h4', text: 'Finding aid')
-      expect(page).to have_css('a', text: 'Online Archive of California')
-    end
-  end
-
   describe 'special instructions' do
     before do
       document = SolrDocument.new(

--- a/spec/components/record/marc_document_component_spec.rb
+++ b/spec/components/record/marc_document_component_spec.rb
@@ -89,10 +89,13 @@ RSpec.describe Record::MarcDocumentComponent, type: :component do
 
   describe "Metadata sections all available" do
     let(:document) do
-      SolrDocument.new(marc_json_struct: marc_sections_fixture, author_struct: [{ creator: [{ link: '...', search: '...' }] }], marc_links_struct: [{ material_type: 'finding aid' }])
+      SolrDocument.new(marc_json_struct: marc_sections_fixture, author_struct: [{ creator: [{ link: '...', search: '...' }] }],
+                       marc_links_struct: [{ href: "http://oac.cdlib.org/findaid/ark:/something-else", material_type: 'finding aid' }])
     end
 
     it "displays correct sections" do
+      expect(page).to have_css('dt', text: 'Finding aid')
+      expect(page).to have_link(href: 'http://oac.cdlib.org/findaid/ark:/something-else')
       expect(page).to have_css('h2', text: "Contributors")
       expect(page).to have_css('h2', text: "Bibliographic information")
     end


### PR DESCRIPTION
Part of #5998 

<img width="627" height="397" alt="Screenshot 2025-09-22 at 09 50 03" src="https://github.com/user-attachments/assets/dbbc7b6c-ba4e-4f7d-a23e-eab4e130bde1" />
