### PR TITLE
if 546 field isn't in marc, don't return true for contains_only_subfi…

### DIFF
--- a/app/models/marc_fields/language.rb
+++ b/app/models/marc_fields/language.rb
@@ -29,6 +29,8 @@ class Language < MarcField
   end
 
   def contains_only_subfield_b?
+    return false unless extracted_fields.lazy.any?
+
     extracted_fields.all? do |_field, subfields|
       subfields.all? do |subfield|
         subfield.code == 'b'

--- a/spec/models/marc_fields/language_spec.rb
+++ b/spec/models/marc_fields/language_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe Language do
         expect(language.label).to eq 'Language'
       end
     end
+
+    context 'when doc has languages with no 546 field' do
+      let(:document) do
+        SolrDocument.new(marc_json_struct: marc, language: ['English'])
+      end
+      let(:marc) { metadata1 }
+
+      it 'is "Language"' do
+        expect(language.label).to eq 'Language'
+      end
+    end
   end
 
   describe 'values' do


### PR DESCRIPTION
…eld_b?
closes #6449 