### PR TITLE
Guard against missing preview arrow targets

### DIFF
--- a/app/javascript/controllers/gallery_layout_controller.js
+++ b/app/javascript/controllers/gallery_layout_controller.js
@@ -76,6 +76,8 @@ export default class extends Controller {
   }
 
   movePointer(targetCenter) {
+    if (!this.currentGalleryCard.previewOutlet.hasArrowTarget) return
+
     const pointerWidth = 21
     const arrowLeft = targetCenter - pointerWidth
     this.currentGalleryCard.previewOutlet.arrowTarget.style.left = arrowLeft + "px"

--- a/app/javascript/controllers/gallery_row_controller.js
+++ b/app/javascript/controllers/gallery_row_controller.js
@@ -91,6 +91,8 @@ export default class extends Controller {
   }
 
   movePointer(targetCenter, leftBound, rightBound) {
+    if (!this.previewOutlet.hasArrowTarget) return
+
     const pointerWidth = 21
     const arrowLeft = targetCenter - pointerWidth
 


### PR DESCRIPTION
Closes https://github.com/sul-dlss/SearchWorks/issues/6704

I think this is likely a timing issue, the preview controller having not fully completed it's `connect` process. It's also likely from bots/short lived requests, so I think we're fine simply guarding to stop the bombardment of honeybadger errors.