### PR TITLE
Disable image processing to avoid warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,6 @@ module SearchWorks
 
     config.view_component.preview_controller = "ViewComponentPreviewController"
     config.lookbook.preview_controller = "ViewComponentPreviewController"
+    config.active_storage.variant_processor = :disabled
   end
 end


### PR DESCRIPTION
The warning states:
Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
