### PR TITLE
Adjust left padding of table of contents

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -382,7 +382,7 @@
 
 .toc {
   list-style-position: outside;
-  padding-left: 0.25rem;
+  padding-left: 1rem;
 }
 
 .citations {


### PR DESCRIPTION
Closes #6413 

I think when I switched from inside to outside list-style-position, the padding probably needed some adjustment.

Smaller:
<img width="781" height="298" alt="Screenshot 2026-01-16 at 4 41 12 PM" src="https://github.com/user-attachments/assets/f64d8327-f768-4771-8197-09002a9dcc2f" />

Desktop:
<img width="1000" height="449" alt="Screenshot 2026-01-16 at 4 41 33 PM" src="https://github.com/user-attachments/assets/75470a12-d5a9-40ba-a7c3-b10bf76e6f51" />
