### PR TITLE
Conditionally render authors list in summary component

### DIFF
--- a/app/components/searchworks4/record_summary_component.html.erb
+++ b/app/components/searchworks4/record_summary_component.html.erb
@@ -4,11 +4,13 @@
     <div>
       <div class="fw-semibold"><%= presenter.heading %></div>
       <div><%= resource_icon %> <%= presenter.document_format %> <%= presenter.main_title_date %></div>
-      <ul class="list-unstyled mb-1">
-        <% authors.each do |author| %>
-          <li><%= author %></li>
-        <% end %>
-      </ul>
+      <% if authors.any? %>
+        <ul class="list-unstyled mb-1">
+          <% authors.each do |author| %>
+            <li><%= author %></li>
+          <% end %>
+        </ul>
+      <% end %>
       <%= render Searchworks4::QuickReportComponent.new if render_quick_report?%>
     </div>
   </div>

--- a/spec/components/searchworks4/record_summary_component_spec.rb
+++ b/spec/components/searchworks4/record_summary_component_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Searchworks4::RecordSummaryComponent, type: :component do
   end
 
   context 'with no authors' do
-    let(:document) { SolrDocument.from_fixture('2.yml') }
+    let(:document) { SolrDocument.from_fixture('5488000.yml') }
 
     it "renders the description" do
-      expect(page).to have_content "Another object"
+      expect(page).to have_content "The gases of swamp rice soils"
       expect(page).to have_css "ul"
       expect(page).to have_no_content "ul li"
     end


### PR DESCRIPTION
SiteImprove isn't happy with an empty `<ul>`.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
