### PR TITLE
Remove new relic capistrano recipes

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -29,7 +29,6 @@ require 'capistrano/passenger'
 require 'dlss/capistrano'
 require 'capistrano/honeybadger'
 require "whenever/capistrano"
-require 'new_relic/recipes'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
These were removed in version 10. All they do is notify New Relic of deployments:

https://github.com/newrelic/newrelic-ruby-agent/blob/9.24.0/lib/new_relic/recipes/capistrano3.rb