### PR TITLE
Interact with Solr at the Blacklight level, not the RSolr level

### DIFF
--- a/app/models/concerns/collection_member.rb
+++ b/app/models/concerns/collection_member.rb
@@ -8,11 +8,9 @@ module CollectionMember
   def parent_collections
     return nil unless is_a_collection_member?
 
-    @parent_collections ||= blacklight_solr.select(
+    @parent_collections ||= Blacklight.default_index.search(
       params: { fq: parent_collection_params }
-    )['response']['docs'].map do |doc|
-      SolrDocument.new(doc)
-    end
+    ).documents
   end
 
   def index_parent_collections
@@ -38,9 +36,5 @@ module CollectionMember
     self["collection"].map do |collection_id|
       "id:#{CollectionHelper.strip_leading_a(collection_id)}"
     end.join(" OR ")
-  end
-
-  def blacklight_solr
-    Blacklight.default_index.connection
   end
 end

--- a/app/models/concerns/digital_collection.rb
+++ b/app/models/concerns/digital_collection.rb
@@ -15,20 +15,16 @@ module DigitalCollection
   # Simple Plain Ruby Object to return an array of collection members
   class CollectionMembers
     delegate :[], :present?, :blank?, :each, :first, :last, :map, :length, to: :documents
+    delegate :total, to: :response
+
     def initialize(document, options = {})
       @document = document
       @options = options
       @type = 'index'
     end
 
-    def total
-      response['numFound']
-    end
-
     def documents
-      @documents ||= response['docs'].map do |document|
-        ::SolrDocument.new(document)
-      end
+      @documents ||= response.documents
     end
 
     def render_type
@@ -40,12 +36,12 @@ module DigitalCollection
     attr_reader :document, :options, :type
 
     def response
-      @response ||= blacklight_solr.select(
+      @response ||= Blacklight.default_index.search(
         params: {
           fq: collection_member_params,
           rows: 20
         }
-      )['response']
+      )
     end
 
     def should_display_filmstrip?
@@ -65,10 +61,6 @@ module DigitalCollection
       documents.count do |doc|
         doc.image_urls.blank?
       end
-    end
-
-    def blacklight_solr
-      Blacklight.default_index.connection
     end
 
     # @return [String] a Solr query string

--- a/app/models/concerns/solr_set.rb
+++ b/app/models/concerns/solr_set.rb
@@ -12,9 +12,7 @@ module SolrSet
   def parent_sets
     return unless set_member?
 
-    @parent_sets ||= set_document_list.map do |doc|
-      SolrDocument.new(doc)
-    end
+    @parent_sets ||= set_document_list
   end
 
   # Used for generating simple title links to the parent sets w/o making a Solr request
@@ -30,7 +28,7 @@ module SolrSet
   private
 
   def set_document_list
-    @document_list ||= Blacklight.default_index.connection.select(set_solr_params)['response']['docs']
+    @document_list ||= Blacklight.default_index.search(**set_solr_params).documents
   end
 
   def set_solr_params

--- a/spec/components/access_panels/appears_in_component_spec.rb
+++ b/spec/components/access_panels/appears_in_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AccessPanels::AppearsInComponent, type: :component do
   context 'when the document is a set member and has a parent set' do
     let(:document) { SolrDocument.new(id: 'abc123', set: ['set1']) }
     let(:set_documents) do
-      [{ id: 'abc123', format_hsim: 'Map', title_display: 'The Set Object' }]
+      [SolrDocument.new(id: 'abc123', format_hsim: 'Map', title_display: 'The Set Object')]
     end
 
     it 'renders a panel heading' do

--- a/spec/models/concerns/collection_member_spec.rb
+++ b/spec/models/concerns/collection_member_spec.rb
@@ -26,24 +26,17 @@ RSpec.describe CollectionMember do
   describe "#parent_collections" do
     let(:multi_collection) { SolrDocument.new(collection: ['12345', '54321']) }
     let(:catkey_prefix) { SolrDocument.new(collection: ['a12345']) }
-    let(:stub_solr) { double('solr') }
     let(:stub_params) { { params: { fq: "id:12345" } } }
-    let(:stub_response) { {
-      'response' => {
-        'docs' => [{ id: 12345 }]
-      }
-    }}
-
-    before do
-      allow(Blacklight.default_index).to receive(:connection).and_return(stub_solr)
+    let(:stub_response) do
+      instance_double(Blacklight::Solr::Response, documents: [SolrDocument.new(id: 12345)])
     end
 
     it "searches solr for ids in the collection" do
