### PR TITLE
Stop testing on ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.4", "4.0"]
+        ruby: ["4.0"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby


### PR DESCRIPTION
We now deploy on Ruby 4.0

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
