### PR TITLE
Display the librarian view using flexbox

### DIFF
--- a/app/assets/stylesheets/searchworks4/librarian-view.css
+++ b/app/assets/stylesheets/searchworks4/librarian-view.css
@@ -18,8 +18,12 @@
 
   .field {
     border-bottom: 1px solid var(--stanford-60-black);
-    clear: both;
+    display: flex;
     word-break: break-all;
+  }
+
+  .control-field-values {
+    white-space: pre-wrap;
   }
 
   .ind1,
@@ -28,12 +32,9 @@
     padding: 0 0.25rem;
   }
 
-  .subfields {
-    padding-left: 5em;
-  }
-
   .tag_ind {
-    float: left;
+    width: 5rem;
+    flex: 0 0 auto;
   }
 }
 

--- a/app/views/catalog/_marc_view.html.erb
+++ b/app/views/catalog/_marc_view.html.erb
@@ -1,7 +1,7 @@
 <div id="marc_view">
   <details class="mb-3">
     <summary class="h3">Metadata</summary>
-    <% fields = @document.to_marc.find_all{|f| ('000'..'999') === f.tag }.reject { |f| f.tag.to_s == '940' }  %>
+    <% fields = @document.to_marc.find_all{|f| ('000'..'999') === f.tag }.reject { |f| f.tag.to_s == '940' } %>
     <div class="field"><%= t('blacklight.search.librarian_view.leader', :leader => @document.to_marc.leader) %></div>
     <%- fields.each do |field| -%>
       <div class="field">
@@ -9,11 +9,7 @@
           <span class="tag">
             <%= h(field.tag) %>
           </span>
-          <%- if field.is_a?(MARC::ControlField) -%>
-            <span class="control_field_values">
-              <%= h(field.value) %>
-            </span>
-          <%- else -%>
+          <%- unless field.is_a?(MARC::ControlField) -%>
             <div class="ind1">
               <%= !field.indicator1.blank? ? field.indicator1 : "&nbsp;&nbsp;".html_safe -%>
             </div>
@@ -22,7 +18,9 @@
             </div>
           <% end %>
         </div>
-        <%- unless field.is_a?(MARC::ControlField) -%>
+        <% if field.is_a?(MARC::ControlField) %>
+          <span class="control-field-values"><%= h(field.value) %></span>
+        <% else %>
           <div class="subfields">
             <%- field.each do |sub| -%>
               <span class="sub_code"><%= h(sub.code) %>|</span> <%= h(sub.value) %>


### PR DESCRIPTION
This allow us to see meaningful space in the control fields (e.g. 008)

Before:
<img width="800" height="527" alt="Screenshot 2026-02-26 at 2 58 31 PM" src="https://github.com/user-attachments/assets/fbdb03fb-a642-4dff-a63f-07f407794ef6" />

After:
<img width="805" height="533" alt="Screenshot 2026-02-26 at 2 58 13 PM" src="https://github.com/user-attachments/assets/48113261-6ada-437d-a1be-331845e8c070" />

