### PR TITLE
Fix additional front-end abort race condition

### DIFF
--- a/app/javascript/controllers/eager_lazy_controller.js
+++ b/app/javascript/controllers/eager_lazy_controller.js
@@ -26,9 +26,18 @@ export default class extends Controller {
     }
   }
 
+  frameWillLoad(event) {
+    // Turbo dispatches this before it marks the frame busy. Stop scheduling the
+    // frame immediately so changing its loading style cannot restart the fetch.
+    delete event.target.dataset.eagerLazyTarget
+  }
+
   eagerLazyLoad(n = 1) {
     this.frameTargets.filter(frame => (
-      frame.loading == "lazy" && !frame.hasAttribute("complete") && !frame.hasAttribute("busy")
+      frame.dataset.eagerLazyTarget == "frame" &&
+      frame.loading == "lazy" &&
+      !frame.hasAttribute("complete") &&
+      !frame.hasAttribute("busy")
     )).slice(0, n).forEach(frame => {
       frame.loading = "eager"
       delete frame.dataset.eagerLazyTarget

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -79,7 +79,8 @@
         <% end %>
       </div>
     <% end %>
-    <div id="content" class="results col <%= content_classes %>" data-controller="eager-lazy">
+    <div id="content" class="results col <%= content_classes %>" data-controller="eager-lazy"
+         data-action="turbo:before-fetch-request->eager-lazy#frameWillLoad">
       <div class="page-entries-info mb-2 d-flex flex-wrap gap-2 justify-content-between align-items-center">
         <%= render PageLinksComponent.new(response: @response) %>
         <div class="d-flex flex-wrap gap-2 align-items-center">

--- a/spec/javascript/eager_lazy_controller.test.js
+++ b/spec/javascript/eager_lazy_controller.test.js
@@ -4,6 +4,7 @@ import test from "node:test"
 import EagerLazyController from "../../app/javascript/controllers/eager_lazy_controller.js"
 
 const eagerLazyLoad = EagerLazyController.prototype.eagerLazyLoad
+const frameWillLoad = EagerLazyController.prototype.frameWillLoad
 
 const buildFrame = ({ loading = "lazy", busy = false, complete = false } = {}) => ({
   loading,
@@ -34,4 +35,15 @@ test("eagerLazyLoad does not restart a lazy frame that Turbo is already loading"
 
   assert.equal(frame.loading, "lazy")
   assert.equal(frame.dataset.eagerLazyTarget, "frame")
+})
+
+test("frameWillLoad removes a frame from the queue before Turbo marks it busy", () => {
+  const frame = buildFrame()
+  const controller = buildController([frame])
+
+  frameWillLoad.call(controller, { target: frame })
+  eagerLazyLoad.call(controller)
+
+  assert.equal(frame.loading, "lazy")
+  assert.equal(frame.dataset.eagerLazyTarget, undefined)
 })


### PR DESCRIPTION
There was still a race condition where the abort occurred before the frame was marked as "busy".  This change now closes that gap by binding to turbo:before-fetch-request, which occurs before turbo does the fetch.

The abort protections now cover these cases:
  - frameWillLoad: request announced after Stimulus connects, before busy appears.
  - !frame.hasAttribute("busy"): request already underway when Stimulus connects.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
