### PR TITLE
Fix article selections tracking

### DIFF
--- a/app/controllers/article_selections_controller.rb
+++ b/app/controllers/article_selections_controller.rb
@@ -51,6 +51,10 @@ class ArticleSelectionsController < ArticlesController
     search_service.fetch(bookmark_ids, rows: bookmark_ids.count)
   end
 
+  def current_search_session
+    nil
+  end
+
   def _prefixes
     @_prefixes ||= super + ['articles', 'catalog']
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,7 @@ Rails.application.routes.draw do
   resources :browse, only: :index
 
   get 'catalog/:id/track' => 'catalog#track', as: 'track_browse'
-  get 'catalog/:id/track' => 'articles#track', as: 'track_article_selections'
+  post 'articles/:id/track' => 'articles#track', as: 'track_article_selections'
 
   get "browse/nearby" => "browse#nearby"
 


### PR DESCRIPTION
Currently article selections (bookmarks) title links are broken in SearchWorks.

This sets the search session to nil for articles selections (makes sense to me, are we in a search session when in the bookmarks?) The tracking will work again, but results in a `Search results` link that's a bit useless (e.g., `/articles/nlebk__2317865?page=1&per_page=20`, reloads the current article).

Alternatively we could say a user visiting the article bookmarks is no longer in an active search and clear it:
https://github.com/sul-dlss/SearchWorks/pull/6438

That would fall back to `search_action_path` for the `Search results` link, which would be `/articles`. I prefer that, but I don't know if I understand 100% of what all this tracking business is responsible for.