### PR TITLE
Add semantic classes for browse nearby call number elements

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -208,24 +208,25 @@
   }
 
   .heading,
-  .tabs {
+  .callnumber-tabs {
     .btn {
       --bs-btn-font-size: 0.875rem;
       --bs-btn-padding-y: 0.0625rem;
     }
   }
 
-  li .btn {
+  .callnumber-btn {
     border-color: var(--stanford-60-black);
     color: var(--stanford-black);
+
     &::before {
       padding-right: 0.25rem;
     }
-  }
 
-  li .btn.active {
-    background-color: var(--stanford-10-black);
-    font-weight: 600;
+    &.active  {
+      background-color: var(--stanford-10-black);
+      font-weight: 600;
+    }
   }
 
   .heading {

--- a/app/components/record/item/marc/callnumber_browse_component.html.erb
+++ b/app/components/record/item/marc/callnumber_browse_component.html.erb
@@ -4,7 +4,7 @@
     <h2 class="m-0 pe-3">Related items</h2>
     <%= link_to "Full page", full_page_path(spines.first.base_callnumber), class: 'btn btn-primary bi bi-arrows-angle-expand fw-normal', data: { 'browse-nearby-target': "fullPage", action: "click->analytics#trackLink" } %>
   </div>
-  <div class="row mt-4 ps-2 tabs" data-browse-nearby-target="tabs">
+  <div class="row mt-4 ps-2 tabs callnumber-tabs" data-browse-nearby-target="tabs">
     <div class="col mb-3">
       Start at call number:
       <ul class="list-inline d-inline ms-2" role="tablist">

--- a/app/components/record/item/marc/callnumber_browse_component.rb
+++ b/app/components/record/item/marc/callnumber_browse_component.rb
@@ -22,7 +22,7 @@ module Record
         def link_to_callnumber_browse(spine, index = 0)
           button_tag(
             spine.base_callnumber,
-            class: "btn #{'active' if index.zero?}",
+            class: "btn callnumber-btn #{'active' if index.zero?}",
             id: "callnumber-browse-#{index}",
             type: "button",
             role: "tab",


### PR DESCRIPTION
The styles for the call number buttons in browse nearby are spilling onto the Stanford S in the preview (note the border):

<img width="817" height="319" alt="Screenshot 2025-11-21 at 8 47 52 AM" src="https://github.com/user-attachments/assets/b343d7e7-97f9-4c38-9acb-fa9becb41e86" />

After:

<img width="982" height="829" alt="Screenshot 2025-11-21 at 9 02 23 AM" src="https://github.com/user-attachments/assets/bef40adc-08a8-4095-a2b7-568401a330a5" />
