### PR TITLE
update fulltext html to match figma

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -377,7 +377,7 @@
 }
 
 .blacklight-articles-fulltext_html {
-  #topnav .navbar-nav { display: none; }
+  #topnav .navbar { display: none; }
   .access-panel-heading {
     display: none;
   }

--- a/app/views/articles/fulltext_html.html.erb
+++ b/app/views/articles/fulltext_html.html.erb
@@ -2,10 +2,14 @@
 
 <% content_for(:search_navbar) { tag.div(class: 'd-none') } %>
 
-<div class="text-end col-xl-9">
-  <%= render AccessPanels::OnlineEdsComponent.new(document: @document) %>
-</div>
+<div class="d-flex justify-content-center align-items-center">
+  <div class="col-md col-xxl-8">
+    <div class="text-end">
+      <%= render AccessPanels::OnlineEdsComponent.new(document: @document) %>
+    </div>
 
-<div class='eds-full-text-section col-xl-9'>
-  <%= sanitize @document.eds_html_fulltext, scrubber: Eds::HtmlScrubber.new %>
+    <div class='eds-full-text-section'>  
+      <%= sanitize @document.eds_html_fulltext, scrubber: Eds::HtmlScrubber.new %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
closes #6103 
<img width="1400" height="791" alt="Screenshot 2025-09-22 at 4 00 36 PM" src="https://github.com/user-attachments/assets/668467c2-5210-47bf-8623-54fafb4422fa" />

Hide whitespace will make this easier to review.
