### PR TITLE
Add some turnstile around availability lookups.

### DIFF
--- a/app/components/access_panels/at_the_library_component.html.erb
+++ b/app/components/access_panels/at_the_library_component.html.erb
@@ -4,5 +4,5 @@
   <% end %>
   <%= render AccessPanels::GroupedLibraryComponent.new(label: 'Off-campus collections', libraries: document.holdings.sal_libraries , document:) %>
 
-  <%= helpers.turbo_frame_tag "availability_#{dom_id(document)}", src: availability_path(document) %>
+  <%= helpers.availability_turbo_frame(document) %>
 </div>

--- a/app/components/main_container_component.html.erb
+++ b/app/components/main_container_component.html.erb
@@ -1,4 +1,4 @@
-<div class="container-lg flex-1 mb-auto" data-controller="google-cover-image">
+<div class="container-lg flex-1 mb-auto" data-controller="google-cover-image inline-turnstile" data-inline-turnstile-site-key-value="<%= Settings.turnstile.site_key %>" data-inline-turnstile-challenge-path-value="<%= bot_detect_challenge_path %>">
   <%= render 'shared/modal' %>
   <main id="main-container" class="mb-5">
 
@@ -7,6 +7,7 @@
       <% FLASH_TYPES_WITH_LEVEL.each do |type, alert_level| %>
         <%= render AlertComponent.new(level: alert_level, message: flash[type].html_safe) if flash[type] %>
       <% end %>
+      <div data-inline-turnstile-target="challenge"></div>
     </div>
 
     <%= content %>

--- a/app/components/searchworks4/physical_availability_component.html.erb
+++ b/app/components/searchworks4/physical_availability_component.html.erb
@@ -16,7 +16,7 @@
       </span>
     </span>
   <% end %>
-  <%= helpers.turbo_frame_tag "availability_#{dom_id(document)}", src: availability_path(document), loading: 'lazy', data: { 'eager-lazy-target': 'frame' } %>
+  <%= helpers.availability_turbo_frame document, loading: 'lazy', data: { 'eager-lazy-target': 'frame' } %>
 <% elsif truncated_display_with_finding_aid? %>
   <%# Instances with a single item collapse the item information %>
   <%= container_tag(classes: %w[border rounded d-inline-flex suppress-item-level-request-button-if-there-is-a-location-level-request-button]) do %>
@@ -97,7 +97,7 @@
           </tbody>
         </table>
       </div>
-      <%= helpers.turbo_frame_tag "availability_#{dom_id(document)}", src: availability_path(document), loading: 'lazy' %>
+      <%= helpers.availability_turbo_frame document, loading: 'lazy' %>
     </div>
   <% end %>
 <% else %>
@@ -167,7 +167,7 @@
           <% end %>
         </div>
       <% end %>
-      <%= helpers.turbo_frame_tag "availability_#{dom_id(document)}", src: availability_path(document), loading: 'lazy' %>
+      <%= helpers.availability_turbo_frame document, loading: 'lazy' %>
     </div>
   <% end %>
 <% end %>

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -6,6 +6,16 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
+  def availability_turbo_frame(document, **attr)
+    immediate = turnstile_ok?
+
+    url = availability_path(document)
+
+    tag.div(data: { 'inline-turnstile-target': ('frame' unless immediate) }) do
+      turbo_frame_tag "availability_#{dom_id(document)}", src: immediate ? url : Base64.encode64(url), disabled: !immediate, **attr
+    end
+  end
+
   # override upstream so we don't check the session for the last view type.
   def document_index_view_type(query_params = params || {})
     view_param = query_params[:view]

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -91,6 +91,9 @@ application.register("google-cover-image", GoogleCoverImageController)
 import HomePageSearchController from "./home_page_search_controller"
 application.register("home-page-search", HomePageSearchController)
 
+import InlineTurnstileController from "./inline_turnstile_controller"
+application.register("inline-turnstile", InlineTurnstileController)
+
 import LibraryH3lpController from "./library_h3lp_controller"
 application.register("library-h3lp", LibraryH3lpController)
 

