### PR TITLE
Remove unnecessary clause params from the default search field; 

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -293,7 +293,6 @@ class CatalogController < ApplicationController
         pf2: '${pf2_cjk}',
         pf3: '${pf3_cjk}'
       }
-      field.clause_params = { edismax: { mm: 0, 'q.op': 'OR' } }
     end
 
     config.add_search_field('search_title') do |field|


### PR DESCRIPTION
#6226 went in a different direction.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
