### PR TITLE
Prevent access conditions from appearing twice

### DIFF
--- a/app/components/access_panels/access_conditions_component.html.erb
+++ b/app/components/access_panels/access_conditions_component.html.erb
@@ -1,20 +1,23 @@
 <%= render @layout.new(classes: 'panel-access-conditions') do |component| %>
   <% component.with_title(classes: 'h3 text-secondary') { 'Access conditions' } %>
   <% component.with_body do %>
-    <% field_map.each do |fields| %>
-      <%= tag.div data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-6'} do %>
-        <% tag.dl class: 'mb-0', data: { 'long-text-target': 'text' } do %>
-          <% fields.each do |field| %>
-            <%= render Record::Cocina::FieldComponent.new(field: field) %>
+    <% if field_map.present? %>
+      <% field_map.each do |fields| %>
+        <%= tag.div data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-6'} do %>
+          <% tag.dl class: 'mb-0', data: { 'long-text-target': 'text' } do %>
+            <% fields.each do |field| %>
+              <%= render Record::Cocina::FieldComponent.new(field: field) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <% mods_access_conditions.each do |accessCondition| %>
-      <%= tag.div data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-6'} do %>
-        <dl class="mb-0" data-long-text-target="text">
-          <%= render ModsDisplay::FieldComponent.new(field: accessCondition) %>
-        </dl>
+    <% else %>
+      <% mods_access_conditions.each do |accessCondition| %>
+        <%= tag.div data: { controller: 'long-text', 'long-text-truncate-class': 'truncate-6'} do %>
+          <dl class="mb-0" data-long-text-target="text">
+            <%= render ModsDisplay::FieldComponent.new(field: accessCondition) %>
+          </dl>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
We just needed an if/else block to ensure that items with both
MODS and Cocina didn't render this twice.

Fixes #6535
