### PR TITLE
Fix logic for availability components to take account of Cocina

### DIFF
--- a/app/components/searchworks4/availability_component.rb
+++ b/app/components/searchworks4/availability_component.rb
@@ -10,7 +10,7 @@ module Searchworks4
     end
 
     def render?
-      document.holdings.present? || document.preferred_online_links.any? || (document.druid.present? && (!document.mods? || document.published_content?))
+      document.holdings.present? || document.preferred_online_links.any? || (document.druid.present? && (!document.cocina? || !document.mods? || document.published_content?))
     end
 
     def truncated_display?

--- a/app/components/searchworks4/online_availability_component.rb
+++ b/app/components/searchworks4/online_availability_component.rb
@@ -12,7 +12,7 @@ module Searchworks4
     end
 
     def render?
-      document.preferred_online_links.any? || (document.druid.present? && (!document.mods? || document.published_content?))
+      document.preferred_online_links.any? || (document.druid.present? && (!document.cocina? || !document.mods? || document.published_content?))
     end
 
     def links


### PR DESCRIPTION
These needed another case to catch items without Cocina or MODS.
