### PR TITLE
Use Base64.urlsafe_encode64 for encoding a url

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -12,7 +12,7 @@ module CatalogHelper
     url = availability_path(document)
 
     tag.div(data: { 'inline-turnstile-target': ('frame' unless immediate) }) do
-      turbo_frame_tag "availability_#{dom_id(document)}", src: immediate ? url : Base64.encode64(url), disabled: !immediate, **attr
+      turbo_frame_tag "availability_#{dom_id(document)}", src: immediate ? url : Base64.urlsafe_encode64(url), disabled: !immediate, **attr
     end
   end
 


### PR DESCRIPTION
Base64.encode64 makes a RFC 2045 encoded base 64, this uses an alphabet that may contain a plus character, which the web browser may transform to a literal space.  When the javascript tries to decode this with atob, it raises an error because the string doesn't decode.  When we use Base64.urlsafe_encode64 instead, it uses "URL and Filename Safe Alphabet" as specified in RFC 4648.

Fixes #6732 

<img width="480" height="87" alt="Screenshot 2026-07-20 at 9 55 42 PM" src="https://github.com/user-attachments/assets/3c1c264d-60f2-4d45-84ad-ec6c6020f57d" />
