### PR TITLE
Fix label target from 'email' to 'to' in feedback form

### DIFF
--- a/app/components/feedback/feedback_form_fields_component.html.erb
+++ b/app/components/feedback/feedback_form_fields_component.html.erb
@@ -31,7 +31,7 @@
             </div>
         </div>
         <div class="mb-3 row">
-            <%= @form.label :email, 'Email', class: 'col-form-label required fw-bold' %>
+            <%= @form.label :to, 'Email', class: 'col-form-label required fw-bold' %>
             <div>
                 <%= @form.email_field :to, value: "", class:"form-control", autocomplete: "email", required: true %>
             </div>


### PR DESCRIPTION
<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
