### PR TITLE
Update Honeybadger to use beforeNotify hook for filtering errors

### DIFF
--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -30,19 +30,18 @@
       defer
     ></script>
     <%= javascript_include_tag "searchworks4", "data-turbo-track": "reload", defer: true %>
-    <script src="//js.honeybadger.io/v6.11/honeybadger.min.js" type="text/javascript"></script>
+    <script src="//js.honeybadger.io/v6.14/honeybadger.min.js" type="text/javascript"></script>
     <script type="text/javascript">
       Honeybadger.configure({
         apiKey: '<%= Honeybadger.config.get(:api_key) %>',
         environment: '<%= Honeybadger.config.get(:env) %>',
-        debug: false,
-        enableUncaught: true,
-        ignorePatterns: [
-          /turnstile is not defined/i,
-          /TurnstileError/,
-        ],
         revision: '<%= Settings.REVISION %>'
-      });
+      })
+      Honeybadger.beforeNotify((notice) => {
+        if ("TurnstileError" === notice.name) {
+          return false
+        }
+      })
     </script>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>


### PR DESCRIPTION
The ignorePatterns was removed in v5: https://github.com/honeybadger-io/honeybadger-js/pull/505

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
