### PR TITLE
We should not call turnstyle.implicitRender()

### DIFF
--- a/app/javascript/controllers/inline_turnstile_controller.js
+++ b/app/javascript/controllers/inline_turnstile_controller.js
@@ -4,10 +4,6 @@ export default class extends Controller {
   static targets = ["challenge", "frame"]
   static values = { challengePath: String, siteKey: String, status: Boolean }
 
-  connect() {
-    turnstile.implicitRender()
-  }
-
   frameTargetConnected(element) {
     if (this.statusValue) {
       this.convertFrame(element.querySelector("turbo-frame"))


### PR DESCRIPTION
    It is no longer part of the API

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Fixes #6618 