### PR TITLE
Continue to use the upstream adv search query builder and just overri…

### DIFF
--- a/app/models/concerns/searchworks/advanced_search_builder.rb
+++ b/app/models/concerns/searchworks/advanced_search_builder.rb
@@ -1,25 +1,42 @@
 # frozen_string_literal: true
 
 module Searchworks
-  # Override blacklight (+ blacklight_advanced_search) to support our custom advanced search form.
+  # Override blacklight_advanced_search to support our custom advanced search form.
   module AdvancedSearchBuilder
-    # Transform "clause" parameters into the Solr JSON Query DSL
-    def add_adv_search_clauses(solr_parameters)
-      search_state.clause_params&.each_value do |clause|
-        next if clause[:query].blank?
+    # Override the upstream query parser to inject the any/all logic
+    class SearchworksAdvancedSearchQueryParser < BlacklightAdvancedSearch::QueryParser
+      def process_query(config)
+        queries = keyword_queries.map do |clause|
+          field = clause[:field]
+          query = clause[:query]
 
-        field = (blacklight_config.search_fields || {})[clause[:field]] if clause[:field]
+          local_params = local_param_hash(field, config)
 
-        field_params = field.solr_parameters || {}
-        field_params = field_params.merge(field.cjk_solr_parameters) if cjk_unigrams_size(clause[:query]).positive? && field&.cjk_solr_parameters
-        field_params = field_params.merge('q.op': 'OR', mm: 0) if clause[:type] == 'any'
+          if clause[:type] == 'any'
+            local_params[:'q.op'] = 'OR'
+            local_params[:mm] = 0
+          end
 
-        query = {
-          edismax: field_params.merge(query: clause[:query])
-        }
-
-        solr_parameters.append_boolean_query(:must, query)
+          ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser]).to_query(local_params)
+        end
+        queries.join(" #{keyword_op} ")
       end
+    end
+
+    # Override the upstream adv. search implementation to use our own query parser
+    def add_adv_search_clauses(solr_parameters)
+      return unless is_advanced_search?
+
+      # If we've got the hint that we're doing an 'advanced' search, then
+      # map that to solr #q, over-riding whatever some other logic may have set, yeah.
+      advanced_query = SearchworksAdvancedSearchQueryParser.new(search_state, blacklight_config)
+      BlacklightAdvancedSearch.deep_merge!(solr_parameters, advanced_query.to_solr)
+      return if advanced_query.keyword_queries.empty?
+
+      # force :qt if set, fine if it's nil, we'll use whatever CatalogController
+      # ordinarily uses.
+      solr_parameters[:qt] = blacklight_config.advanced_search[:qt]
+      solr_parameters[:defType] = "lucene"
     end
   end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -103,19 +103,4 @@ RSpec.describe SearchBuilder do
       end
     end
   end
-
-  describe 'advanced search' do
-    let(:blacklight_params) do
-      { clause: { "0" => { "field" => "search", "type" => "all", "query" => "art tea" }, "1" => { "field" => "search_title", "type" => "any", "query" => "bread roses" } } }
-    end
-
-    it 'builds the correct solr query' do
-      search_builder.add_adv_search_clauses(solr_params)
-
-      expect(solr_params.dig('json', 'query', 'bool', 'must')).to be_present.and(include(
-                                                                                   { edismax: hash_including(query: 'art tea') },
-                                                                                   { edismax: hash_including(query: 'bread roses', 'q.op': 'OR', mm: 0, qf: "${qf_title}") }
-                                                                                 ))
-    end
-  end
 end


### PR DESCRIPTION
…de lots of upstream code to inject the any/all toggle in the right place.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
