### PR TITLE
Fix related resource display for Cocina-backed objects

### DIFF
--- a/app/assets/stylesheets/searchworks4/record.css
+++ b/app/assets/stylesheets/searchworks4/record.css
@@ -37,6 +37,19 @@
   }
 }
 
+/* nested dl styling for related resources */
+.related-item {
+  dt {
+    font-weight: normal;
+    font-style: italic;
+    margin-left: 0;
+  }
+
+  dd {
+    margin-left: 0;
+  }
+}
+
 .document-title {
   /* create room for the thumbnail */
   margin-right: 150px;

--- a/app/components/record/cocina/bibliographic_component.html.erb
+++ b/app/components/record/cocina/bibliographic_component.html.erb
@@ -1,9 +1,26 @@
 <%= render Searchworks4::DocumentSectionLayout.new(title: 'Bibliographic information') do %>
-  <% field_map.each do |fields, delimiter| %>
-    <% fields.each do |field| %>
-      <%= tag.div class: 'my-2' do %>
-        <%= render Record::Cocina::FieldComponent.new(field: field, delimiter: delimiter) %>
-      <% end %>
+  <% general_note_display_data.each do |field| %>
+    <%= tag.div class: 'my-2' do %>
+      <%= render Record::Cocina::FieldComponent.new(field: field) %>
+    <% end %>
+  <% end %>
+
+  <% related_resource_display_data.each do |field| %>
+    <%= tag.div class: 'my-2' do %>
+      <%= tag.dt field.label %>
+      <%= render Record::Cocina::RelatedResourceComponent.with_collection(field.objects) %>
+    <% end %>
+  <% end %>
+
+  <% identifier_display_data.each do |field| %>
+    <%= tag.div class: 'my-2' do %>
+      <%= render Record::Cocina::FieldComponent.new(field: field, delimiter: ', ') %>
+    <% end %>
+  <% end %>
+
+  <% access_display_data.each do |field| %>
+    <%= tag.div class: 'my-2' do %>
+      <%= render Record::Cocina::FieldComponent.new(field: field) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/record/cocina/bibliographic_component.rb
+++ b/app/components/record/cocina/bibliographic_component.rb
@@ -11,24 +11,14 @@ module Record
       attr_reader :document
 
       delegate :cocina_display, to: :document
-
-      COMMA = ', '
-
-      # Ordered list of fields and delimiters to display
-      def field_map
-        @field_map ||= [
-          [cocina_display.general_note_display_data, nil],
-          [cocina_display.related_resource_display_data, nil],
-          [cocina_display.identifier_display_data, COMMA],
-          [access_display_data, nil]
-        ].select { |field, _| field.present? }
-      end
+      delegate :general_note_display_data, :related_resource_display_data, :identifier_display_data, to: :cocina_display
 
       def render?
-        field_map.present?
+        general_note_display_data.present? ||
+          related_resource_display_data.present? ||
+          identifier_display_data.present? ||
+          access_display_data.present?
       end
-
-      private
 
       # If the document has a druid, we don't want to show the purl for the object on the page twice.
       # The purl will show up in the OtherListingsComponent if there is a druid

--- a/app/components/record/cocina/related_resource_component.html.erb
+++ b/app/components/record/cocina/related_resource_component.html.erb
@@ -1,0 +1,13 @@
+<% if url? %>
+  <%= tag.dd do %>
+    <%= tag.a href: link_url do %>
+      <%= link_text %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= tag.dd class: "related-item" do %>
+    <%= tag.dl do %>
+      <%= render Record::Cocina::FieldComponent.with_collection(related_resource.display_data) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/record/cocina/related_resource_component.rb
+++ b/app/components/record/cocina/related_resource_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Record
+  module Cocina
+    # Component for displaying related resources. Renders a simple link if a
+    # URL is present, otherwise uses the nested item presentation.
+    class RelatedResourceComponent < ViewComponent::Base
+      def initialize(related_resource:)
+        super()
+        @related_resource = related_resource
+      end
+
+      attr_reader :related_resource
+
+      def render?
+        related_resource.display_data.present?
+      end
+
+      def url?
+        link_url.present?
+      end
+
+      def link_text
+        related_resource.to_s
+      end
+
+      def link_url
+        related_resource.url
+      end
+    end
+  end
+end

--- a/spec/components/record/cocina_document_component_spec.rb
+++ b/spec/components/record/cocina_document_component_spec.rb
@@ -101,5 +101,24 @@ RSpec.describe Record::CocinaDocumentComponent, type: :component do
     it "does not display the purl URL" do
       expect(page).to have_no_css("dd", text: "https://purl.stanford.edu/bc798xr9549")
     end
+
+    context "with a related resource that has no URL (preferred citation)" do
+      let(:druid) { 'bb060nk0241' }
+
+      it "displays the related resource as a nested dl" do
+        expect(page).to have_css("dt", text: "Related item")
+        expect(page).to have_css("dd dl dt", text: "Preferred citation")
+        expect(page).to have_css("dd dl dd", text: /Cereb\. Cortex \(2016\) 26 \(5\): 2205-2214/)
+      end
+    end
+
+    context "with a related resource that has a URL" do
+      let(:druid) { 'bx988zq7071' }
+
+      it "displays the related resource as a link" do
+        expect(page).to have_css("dt", text: "Part of")
+        expect(page).to have_link("Finding aid", href: "http://www.oac.cdlib.org/findaid/ark:/13030/tf7b69n911/")
+      end
+    end
   end
 end


### PR DESCRIPTION
This borrows logic from PURL to hyperlink related resources that
have URLs, and use the nested-item presentation for those that
are more well-described objects.

Fixes #6527
