### PR TITLE
Change list style of contents to outside

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -397,7 +397,7 @@
 }
 
 .toc {
-  list-style-position: inside;
+  list-style-position: outside;
   padding-left: 0.25rem;
 }
 


### PR DESCRIPTION
Closes #6266 

Before:
<img width="622" height="173" alt="Screenshot 2025-11-12 at 12 50 10 PM" src="https://github.com/user-attachments/assets/47dff133-65d5-4738-bd51-d47721869b7c" />

After:
<img width="625" height="177" alt="Screenshot 2025-11-12 at 12 50 25 PM" src="https://github.com/user-attachments/assets/bc1ededc-f004-404e-a6c2-253c7253de1d" />
