### PR TITLE
Fix the Turbo/Stimulus lifecycle race

### DIFF
--- a/app/javascript/controllers/gallery_row_controller.js
+++ b/app/javascript/controllers/gallery_row_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import scrollOver from "../scroll-over"
+import scrollOver from "../scroll-over.js"
 
 // Connects to data-controller="gallery-row"
 export default class extends Controller {
@@ -35,12 +35,27 @@ export default class extends Controller {
     this.adjustPreviewMargins()
   }
 
-  get previewContainer() {
-    return this.galleryCardOutletElement.parentElement
+  disconnect() {
+    this.currentPreview = undefined
+  }
+
+  // Stimulus lifecycle callback invoked when a gallery-card outlet disconnects.
+  galleryCardOutletDisconnected(_outlet, element) {
+    if (this.currentPreview === element) this.currentPreview = undefined
   }
 
   adjustPreviewMargins() {
     if (!this.currentPreview) return
+
+    const galleryCardOutlets = this.galleryCardOutlets
+    const currentGalleryCard = galleryCardOutlets.find((outlet) => outlet.element === this.currentPreview)
+    if (!currentGalleryCard || !this.hasPreviewOutlet) {
+      this.currentPreview = undefined
+      return
+    }
+
+    const previewContainer = currentGalleryCard.element.parentElement
+    if (!previewContainer) return
 
     // This is assuming the preview is styled for 100% width
     this.previewOutletElement.style.marginLeft = 0
@@ -48,7 +63,7 @@ export default class extends Controller {
     const maxPreviewWidth = this.maxPreviewWidthValue
     const galleryRect = this.currentPreview.getBoundingClientRect()
     const previewRect = this.previewOutletElement.getBoundingClientRect()
-    const galleryDocumentWidth = this.previewContainer.getBoundingClientRect().width / this.galleryCardOutlets.length
+    const galleryDocumentWidth = previewContainer.getBoundingClientRect().width / galleryCardOutlets.length
     const previewWidth = previewRect.width
     const leftBound = previewRect.left
     const rightBound = leftBound + previewWidth

--- a/app/javascript/controllers/preview_controller.js
+++ b/app/javascript/controllers/preview_controller.js
@@ -34,8 +34,9 @@ export default class extends Controller {
   }
 
   appendFrame() {
+    if (this.hasFrameTarget) return
+
     const frame = document.createElement("turbo-frame")
-    frame.setAttribute("data-preview-target", "frame")
     frame.setAttribute("data-preview-target", "frame")
     this.element.appendChild(frame)
   }
@@ -45,6 +46,9 @@ export default class extends Controller {
   }
 
   load(id, url) {
+    // Turbo may remove a frame while rendering or restoring a cached page.
+    this.appendFrame()
+
     if (this.idValue != id) {
       this.reset()
       this.idValue = id

--- a/spec/javascript/gallery_row_controller.test.js
+++ b/spec/javascript/gallery_row_controller.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import GalleryRowController from "../../app/javascript/controllers/gallery_row_controller.js"
+
+const adjustPreviewMargins = GalleryRowController.prototype.adjustPreviewMargins
+const disconnect = GalleryRowController.prototype.disconnect
+const galleryCardOutletDisconnected = GalleryRowController.prototype.galleryCardOutletDisconnected
+
+test("adjustPreviewMargins ignores a selected card removed by a Turbo frame render", () => {
+  const selectedCard = {}
+  const controller = {
+    currentPreview: selectedCard,
+    galleryCardOutlets: [],
+    hasPreviewOutlet: true
+  }
+
+  assert.doesNotThrow(() => adjustPreviewMargins.call(controller))
+  assert.equal(controller.currentPreview, undefined)
+})
+
+test("disconnect clears the selected card retained by a Stimulus controller reconnect", () => {
+  const controller = { currentPreview: {} }
+
+  disconnect.call(controller)
+
+  assert.equal(controller.currentPreview, undefined)
+})
+
+test("disconnecting the selected gallery card clears it", () => {
+  const selectedCard = {}
+  const controller = { currentPreview: selectedCard }
+
+  galleryCardOutletDisconnected.call(controller, {}, selectedCard)
+
+  assert.equal(controller.currentPreview, undefined)
+})

--- a/spec/javascript/preview_controller.test.js
+++ b/spec/javascript/preview_controller.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import PreviewController from "../../app/javascript/controllers/preview_controller.js"
+
+const load = PreviewController.prototype.load
+const reset = PreviewController.prototype.reset
+
+test("load restores a preview frame removed by Turbo before resetting it", () => {
+  const frame = {
+    innerHTML: "stale preview",
+    attributes: {},
+    setAttribute(name, value) {
+      this.attributes[name] = value
+    }
+  }
+  const controller = {
+    idValue: "old-document",
+    appendFrame() {
+      this.frameTarget = frame
+    },
+    reset,
+    open() {}
+  }
+
+  assert.doesNotThrow(() => load.call(controller, "new-document", "/catalog/new-document/preview"))
+  assert.equal(frame.innerHTML, "")
+  assert.equal(frame.attributes.id, "preview_new-document")
+  assert.equal(frame.attributes.src, "/catalog/new-document/preview")
+})


### PR DESCRIPTION
* Clear the stale preview state when disconnecting or when the selected card outlet disappears.
* Avoid singular outlet getters while /browse/nearby is replacing gallery cards.
* Restore a preview frame if Turbo temporarily removes it

Fixes #6801

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
