### PR TITLE
Add error pattern for Cloudflare Turnstile

### DIFF
--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -40,6 +40,7 @@
         ignorePatterns: [
           /turnstile is not defined/i,
           /TurnstileError/,
+          /\[Cloudflare Turnstile\] Error/
         ],
         revision: '<%= Settings.REVISION %>'
       });


### PR DESCRIPTION
This prevents a bunch of Cloudflare frontend errors (~450/hr), that are not actionable to us, from being reported. Presumably these are bots.
See https://app.honeybadger.io/projects/50022/faults/132138684

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
