### PR TITLE
Allow the inline_turnstyle_controller.js to reload when CSRF is stale

### DIFF
--- a/app/javascript/controllers/inline_turnstile_controller.js
+++ b/app/javascript/controllers/inline_turnstile_controller.js
@@ -87,6 +87,12 @@ export default class extends Controller {
       body: JSON.stringify({ cf_turnstile_response: token })
     })
 
+    // A long-lived page may have a CSRF token from an expired or replaced session.
+    if (response.status === 422) {
+      window.location.reload()
+      return
+    }
+
     const responseBody = await response.text()
     let result
 


### PR DESCRIPTION
Logging additions to https://app.honeybadger.io/projects/50022/faults/132661450 indicate that this fault often happens after the page has been open for a long time.  If there is a failure, we can reload the page which will generate a new CSRF token.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
