### PR TITLE
Restore correct stimulus controller for citation copy

### DIFF
--- a/app/components/searchworks4/citations/citation_component.html.erb
+++ b/app/components/searchworks4/citations/citation_component.html.erb
@@ -63,7 +63,7 @@
 
   <% citations.each do |style, citation| %>
     <%= tag.div class: "mb-4 bg-light p-2 citations",
-                data: { citation_format_target: "tab", citation_format_controller: "copy-text"},
+                data: { citation_format_target: "tab", controller: "copy-text"},
                 id: "citation-format-#{style}",
                 hidden: style != default_style do %>
       <% unless unavailable? %>


### PR DESCRIPTION
This got changed in https://github.com/sul-dlss/SearchWorks/pull/6391 and I missed it on review.