### PR TITLE
Don't render subfield 7s

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -257,7 +257,7 @@ module Constants
     # No Physics or Meyer (ACOMP) in doc provided, the show up on web
   }
 
-  EXCLUDE_FIELDS = ['w', '0', '1', '2', '5', '6', '8', '?', '=']
+  EXCLUDE_FIELDS = ['w', '0', '1', '2', '5', '6', '7', '8', '?', '=']
 
   NIELSEN_TAGS = { '505' => '905', '520' => '920', '586' => '986' }
   SOURCES = {


### PR DESCRIPTION
Per gsearch in SW-4645.

There's some more cleanup of pre-composed fields or fields with special rendering, but this should suppress the majority of them.