### PR TITLE
Increase left padding of table of contents

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -382,7 +382,7 @@
 
 .toc {
   list-style-position: outside;
-  padding-left: 1rem;
+  padding-left: 1.25rem;
 }
 
 .citations {


### PR DESCRIPTION
Need to increase it even more to work around the browser specific handling Sarah mentioned in https://github.com/sul-dlss/SearchWorks/pull/6420#issuecomment-3782575925
<img width="751" height="186" alt="Screenshot 2026-01-22 at 8 15 16 AM" src="https://github.com/user-attachments/assets/a903fcdf-729c-41dd-a894-ccc6aebd7345" />
