### PR TITLE
Remove extraneous initializer

### DIFF
--- a/config/initializers/rails_config.rb
+++ b/config/initializers/rails_config.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Config.setup do |config|
-  config.const_name = "Settings"
-end


### PR DESCRIPTION
The config is set up in config/initializers/config.rb

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