--- a/app/javascript/controllers/inline_turnstile_controller.js
+++ b/app/javascript/controllers/inline_turnstile_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["challenge", "frame"]
+  static values = { challengePath: String, siteKey: String, status: Boolean }
+
+  frameTargetConnected(element) {
+    if (this.statusValue) {
+      this.convertFrame(element.querySelector('turbo-frame'))
+    } else {
+      this.connectChallenge()
+    }
+  }
+  
+  statusValueChanged() {
+    if (!this.statusValue) return;
+
+    this.frameTargets.forEach((element) => {
+      this.convertFrame(element.querySelector('turbo-frame'))
+    });
+  }
+  
+  convertFrame(frame) {
+    frame.src = atob(frame.src)
+    frame.removeAttribute('disabled')
+  }
+
+  connectChallenge() {
+    if (this.statusValue || !this.hasChallengeTarget || this.challengeTarget.childElementCount > 0) return;
+
+    turnstile.render(this.challengeTarget, {
+      sitekey: this.siteKeyValue,
+      callback: (token) => this.handleChallengeResponse(token),
+      'before-interactive-callback': () => {
+        this.challengeTarget.classList.add('alert', 'alert-info', 'alert-dismissible', 'shadow-sm', 'mt-4', 'mb-0');
+        if (!this.challengeTarget.querySelector('i.bi.bi-info-circle-fill')) {
+          const msg = document.createElement('div');
+          msg.innerText = "For real-time availability, please verify below.";
+          msg.classList.add('text-body', 'mb-2');
+          this.challengeTarget.prepend(msg)
+          const icon = document.createElement('i');
+          icon.classList.add('bi', 'bi-info-circle-fill', 'fs-3', 'me-3', 'mt-4', 'float-start');
+          this.challengeTarget.prepend(icon);
+        }
+      },
+      appearance: 'interaction-only'
+    });
+  }
+
+  async handleChallengeResponse(token) {
+    const csrfToken = document.querySelector("[name='csrf-token']");
+
+    const response = await fetch(this.challengePathValue, {
+      method: 'POST',
+      headers: {
+        "X-CSRF-Token": csrfToken?.content,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ cf_turnstile_response: token }),
+    });
+
+    const result = await response.json();
+    if (result["success"] == true) {
+      turnstile.remove();
+      this.challengeTarget.className = '';
+      this.challengeTarget.innerHTML = '';
+      this.statusValue = true;
+    }
+  }
+}

--- a/app/javascript/controllers/inline_turnstile_controller.js
+++ b/app/javascript/controllers/inline_turnstile_controller.js
@@ -4,6 +4,10 @@ export default class extends Controller {
   static targets = ["challenge", "frame"]
   static values = { challengePath: String, siteKey: String, status: Boolean }
 
+  connect() {
+    turnstile.implicitRender();
+  }
+
   frameTargetConnected(element) {
     if (this.statusValue) {
       this.convertFrame(element.querySelector('turbo-frame'))

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -95,6 +95,8 @@
         </div>
       </div>
 
+      <div data-inline-turnstile-target="challenge"></div>
+
       <% # container for all documents in index list view -%>
       <div id="documents" class="documents-<%= document_index_view_type %>">
         <%= render view_config.document_component.with_collection(@response.documents.map { |document| document_presenter(document) }, counter_offset: document_counter_with_offset(-1)) %>

--- a/app/views/catalog/availability_modal.html.erb
+++ b/app/views/catalog/availability_modal.html.erb
@@ -16,7 +16,7 @@
       <%= render Searchworks4::OnlineAccordionComponent.new(document: @document, toggled_library: params[:library]) %>
       <%= render Searchworks4::AvailabilityAccordionComponent.with_collection(@document.holdings.non_sal_libraries, document: @document, toggled_library: params[:library])%>
       <%= render Searchworks4::AvailabilityAccordionComponent.new(library: @document.holdings.sal_libraries.first, document: @document, toggled_library: params[:library], libraries: @document.holdings.sal_libraries) %>
-      <%= turbo_frame_tag "availability_#{dom_id(@document)}", src: availability_path(@document) %>
+      <%= availability_turbo_frame @document %>
     </div>
   </div>
   <% end %>

--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -25,6 +25,10 @@
     <%= stylesheet_link_tag "print", media: "print", 'data-turbo-track' => true %>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+      defer
+    ></script>
     <%= javascript_include_tag "searchworks4", "data-turbo-track": "reload", defer: true %>
     <script src="//js.honeybadger.io/v6.11/honeybadger.min.js" type="text/javascript"></script>
     <script type="text/javascript">


### PR DESCRIPTION
without being disruptive and requiring a full page reload, prompt for turnstile before loading the availability turbo-frames.

<img width="934" height="345" alt="Screenshot 2025-10-03 at 13 48 48" src="https://github.com/user-attachments/assets/0c34bc4b-8bee-4a57-b30e-f528f55d4fd1" />
