### PR TITLE
Force reload of stale JS on long-lived tabs

### DIFF
--- a/app/controllers/asset_version_controller.rb
+++ b/app/controllers/asset_version_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Lets clients check whether the JavaScript they have loaded still matches
+# what the server is currently deploying, so long-lived tabs can detect drift.
+class AssetVersionController < ApplicationController
+  def show
+    response.headers["Cache-Control"] = "no-store"
+    render json: { revision: Settings.REVISION }
+  end
+end

--- a/app/javascript/controllers/asset_version_controller.js
+++ b/app/javascript/controllers/asset_version_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="asset-version"
+//
+// Long-lived tabs never re-request the page, so they can keep running JS
+// from weeks-old deploys. Once the page was rendered more than a week ago,
+// start checking whether the server is serving a newer revision, and reload
+// if so. Age is measured from the server-stamped render time rather than
+// from when this script started running, since a page served from the
+// browser's disk cache can execute its JS long after it was rendered.
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+export default class extends Controller {
+  static values = { url: String, revision: String, loadedAt: Number }
+
+  connect() {
+    this.timer = setInterval(() => this.checkRevision(), CHECK_INTERVAL_MS)
+  }
+
+  disconnect() {
+    clearInterval(this.timer)
+  }
+
+  checkRevision() {
+    if (Date.now() - this.loadedAtValue * 1000 < MAX_AGE_MS) return
+
+    fetch(this.urlValue, { cache: "no-store" })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.revision !== this.revisionValue) window.location.reload()
+      })
+      .catch((error) => console.error("asset_version fetch failed", error))
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("articles-facet-more", ArticlesFacetMoreController)
 import ArticlesFacetPaginateController from "./articles_facet_paginate_controller"
 application.register("articles-facet-paginate", ArticlesFacetPaginateController)
 
+import AssetVersionController from "./asset_version_controller"
+application.register("asset-version", AssetVersionController)
+
 import AvailabilityController from "./availability_controller"
 application.register("availability", AvailabilityController)
 

--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -51,6 +51,12 @@
     <% if content_for?(:body_attributes) %>
       <%= content_for(:body_attributes) %>
     <% end %>>
+    <div
+      data-controller="asset-version"
+      data-asset-version-url-value="<%= asset_version_path %>"
+      data-asset-version-revision-value="<%= Settings.REVISION %>"
+      data-asset-version-loaded-at-value="<%= Time.current.to_i %>"
+    ></div>
     <%= render blacklight_config.skip_link_component.new do %>
       <%= content_for(:skip_links) %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@
 Rails.application.routes.draw do
   root to: "catalog#index"
 
+  get "asset_version" => "asset_version#show", as: :asset_version
+
   # redirect Symphony-migrated FOLIO HRIDs to their original Symphony URLs
   constraints(id: /a\d+/) do
     get '/view/:id', to: redirect { |path_params, _req| "/view/#{path_params[:id].delete_prefix('a')}" }

--- a/spec/requests/asset_version_spec.rb
+++ b/spec/requests/asset_version_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Checking the asset version' do
+  it 'returns the current server revision as json' do
+    allow(Settings).to receive(:REVISION).and_return('abc123')
+
+    get '/asset_version'
+
+    expect(response).to have_http_status :ok
+    expect(response.parsed_body).to eq('revision' => 'abc123')
+  end
+
+  it 'instructs clients not to cache the response' do
+    get '/asset_version'
+
+    expect(response.headers['Cache-Control']).to eq 'no-store'
+  end
+end


### PR DESCRIPTION
Adds a /asset_version endpoint exposing the server's current deploy revision, and a Stimulus controller that checks it once a page has been rendered for
  over a week, reloading if the revision has changed. Fixes clients stuck running weeks-old JS from tabs that never re-navigate.

We've seen this where bots keep reporting Honeybadger errors that ought to be filtered out
