### PR TITLE
Fix empty browse nearby Turbo frame response

### DIFF
--- a/app/views/browse/nearby.html.erb
+++ b/app/views/browse/nearby.html.erb
@@ -1,8 +1,8 @@
+<turbo-frame id="filmstrip_<%= params[:call_number].gsub(' ', '-') %>">
   <% if @spines.present? %>
-    <turbo-frame id="filmstrip_<%= params[:call_number].gsub(' ', '-') %>">
-      <% view_config = blacklight_config&.view_config(:gallery) %>
-      <div class="d-flex">
-        <%= render view_config.document_component.with_collection(@spines.map(&:document_with_preferred_item).map { |document| document_presenter(document) }, starting_document: @original_doc, preview_id: @preview_id) %>
-      </div>
-    </turbo-frame>
+    <% view_config = blacklight_config&.view_config(:gallery) %>
+    <div class="d-flex">
+      <%= render view_config.document_component.with_collection(@spines.map(&:document_with_preferred_item).map { |document| document_presenter(document) }, starting_document: @original_doc, preview_id: @preview_id) %>
+    </div>
   <% end %>
+</turbo-frame>

--- a/spec/views/browse/nearby.html.erb_spec.rb
+++ b/spec/views/browse/nearby.html.erb_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "browse/nearby" do
+  before do
+    assign(:spines, [])
+    allow(view).to receive(:params).and_return(call_number: '5174 1230')
+  end
+
+  it "renders the requested turbo frame when there are no nearby items" do
+    render
+
+    expect(rendered).to have_css('turbo-frame#filmstrip_5174-1230', count: 1)
+  end
+end


### PR DESCRIPTION
We need to return a turbo-frame even when there is nothing in the turbo-frame

See https://app.honeybadger.io/projects/50022/faults/127065940
