### PR TITLE
Do not raise an error if a turbo-frame response is a bot rejection page 

### DIFF
--- a/app/javascript/turbo/handleFilmstripFrameMissing.js
+++ b/app/javascript/turbo/handleFilmstripFrameMissing.js
@@ -1,0 +1,51 @@
+// Browse nearby is optional content. If an intermediary response does not include
+// its frame, leave the filmstrip empty instead of raising an unhandled Turbo error.
+const MAX_RESPONSE_BODY_LENGTH = 10_000
+const BIG_IP_SUPPORT_ID_MARKER = "Your support ID is:"
+
+export async function reportMissingFilmstripFrame(event) {
+  const response = event.detail?.response
+  const context = {
+    expected_frame_id: event.target.id,
+    page_url: globalThis.location?.href,
+    response_content_type: response?.headers?.get("content-type"),
+    response_redirected: response?.redirected,
+    response_request_id: response?.headers?.get("x-request-id"),
+    response_status: response?.status,
+    response_status_text: response?.statusText,
+    response_url: response?.url
+  }
+
+  try {
+    const responseBody = await response.clone().text()
+
+    // BIG-IP may replace the optional filmstrip response with its own block page.
+    // This is an expected condition and does not need to be reported.
+    if (responseBody.includes(BIG_IP_SUPPORT_ID_MARKER)) return
+
+    context.response_body = responseBody.slice(0, MAX_RESPONSE_BODY_LENGTH)
+    context.response_body_truncated = responseBody.length > MAX_RESPONSE_BODY_LENGTH
+  } catch(error) {
+    context.response_body_read_error = error.message
+  }
+
+  const error = new Error(`Missing browse nearby Turbo frame: ${event.target.id}`)
+
+  if (globalThis.Honeybadger) {
+    globalThis.Honeybadger.notify(error, {
+      name: "TurboFilmstripFrameMissing",
+      component: "handleFilmstripFrameMissing",
+      context,
+      tags: ["turbo", "browse-nearby", "frame-missing"]
+    })
+  } else {
+    console.error(error, context)
+  }
+}
+
+export default function(event) {
+  if (!event.target.id?.startsWith("filmstrip_")) return
+
+  event.preventDefault()
+  return reportMissingFilmstripFrame(event).catch((error) => console.error(error))
+}

--- a/app/javascript/turbo/index.js
+++ b/app/javascript/turbo/index.js
@@ -1,4 +1,7 @@
 import { StreamActions } from "@hotwired/turbo"
 
+import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing"
 import updateOpener from "./updateOpener"
+
+document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)
 StreamActions.updateOpener = updateOpener

--- a/spec/javascript/handleFilmstripFrameMissing.test.js
+++ b/spec/javascript/handleFilmstripFrameMissing.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict"
+import test, { afterEach } from "node:test"
+
+import handleFilmstripFrameMissing, { reportMissingFilmstripFrame } from "../../app/javascript/turbo/handleFilmstripFrameMissing.js"
+
+const buildResponse = (body = "<html>Unexpected response</html>") => ({
+  clone() {
+    return { text: async() => body }
+  },
+  headers: {
+    get(header) {
+      return {
+        "content-type": "text/html; charset=utf-8",
+        "x-request-id": "request-id"
+      }[header]
+    }
+  },
+  redirected: false,
+  status: 200,
+  statusText: "OK",
+  url: "https://example.com/browse/nearby"
+})
+
+const buildEvent = (id, response = buildResponse()) => ({
+  target: { id },
+  detail: { response },
+  defaultPrevented: false,
+  preventDefault() {
+    this.defaultPrevented = true
+  }
+})
+
+afterEach(() => delete globalThis.Honeybadger)
+
+test("prevents Turbo from raising when a browse nearby filmstrip is missing", async() => {
+  globalThis.Honeybadger = { notify() {} }
+  const event = buildEvent("filmstrip_DS796-.H757-C44-1998")
+
+  await handleFilmstripFrameMissing(event)
+
+  assert.equal(event.defaultPrevented, true)
+})
+
+test("allows Turbo to handle other missing frames normally", () => {
+  const event = buildEvent("availability_solr_document_3780342")
+
+  handleFilmstripFrameMissing(event)
+
+  assert.equal(event.defaultPrevented, false)
+})
+
+test("reports the missing frame response body to Honeybadger", async() => {
+  let notice
+  globalThis.Honeybadger = { notify: (error, options) => { notice = { error, options } } }
+  const event = buildEvent("filmstrip_DS796-.H757-C44-1998")
+
+  await reportMissingFilmstripFrame(event)
+
+  assert.equal(notice.options.name, "TurboFilmstripFrameMissing")
+  assert.equal(notice.options.context.response_body, "<html>Unexpected response</html>")
+  assert.equal(notice.options.context.response_body_truncated, false)
+  assert.equal(notice.options.context.response_status, 200)
+  assert.equal(notice.options.context.response_request_id, "request-id")
+})
+
+test("silently ignores a BIG-IP block page", async() => {
+  let notified = false
+  globalThis.Honeybadger = { notify: () => { notified = true } }
+  const response = buildResponse("<html>Your support ID is: 123456789</html>")
+  const event = buildEvent("filmstrip_DS796-.H757-C44-1998", response)
+
+  await handleFilmstripFrameMissing(event)
+
+  assert.equal(event.defaultPrevented, true)
+  assert.equal(notified, false)
+})
+
+test("reports when the missing frame response body cannot be read", async() => {
+  let notice
+  globalThis.Honeybadger = { notify: (error, options) => { notice = { error, options } } }
+  const response = buildResponse()
+  response.clone = () => ({ text: async() => { throw new Error("body unavailable") } })
+
+  await reportMissingFilmstripFrame(buildEvent("filmstrip_PR146-.H88-2009eb", response))
+
+  assert.equal(notice.options.context.response_body, undefined)
+  assert.equal(notice.options.context.response_body_read_error, "body unavailable")
+})


### PR DESCRIPTION
This might be the bot protection page, and this logging can help us prove it

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
