### PR TITLE
Pin Solr to 9.9.0

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -5,3 +5,4 @@ collection:
 port: 8983
 env:
   SOLR_OPTS: '-Dsolr.config.lib.enabled=true'
+version: 9.9.0


### PR DESCRIPTION
```
solr-9.10.0.tgz: |=============================================================|

solr-9.10.0.tgz.sha512: |======================================================|
rake aborted!
Failed to execute solr create: Option '-p','--port': Deprecated for removal since 9.7: Use --solr-url instead
```