-      expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
+      expect(Blacklight.default_index).to receive(:search).with(**stub_params).and_return(stub_response)
       expect(member.parent_collections).to be_present
     end
     it "returns a solr document" do
-      expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
+      allow(Blacklight.default_index).to receive(:search).with(**stub_params).and_return(stub_response)
       member.parent_collections.each do |parent|
         expect(parent).to be_a SolrDocument
       end

--- a/spec/models/concerns/digital_collection_spec.rb
+++ b/spec/models/concerns/digital_collection_spec.rb
@@ -35,29 +35,25 @@ RSpec.describe DigitalCollection do
   describe "CollectionMembers" do
     let(:collection_members) { DigitalCollection::CollectionMembers.new(collection) }
     let(:collection_members_with_rows) { DigitalCollection::CollectionMembers.new(collection, rows: 17) }
-    let(:stub_solr) { double('solr') }
     let(:stub_params) { { params: { fq: "collection:\"1234\" OR collection:\"a1234\"", rows: 20 } } }
     let(:rows_params) { { params: { fq: "collection:\"1234\" OR collection:\"a1234\"", rows: 17 } } }
     let(:small_rows_params) { { params: { fq: "collection:\"1234\" OR collection:\"a1234\"", rows: 3 } } }
-    let(:stub_response) { {
-      'response' => {
-        'numFound' => 2,
-        'docs' => [{ id: 4321 }, { id: 8765 }]
-      }
-    }}
-
-    before do
-      allow(Blacklight.default_index).to receive(:connection).and_return(stub_solr)
+    let(:stub_response) do
+      instance_double(
+        Blacklight::Solr::Response,
+        total: 2,
+        documents: [SolrDocument.new(id: 4321), SolrDocument.new(id: 8765)]
+      )
     end
 
     describe "#documents" do
       it "searches solr for all members of a collection" do
-        expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
+        expect(Blacklight.default_index).to receive(:search).with(**stub_params).and_return(stub_response)
         expect(collection_members.documents).to be_present
       end
 
       it "returns solr documents" do
-        expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
+        allow(Blacklight.default_index).to receive(:search).with(**stub_params).and_return(stub_response)
         collection_members.documents.each do |member|
           expect(member).to be_a SolrDocument
         end
@@ -66,7 +62,7 @@ RSpec.describe DigitalCollection do
 
     describe "#total" do
       it "returns the numFound integer" do
-        expect(Blacklight.default_index.connection).to receive(:select).with(stub_params).and_return(stub_response)
+        allow(Blacklight.default_index).to receive(:search).with(**stub_params).and_return(stub_response)
         expect(collection_members.total).to eq 2
       end
     end

--- a/spec/models/concerns/solr_set_spec.rb
+++ b/spec/models/concerns/solr_set_spec.rb
@@ -4,13 +4,10 @@ require 'rails_helper'
 
 RSpec.describe SolrSet do
   let(:solr_data) { { id: '12345', set: ['set1'], set_with_title: ['set1 -|- SetABC'] } }
-  let(:documents) { [{ id: 'set1', title_display: 'SetABC' }] }
+  let(:documents) { [SolrDocument.new(id: 'set1', title_display: 'SetABC')] }
+  let(:stub_response) { instance_double(Blacklight::Solr::Response, documents:) }
 
   subject { SolrDocument.new(solr_data) }
-
-  before do
-    allow(subject).to receive_messages(set_document_list: documents)
-  end
 
   context 'when an item is a member of a set' do
     describe '#set_member?' do
@@ -21,9 +18,14 @@ RSpec.describe SolrSet do
 
     describe '#parent_sets' do
       it 'returns an array of solr documents' do
+        allow(Blacklight.default_index).to receive(:search)
+          .with(params: { fq: 'id:set1' })
+          .and_return(stub_response)
+
         expect(subject.parent_sets).to be_all do |set|
           set.is_a?(SolrDocument)
         end
+        expect(Blacklight.default_index).to have_received(:search).with(params: { fq: 'id:set1' })
       end
     end
 


### PR DESCRIPTION
This change ensures we're consistently using the same abstraction level across the application

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
