### PR TITLE
Call turnstile.render explicitly because implicitRender no longer works

### DIFF
--- a/app/javascript/controllers/inline_turnstile_controller.js
+++ b/app/javascript/controllers/inline_turnstile_controller.js
@@ -4,6 +4,14 @@ export default class extends Controller {
   static targets = ["challenge", "frame"]
   static values = { challengePath: String, siteKey: String, status: Boolean }
 
+  connect() {
+    let cfTurnstileElement = this.element.querySelector('.cf-turnstile')
+
+    if (cfTurnstileElement) {
+      turnstile.render(cfTurnstileElement, { sitekey: this.siteKeyValue })
+    }
+  }
+
   frameTargetConnected(element) {
     if (this.statusValue) {
       this.convertFrame(element.querySelector("turbo-frame"))


### PR DESCRIPTION
Fixes #6618 

This seems to fix the issue when using the [test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) locally.