### PR TITLE
Use Rails parameters API to expect that format_main_ssim is an array

### DIFF
--- a/app/controllers/concerns/format_params_mapping.rb
+++ b/app/controllers/concerns/format_params_mapping.rb
@@ -12,8 +12,10 @@ module FormatParamsMapping
   def map_format_params
     return unless params.dig(:f, :format_main_ssim)
 
+    legacy_formats = params[:f].expect(format_main_ssim: [])
+
     params[:f][:format_hsim] ||= []
-    params[:f][:format_hsim] += params.dig(:f, :format_main_ssim).map { |f| legacy_format_data_mapping[f] || f }
+    params[:f][:format_hsim] += legacy_formats.map { |format| legacy_format_data_mapping[format] || format }
     params[:f].delete(:format_main_ssim)
   end
 

--- a/spec/requests/format_params_mapping_spec.rb
+++ b/spec/requests/format_params_mapping_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Legacy format parameter mapping' do
+  it 'maps legacy formats and preserves current formats' do
+    get '/?f[format_main_ssim][]=Music%20recording&f[format_hsim][]=Book&f[building_facet][]=Business'
+
+    redirect_params = Rack::Utils.parse_nested_query(URI.parse(response.location).query)
+
+    expect(redirect_params.dig('f', 'format_hsim')).to eq ['Book', 'Sound recording']
+  end
+
+  it 'rejects an indexed format facet value' do
+    get '/catalog.rss?f%5Bformat_main_ssim%5D%5B0%5D=Database'
+
+    expect(response).to have_http_status(:bad_request)
+  end
+end


### PR DESCRIPTION
Sometimes facebooks crawler tries to mutate the URL, causing `undefined method 'map'` errors

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
