### PR TITLE
Use exclude_primary to avoid duplicating the main title

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,11 +180,12 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 2.0)
       observer (< 1.0)
-    cocina_display (1.10.0)
+    cocina_display (1.12.1)
       activesupport (>= 7)
       edtf (~> 3.2)
       geo_coord (~> 0.2)
       i18n
+      iso8601 (~> 0.13.0)
       janeway-jsonpath (~> 0.6)
       zeitwerk (~> 2.7)
     coderay (1.1.3)
@@ -307,6 +308,7 @@ GEM
       reline (>= 0.4.2)
     iso-639 (0.3.8)
       csv
+    iso8601 (0.13.0)
     janeway-jsonpath (0.6.0)
     jbuilder (2.14.1)
       actionview (>= 7.0.0)

--- a/app/components/record/cocina/description_component.rb
+++ b/app/components/record/cocina/description_component.rb
@@ -18,7 +18,7 @@ module Record
       # Ordered list of fields and delimiters to display
       def field_map
         @field_map ||= [
-          [title_display_data, COMMA],
+          [cocina_display.title_display_data(exclude_primary: true), COMMA],
           [cocina_display.form_display_data, SEMICOLON],
           [cocina_display.form_note_display_data, COMMA],
           [cocina_display.publication_display_data, COMMA],
@@ -27,11 +27,6 @@ module Record
           [cocina_display.language_display_data, SEMICOLON],
           [cocina_display.map_display_data, COMMA]
         ].select { |field, _| field.present? }
-      end
-
-      # All the titles, except the main title
-      def title_display_data
-        cocina_display.title_display_data.reject { it.label == 'Title' }
       end
 
       def render?


### PR DESCRIPTION
Only affects Cocina-backed items.
