### PR TITLE
Add collection superheads to the collection masthead and collection record view

### DIFF
--- a/app/components/record/document_layout_component.html.erb
+++ b/app/components/record/document_layout_component.html.erb
@@ -8,6 +8,7 @@
       itemtype: document.itemtype do %>
   <div class="document-main-section">
     <%= thumbnail %>
+    <%= render Searchworks4::CollectionSuperhead.new if document.is_a_collection? || document.has_finding_aid? %>
 
     <h1 class="document-title">
       <span itemprop="name"><%= title %></span>

--- a/app/components/searchworks4/collection_superhead.rb
+++ b/app/components/searchworks4/collection_superhead.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Searchworks4
+  class CollectionSuperhead < ViewComponent::Base
+    def call
+      tag.div 'Collection', class: 'superhead small fw-semibold text-uppercase text-secondary mb-2'
+    end
+  end
+end

--- a/app/components/searchworks4/search_result/collection_info_component.html.erb
+++ b/app/components/searchworks4/search_result/collection_info_component.html.erb
@@ -1,4 +1,6 @@
 <div class="p-4 mb-3 bg-fog-light collection-info">
+  <%= render Searchworks4::CollectionSuperhead.new %>
+
   <div class="d-flex justify-content-between gap-3">
     <h1 class="h2 mb-0"><%= collection[:title_display] %></h1>
     <%= link_to solr_document_path(collection[:id]), class: "align-self-baseline text-nowrap btn btn-icon btn-outline-primary" do %>

--- a/app/components/searchworks4/search_result/collection_info_component.rb
+++ b/app/components/searchworks4/search_result/collection_info_component.rb
@@ -11,7 +11,7 @@ module Searchworks4
       attr_reader :collection
 
       def render?
-        helpers.page_location.collection? && collection.present?
+        collection.present?
       end
 
       def presenter

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -26,7 +26,7 @@
 
 <h1 class="visually-hidden">Search Results</h1>
 
-<%= render Searchworks4::SearchResult::CollectionInfoComponent.new(collection: @parent) %>
+<%= render Searchworks4::SearchResult::CollectionInfoComponent.new(collection: @parent) if page_location.collection? %>
 <%= render Searchworks4::SearchResult::BookplateFundComponent.new(bookplate: bookplate_from_document_list) %>
 
 <% if has_search_parameters? && !hide_constraints %>

--- a/spec/components/searchworks4/search_result/collection_info_component_spec.rb
+++ b/spec/components/searchworks4/search_result/collection_info_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Searchworks4::SearchResult::CollectionInfoComponent, type: :component do
+  before do
+    render_inline(described_class.new(collection:))
+  end
+
+  let(:collection) { SolrDocument.from_fixture('11966809.yml') }
+
+  it "renders the collection information" do
+    expect(page).to have_css '.superhead', text: 'Collection'
+    expect(page).to have_text 'SFO Travel Ban Protest poster collection'
+    expect(page).to have_link 'Collection details', href: "/view/#{collection.id}"
+  end
+end


### PR DESCRIPTION
Part of #5998

<img width="529" height="247" alt="Screenshot 2025-09-23 at 11 50 11" src="https://github.com/user-attachments/assets/201f7fe9-d952-4231-8d09-eb5f292c833e" />

<img width="339" height="309" alt="Screenshot 2025-09-23 at 11 50 26" src="https://github.com/user-attachments/assets/78d4fd86-98f2-461a-b729-a52af7a35120" />
