### PR TITLE
Use same rendering format for all related resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,4 +120,4 @@ gem "citeproc", "~> 1.1"
 gem 'citeproc-ruby', '~> 2.0'
 gem 'csl', '~> 2.0'
 gem "csl-styles", "~> 2.0"
-gem "cocina_display"
+gem "cocina_display", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     benchmark (0.5.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     blacklight (9.0.0)
       globalid
@@ -180,7 +180,7 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 2.0)
       observer (< 1.0)
-    cocina_display (2.1.0)
+    cocina_display (2.3.2)
       activesupport (>= 7)
       edtf (~> 3.2)
       geo_coord (~> 0.2)
@@ -312,7 +312,7 @@ GEM
       activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.3)
+    json (2.19.4)
     jwt (3.1.2)
       base64
     kaminari (1.2.2)
@@ -374,7 +374,7 @@ GEM
     matrix (0.4.3)
     mini_mime (1.1.5)
     minitar (1.1.0)
-    minitest (6.0.3)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -704,7 +704,7 @@ DEPENDENCIES
   capybara (~> 3.0)
   citeproc (~> 1.1)
   citeproc-ruby (~> 2.0)
-  cocina_display
+  cocina_display (~> 2.3)
   config
   csl (~> 2.0)
   csl-styles (~> 2.0)

--- a/app/components/record/cocina/related_resource_component.html.erb
+++ b/app/components/record/cocina/related_resource_component.html.erb
@@ -1,13 +1,24 @@
-<% if url? %>
-  <%= tag.dd do %>
-    <%= tag.a href: link_url do %>
-      <%= link_text %>
+<dd>
+  <dl class="related-item">
+    <dt class="visually-hidden">Title</dt>
+    <dd class="title">
+      <% if related_resource.url? %>
+        <%= link_to related_resource.to_s, related_resource.url, class: 'su-underline' %>
+      <% else %>
+        <%= helpers.auto_link related_resource.to_s, html: { class: 'su-underline' } %>
+      <% end %>
+    </dd>
+    <% if related_resource.display_data.present? %>
+      <div class="display-data">
+      <% related_resource.display_data.each do |field| %>
+        <dt><%= field.label %></dt>
+        <% field.values.each do |value| %>
+          <dd>
+            <%= auto_link value, html: { class: 'su-underline' } %>
+          </dd>
+        <% end %>
+      <% end %>
+      </div>
     <% end %>
-  <% end %>
-<% else %>
-  <%= tag.dd class: "related-item" do %>
-    <%= tag.dl do %>
-      <%= render Record::Cocina::FieldComponent.with_collection(related_resource.display_data) %>
-    <% end %>
-  <% end %>
-<% end %>
+  </dl>
+</dd>

--- a/app/components/record/cocina/related_resource_component.rb
+++ b/app/components/record/cocina/related_resource_component.rb
@@ -13,19 +13,7 @@ module Record
       attr_reader :related_resource
 
       def render?
-        related_resource.display_data.present?
-      end
-
-      def url?
-        link_url.present?
-      end
-
-      def link_text
-        related_resource.to_s
-      end
-
-      def link_url
-        related_resource.url
+        related_resource.present?
       end
     end
   end


### PR DESCRIPTION
This ports the same display strategy used in Purl, from
https://github.com/sul-dlss/purl/pull/1736.
