### PR TITLE
Remove `enableRemoteStreaming` configuration

### DIFF
--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -211,7 +211,7 @@
   </requestHandler>
 
   <requestDispatcher handleSelect="true" >
-    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
+    <requestParsers multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
   <requestHandler name="standard" class="solr.StandardRequestHandler" />


### PR DESCRIPTION
This is no longer the default (as of Solr 7.x) and if we're not using it, we should turn it off.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
