### PR TITLE
Always display the OAC finding aid in "More Options"

### DIFF
--- a/app/components/access_panels/related_component.rb
+++ b/app/components/access_panels/related_component.rb
@@ -20,7 +20,7 @@ module AccessPanels
     private
 
     def hidden # rubocop:disable Naming/PredicateMethod
-      oclc.blank?
+      oclc.blank? && !additional_finding_aids?
     end
 
     def finding_aid_class(link)

--- a/spec/components/access_panels/related_component_spec.rb
+++ b/spec/components/access_panels/related_component_spec.rb
@@ -21,35 +21,18 @@ RSpec.describe AccessPanels::RelatedComponent, type: :component do
   end
 
   describe 'finding aid links' do
-    context 'when there is a WorldCat link' do
-      before do
-        document = SolrDocument.new(
-          oclc: ['12345'],
-          marc_links_struct: [{ href: 'http://oac.cdlib.org/findaid/ark:/something-else', note: 'finding aid is here' },
-                              { href: 'http://archives.stanford.edu/findaid/ark:/archives-ark-id', note: 'finding aid' }]
-        )
-        render_inline(described_class.new(document:))
-      end
-
-      it 'renders the additional non-preferred (OAC) finding aid with the oac image class' do
-        expect(page).to have_css('li.oac a', text: 'Online Archive of California')
-        expect(page).to have_link 'Online Archive of California', href: 'http://oac.cdlib.org/findaid/ark:/something-else'
-      end
+    before do
+      document = SolrDocument.new(
+        oclc: ['12345'],
+        marc_links_struct: [{ href: 'http://oac.cdlib.org/findaid/ark:/something-else', note: 'finding aid is here' },
+                            { href: 'http://archives.stanford.edu/findaid/ark:/archives-ark-id', note: 'finding aid' }]
+      )
+      render_inline(described_class.new(document:))
     end
 
-    context 'when there is no WorldCat link' do
-      before do
-        document = SolrDocument.new(
-          marc_links_struct: [{ href: 'http://oac.cdlib.org/findaid/ark:/something-else', note: 'finding aid is here' },
-                              { href: 'http://archives.stanford.edu/findaid/ark:/archives-ark-id', note: 'finding aid' }]
-        )
-        render_inline(described_class.new(document:))
-      end
-
-      it 'does not display the additional finding aid' do
-        expect(page).to have_css('section.panel-related', visible: false)
-        expect(page).to have_no_link 'Online Archive of California', href: 'http://oac.cdlib.org/findaid/ark:/something-else'
-      end
+    it 'renders the additional non-preferred (OAC) finding aid with the oac image class' do
+      expect(page).to have_css('li.oac a', text: 'Online Archive of California')
+      expect(page).to have_link 'Online Archive of California', href: 'http://oac.cdlib.org/findaid/ark:/something-else'
     end
   end
 end


### PR DESCRIPTION
Closes #6303.

Previously we were only displaying the OAC finding aid in the case that we were already showing the WorldCat link, to reduce visual clutter. Staff have found this confusing, they expect the link to be consistently present across records.