### PR TITLE
Make convertFrame idempotent, by only decoding challenge-gated frames

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,4 +1,4 @@
-name: JavaScript Linting
+name: JavaScript
 
 on:
   pull_request:
@@ -6,23 +6,26 @@ on:
       - '**/*.js'
       - 'package.json'
       - 'yarn.lock'
-      - '.eslintrc.json'
-      - '.github/workflows/javascript-linter.yml'
+      - 'eslint.config.js'
+      - '.github/workflows/javascript.yml'
 
 jobs:
-  eslint:
+  javascript:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'yarn'
-          
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        
+
       - name: Run ESLint
         run: yarn lint
+
+      - name: Run JavaScript tests
+        run: npm test

--- a/app/javascript/controllers/inline_turnstile_controller.js
+++ b/app/javascript/controllers/inline_turnstile_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
   static values = { challengePath: String, siteKey: String, status: Boolean }
 
   connect() {
-    let cfTurnstileElement = this.element.querySelector('.cf-turnstile')
+    let cfTurnstileElement = this.element.querySelector(".cf-turnstile")
 
     if (window.turnstile && cfTurnstileElement) {
       turnstile.render(cfTurnstileElement, { sitekey: this.siteKeyValue })
@@ -29,6 +29,10 @@ export default class extends Controller {
   }
 
   convertFrame(frame) {
+    // A frame restored from the browser's back/forward cache may already have
+    // been decoded and enabled before Stimulus reconnects this controller.
+    if (!frame?.hasAttribute("disabled")) return
+
     frame.src = atob(frame.src)
     frame.removeAttribute("disabled")
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:dev": "esbuild app/javascript/searchworks4.js app/javascript/searchworks4-adv-search.js --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets",
     "build:css": "sass ./app/assets/stylesheets/searchworks4.scss:./app/assets/builds/searchworks4.css --no-source-map --quiet-deps --load-path=node_modules",
     "lint": "eslint app/javascript/",
-    "lint:fix": "eslint app/javascript/ --fix"
+    "lint:fix": "eslint app/javascript/ --fix",
+    "test": "node --test spec/javascript/*.test.js"
   }
 }

--- a/spec/javascript/inline_turnstile_controller.test.js
+++ b/spec/javascript/inline_turnstile_controller.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import InlineTurnstileController from "../../app/javascript/controllers/inline_turnstile_controller.js"
+
+const convertFrame = InlineTurnstileController.prototype.convertFrame
+
+const buildFrame = ({ src, disabled }) => ({
+  src,
+  disabled,
+  hasAttribute(attribute) {
+    return attribute === "disabled" && this.disabled
+  },
+  removeAttribute(attribute) {
+    if (attribute === "disabled") this.disabled = false
+  }
+})
+
+test("convertFrame decodes and enables a challenge-gated frame", () => {
+  const frame = buildFrame({
+    src: btoa("/availability/7617682"),
+    disabled: true
+  })
+
+  convertFrame.call({}, frame)
+
+  assert.equal(frame.src, "/availability/7617682")
+  assert.equal(frame.disabled, false)
+})
+
+test("convertFrame ignores a frame already enabled before Stimulus reconnects", () => {
+  const frame = buildFrame({
+    src: "/availability/7617682",
+    disabled: false
+  })
+
+  assert.doesNotThrow(() => convertFrame.call({}, frame))
+  assert.equal(frame.src, "/availability/7617682")
+})


### PR DESCRIPTION
This prevents a decode error when restoring an already decoded frame from the stimulus cache

Fixes #6762 

