### PR TITLE
Handle network failures for lazy availability Turbo frames 

### DIFF
--- a/app/javascript/turbo/handleFrameFetchRequest.js
+++ b/app/javascript/turbo/handleFrameFetchRequest.js
@@ -1,6 +1,9 @@
-// Browse nearby is optional content. Turbo does not handle a rejected fetch for
-// frame src requests, so turn network failures into an empty filmstrip response.
-function emptyFilmstripResponse(frameId) {
+const FALLBACK_FRAME_ID_PREFIXES = ["availability_", "filmstrip_"]
+
+// Turbo does not handle rejected fetches for frame src requests. These frames
+// enhance content that is already present on the page, so replace network
+// failures with an empty frame response instead of leaving an unhandled promise.
+function emptyFrameResponse(frameId) {
   const escapedFrameId = frameId.replaceAll("&", "&amp;")
     .replaceAll('"', "&quot;")
     .replaceAll("<", "&lt;")
@@ -14,7 +17,7 @@ function emptyFilmstripResponse(frameId) {
 
 export default function(event) {
   const frameId = event.target.id
-  if (!frameId?.startsWith("filmstrip_")) return
+  if (!FALLBACK_FRAME_ID_PREFIXES.some((prefix) => frameId?.startsWith(prefix))) return
 
   const fetchRequest = event.detail.fetchRequest
   const response = fetchRequest?.response || globalThis.fetch(event.detail.url, event.detail.fetchOptions)
@@ -24,7 +27,7 @@ export default function(event) {
     response: Promise.resolve(response).catch((error) => {
       if (error.name === "AbortError") throw error
 
-      return emptyFilmstripResponse(frameId)
+      return emptyFrameResponse(frameId)
     })
   }
 }

--- a/app/javascript/turbo/index.js
+++ b/app/javascript/turbo/index.js
@@ -1,9 +1,9 @@
 import { StreamActions } from "@hotwired/turbo"
 
-import handleFilmstripFetchRequest from "./handleFilmstripFetchRequest"
+import handleFrameFetchRequest from "./handleFrameFetchRequest"
 import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing"
 import updateOpener from "./updateOpener"
 
-document.addEventListener("turbo:before-fetch-request", handleFilmstripFetchRequest)
+document.addEventListener("turbo:before-fetch-request", handleFrameFetchRequest)
 document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)
 StreamActions.updateOpener = updateOpener

--- a/spec/javascript/handleFrameFetchRequest.test.js
+++ b/spec/javascript/handleFrameFetchRequest.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import test, { afterEach } from "node:test"
 
-import handleFilmstripFetchRequest from "../../app/javascript/turbo/handleFilmstripFetchRequest.js"
+import handleFrameFetchRequest from "../../app/javascript/turbo/handleFrameFetchRequest.js"
 
 const originalFetch = globalThis.fetch
 
@@ -19,14 +19,26 @@ test("turns a filmstrip network failure into an empty frame response", async() =
   globalThis.fetch = async() => { throw new TypeError("Failed to fetch") }
   const event = buildEvent()
 
-  handleFilmstripFetchRequest(event)
+  handleFrameFetchRequest(event)
   const response = await event.detail.fetchRequest.response
 
   assert.equal(response.status, 503)
   assert.equal(await response.text(), '<turbo-frame id="filmstrip_MFILM-N.S.-11047:4"></turbo-frame>')
 })
 
-test("uses a successful filmstrip response", async() => {
+test("turns Safari availability load failures into an empty frame response", async() => {
+  globalThis.fetch = async() => { throw new TypeError("Load failed") }
+  const event = buildEvent("availability_solr_document_5574017")
+  event.detail.url = new URL("https://example.com/availability/5574017")
+
+  handleFrameFetchRequest(event)
+  const response = await event.detail.fetchRequest.response
+
+  assert.equal(response.status, 503)
+  assert.equal(await response.text(), '<turbo-frame id="availability_solr_document_5574017"></turbo-frame>')
+})
+
+test("uses a successful frame response", async() => {
   const successfulResponse = new Response("filmstrip", { status: 200 })
   const event = buildEvent()
   let request
@@ -35,31 +47,31 @@ test("uses a successful filmstrip response", async() => {
     return successfulResponse
   }
 
-  handleFilmstripFetchRequest(event)
+  handleFrameFetchRequest(event)
 
   assert.equal(await event.detail.fetchRequest.response, successfulResponse)
   assert.equal(request.url, event.detail.url)
   assert.equal(request.options, event.detail.fetchOptions)
 })
 
-test("allows Turbo to fetch non-filmstrip frames", () => {
+test("allows Turbo to fetch unrelated frames", () => {
   let fetched = false
   globalThis.fetch = async() => { fetched = true }
-  const event = buildEvent("availability_solr_document_3030710")
+  const event = buildEvent("unhandled_frame")
 
-  handleFilmstripFetchRequest(event)
+  handleFrameFetchRequest(event)
 
   assert.equal(event.detail.fetchRequest, undefined)
   assert.equal(fetched, false)
 })
 
-test("preserves abort errors", async() => {
+test("preserves abort errors for Turbo to handle", async() => {
   const abortError = new Error("The operation was aborted")
   abortError.name = "AbortError"
   globalThis.fetch = async() => { throw abortError }
-  const event = buildEvent()
+  const event = buildEvent("availability_solr_document_5574017")
 
-  handleFilmstripFetchRequest(event)
+  handleFrameFetchRequest(event)
 
   await assert.rejects(event.detail.fetchRequest.response, abortError)
 })
@@ -69,7 +81,7 @@ test("wraps a response supplied by another Turbo request interceptor", async() =
   const event = buildEvent()
   event.detail.fetchRequest = { response: Promise.resolve(cachedResponse) }
 
-  handleFilmstripFetchRequest(event)
+  handleFrameFetchRequest(event)
 
   assert.equal(await event.detail.fetchRequest.response, cachedResponse)
 })


### PR DESCRIPTION
without producing unhandled promise rejections.

Safari reports requests canceled during navigation as `TypeError: Load failed` instead of `AbortError`. Turbo leaves rejected frame `src` requests unhandled, causing Honeybadger errors when users follow external links while availability requests are still loading.

This generalizes the existing filmstrip fallback to return an empty Turbo frame for failed availability requests.

See also https://github.com/hotwired/turbo/issues/1560

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
