### PR TITLE
Do not attempt to change a "busy" frame from lazy to eager

### DIFF
--- a/app/javascript/controllers/eager_lazy_controller.js
+++ b/app/javascript/controllers/eager_lazy_controller.js
@@ -27,7 +27,9 @@ export default class extends Controller {
   }
 
   eagerLazyLoad(n = 1) {
-    this.frameTargets.filter(frame => frame.loading == "lazy" && !frame.attributes.complete).slice(0, n).forEach(frame => {
+    this.frameTargets.filter(frame => (
+      frame.loading == "lazy" && !frame.hasAttribute("complete") && !frame.hasAttribute("busy")
+    )).slice(0, n).forEach(frame => {
       frame.loading = "eager"
       delete frame.dataset.eagerLazyTarget
     })
@@ -36,7 +38,7 @@ export default class extends Controller {
   }
 
   garbageCollectOtherFrameTargets() {
-    this.frameTargets.filter(frame => frame.loading != "lazy" || frame.attributes.complete).forEach(frame => {
+    this.frameTargets.filter(frame => frame.loading != "lazy" || frame.hasAttribute("complete")).forEach(frame => {
       delete frame.dataset.eagerLazyTarget
     })
 

--- a/spec/javascript/eager_lazy_controller.test.js
+++ b/spec/javascript/eager_lazy_controller.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import EagerLazyController from "../../app/javascript/controllers/eager_lazy_controller.js"
+
+const eagerLazyLoad = EagerLazyController.prototype.eagerLazyLoad
+
+const buildFrame = ({ loading = "lazy", busy = false, complete = false } = {}) => ({
+  loading,
+  dataset: { eagerLazyTarget: "frame" },
+  hasAttribute(attribute) {
+    return (attribute === "busy" && busy) || (attribute === "complete" && complete)
+  }
+})
+
+const buildController = (frameTargets) => ({
+  frameTargets,
+  garbageCollectOtherFrameTargets() {}
+})
+
+test("eagerLazyLoad promotes the next idle lazy frame", () => {
+  const frame = buildFrame()
+
+  eagerLazyLoad.call(buildController([frame]))
+
+  assert.equal(frame.loading, "eager")
+  assert.equal(frame.dataset.eagerLazyTarget, undefined)
+})
+
+test("eagerLazyLoad does not restart a lazy frame that Turbo is already loading", () => {
+  const frame = buildFrame({ busy: true })
+
+  eagerLazyLoad.call(buildController([frame]))
+
+  assert.equal(frame.loading, "lazy")
+  assert.equal(frame.dataset.eagerLazyTarget, "frame")
+})


### PR DESCRIPTION
It is already in the process of being loaded, and the change would cancel the first load.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
