### PR TITLE
Handle browse-nearby network failures gracefully

### DIFF
--- a/app/javascript/turbo/handleFilmstripFetchRequest.js
+++ b/app/javascript/turbo/handleFilmstripFetchRequest.js
@@ -1,0 +1,30 @@
+// Browse nearby is optional content. Turbo does not handle a rejected fetch for
+// frame src requests, so turn network failures into an empty filmstrip response.
+function emptyFilmstripResponse(frameId) {
+  const escapedFrameId = frameId.replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+
+  return new Response(`<turbo-frame id="${escapedFrameId}"></turbo-frame>`, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+    status: 503
+  })
+}
+
+export default function(event) {
+  const frameId = event.target.id
+  if (!frameId?.startsWith("filmstrip_")) return
+
+  const fetchRequest = event.detail.fetchRequest
+  const response = fetchRequest?.response || globalThis.fetch(event.detail.url, event.detail.fetchOptions)
+
+  event.detail.fetchRequest = {
+    ...fetchRequest,
+    response: Promise.resolve(response).catch((error) => {
+      if (error.name === "AbortError") throw error
+
+      return emptyFilmstripResponse(frameId)
+    })
+  }
+}

--- a/app/javascript/turbo/index.js
+++ b/app/javascript/turbo/index.js
@@ -1,7 +1,9 @@
 import { StreamActions } from "@hotwired/turbo"
 
+import handleFilmstripFetchRequest from "./handleFilmstripFetchRequest"
 import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing"
 import updateOpener from "./updateOpener"
 
+document.addEventListener("turbo:before-fetch-request", handleFilmstripFetchRequest)
 document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)
 StreamActions.updateOpener = updateOpener

--- a/spec/javascript/handleFilmstripFetchRequest.test.js
+++ b/spec/javascript/handleFilmstripFetchRequest.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import test, { afterEach } from "node:test"
+
+import handleFilmstripFetchRequest from "../../app/javascript/turbo/handleFilmstripFetchRequest.js"
+
+const originalFetch = globalThis.fetch
+
+const buildEvent = (id = "filmstrip_MFILM-N.S.-11047:4") => ({
+  target: { id },
+  detail: {
+    fetchOptions: { headers: { "Turbo-Frame": id } },
+    url: new URL("https://example.com/browse/nearby?start=3030710")
+  }
+})
+
+afterEach(() => { globalThis.fetch = originalFetch })
+
+test("turns a filmstrip network failure into an empty frame response", async() => {
+  globalThis.fetch = async() => { throw new TypeError("Failed to fetch") }
+  const event = buildEvent()
+
+  handleFilmstripFetchRequest(event)
+  const response = await event.detail.fetchRequest.response
+
+  assert.equal(response.status, 503)
+  assert.equal(await response.text(), '<turbo-frame id="filmstrip_MFILM-N.S.-11047:4"></turbo-frame>')
+})
+
+test("uses a successful filmstrip response", async() => {
+  const successfulResponse = new Response("filmstrip", { status: 200 })
+  const event = buildEvent()
+  let request
+  globalThis.fetch = async(url, options) => {
+    request = { options, url }
+    return successfulResponse
+  }
+
+  handleFilmstripFetchRequest(event)
+
+  assert.equal(await event.detail.fetchRequest.response, successfulResponse)
+  assert.equal(request.url, event.detail.url)
+  assert.equal(request.options, event.detail.fetchOptions)
+})
+
+test("allows Turbo to fetch non-filmstrip frames", () => {
+  let fetched = false
+  globalThis.fetch = async() => { fetched = true }
+  const event = buildEvent("availability_solr_document_3030710")
+
+  handleFilmstripFetchRequest(event)
+
+  assert.equal(event.detail.fetchRequest, undefined)
+  assert.equal(fetched, false)
+})
+
+test("preserves abort errors", async() => {
+  const abortError = new Error("The operation was aborted")
+  abortError.name = "AbortError"
+  globalThis.fetch = async() => { throw abortError }
+  const event = buildEvent()
+
+  handleFilmstripFetchRequest(event)
+
+  await assert.rejects(event.detail.fetchRequest.response, abortError)
+})
+
+test("wraps a response supplied by another Turbo request interceptor", async() => {
+  const cachedResponse = new Response("cached", { status: 200 })
+  const event = buildEvent()
+  event.detail.fetchRequest = { response: Promise.resolve(cachedResponse) }
+
+  handleFilmstripFetchRequest(event)
+
+  assert.equal(await event.detail.fetchRequest.response, cachedResponse)
+})


### PR DESCRIPTION
Previous handler handled bad content returned from the server, but in the current hb logs we're seeing errors returned when the network connection fails. All of this behavior appears to be bots, so handling the error is the best approach

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
