### PR TITLE
Fixed race condition in fetch error handler

### DIFF
--- a/app/javascript/searchworks4.js
+++ b/app/javascript/searchworks4.js
@@ -1,5 +1,7 @@
 // Entry point for the build script in your packageon
 
+// Register event handlers before Turbo upgrades eager frames and starts fetching.
+import "./turbo/registerEventHandlers"
 import "@hotwired/turbo-rails"
 import "blacklight-frontend"
 

--- a/app/javascript/turbo/index.js
+++ b/app/javascript/turbo/index.js
@@ -1,9 +1,5 @@
 import { StreamActions } from "@hotwired/turbo"
 
-import handleFilmstripFetchRequest from "./handleFilmstripFetchRequest"
-import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing"
 import updateOpener from "./updateOpener"
 
-document.addEventListener("turbo:before-fetch-request", handleFilmstripFetchRequest)
-document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)
 StreamActions.updateOpener = updateOpener

--- a/app/javascript/turbo/registerEventHandlers.js
+++ b/app/javascript/turbo/registerEventHandlers.js
@@ -1,0 +1,5 @@
+import handleFilmstripFetchRequest from "./handleFilmstripFetchRequest"
+import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing"
+
+document.addEventListener("turbo:before-fetch-request", handleFilmstripFetchRequest)
+document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)

--- a/spec/javascript/handleFilmstripFetchRequest.test.js
+++ b/spec/javascript/handleFilmstripFetchRequest.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
 import test, { afterEach } from "node:test"
 
 import handleFilmstripFetchRequest from "../../app/javascript/turbo/handleFilmstripFetchRequest.js"
@@ -14,6 +15,15 @@ const buildEvent = (id = "filmstrip_MFILM-N.S.-11047:4") => ({
 })
 
 afterEach(() => { globalThis.fetch = originalFetch })
+
+test("registers the interceptor before Turbo starts eager frame requests", async() => {
+  const entrypoint = await readFile(new URL("../../app/javascript/searchworks4.js", import.meta.url), "utf8")
+  const registrationIndex = entrypoint.indexOf('import "./turbo/registerEventHandlers"')
+  const turboIndex = entrypoint.indexOf('import "@hotwired/turbo-rails"')
+
+  assert.notEqual(registrationIndex, -1)
+  assert.ok(registrationIndex < turboIndex)
+})
 
 test("turns a filmstrip network failure into an empty frame response", async() => {
   globalThis.fetch = async() => { throw new TypeError("Failed to fetch") }


### PR DESCRIPTION
The problem was eager turbo frames were loading before the error handler were loaded. This resolves that order so that handlers are in place first.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
