### PR TITLE
Assign context to the frontend honeybadger errors

### DIFF
--- a/app/javascript/frontend_error_context.js
+++ b/app/javascript/frontend_error_context.js
@@ -1,0 +1,30 @@
+let turboVisitAction = null
+
+export const recordTurboVisit = (event) => {
+  turboVisitAction = event.detail?.action || null
+}
+
+export const frontendErrorContext = ({
+  documentObject = document,
+  performanceObject = performance,
+  now = Date.now()
+} = {}) => {
+  const assetVersionElement = documentObject.querySelector('[data-controller~="asset-version"]')
+  const renderedAt = Number(assetVersionElement?.dataset.assetVersionLoadedAtValue)
+
+  return {
+    asset_revision: assetVersionElement?.dataset.assetVersionRevisionValue || null,
+    page_age_seconds: Math.round(performanceObject.now() / 1000),
+    server_rendered_page_age_seconds: renderedAt ? Math.max(0, Math.round(now / 1000 - renderedAt)) : null,
+    turbo_restored: turboVisitAction === "restore",
+    turbo_visit_action: turboVisitAction
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("turbo:visit", recordTurboVisit)
+}
+
+if (typeof window !== "undefined") {
+  window.searchworksFrontendErrorContext = frontendErrorContext
+}

--- a/app/javascript/searchworks4.js
+++ b/app/javascript/searchworks4.js
@@ -1,5 +1,6 @@
 // Entry point for the build script in your packageon
 
+import "./frontend_error_context"
 import "@hotwired/turbo-rails"
 import "blacklight-frontend"
 

--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -38,6 +38,8 @@
         revision: '<%= Settings.REVISION %>'
       })
       Honeybadger.beforeNotify((notice) => {
+        Object.assign(notice.context, window.searchworksFrontendErrorContext?.())
+
         if ("TurnstileError" === notice.name) {
           return false
         }

--- a/spec/javascript/frontend_error_context.test.js
+++ b/spec/javascript/frontend_error_context.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { frontendErrorContext, recordTurboVisit } from "../../app/javascript/frontend_error_context.js"
+
+const documentObject = {
+  querySelector() {
+    return {
+      dataset: {
+        assetVersionLoadedAtValue: "1000",
+        assetVersionRevisionValue: "abc123"
+      }
+    }
+  }
+}
+
+const performanceObject = { now: () => 12_345 }
+
+test("frontendErrorContext describes the age and revision of the current page", () => {
+  recordTurboVisit({ detail: { action: "advance" } })
+
+  assert.deepEqual(frontendErrorContext({ documentObject, performanceObject, now: 1_100_000 }), {
+    asset_revision: "abc123",
+    page_age_seconds: 12,
+    server_rendered_page_age_seconds: 100,
+    turbo_restored: false,
+    turbo_visit_action: "advance"
+  })
+})
+
+test("frontendErrorContext identifies a page restored by Turbo", () => {
+  recordTurboVisit({ detail: { action: "restore" } })
+
+  const context = frontendErrorContext({ documentObject, performanceObject, now: 1_100_000 })
+
+  assert.equal(context.turbo_restored, true)
+  assert.equal(context.turbo_visit_action, "restore")
+})


### PR DESCRIPTION
This makes it much easier to diagnose problems

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
