### PR TITLE
Allow long text in the access panels to wrap

### DIFF
--- a/app/components/access_panels/layout_component.html.erb
+++ b/app/components/access_panels/layout_component.html.erb
@@ -4,7 +4,7 @@
   <div class="access-panel-heading">
     <%= title %>
   </div>
-  <div class="access-panel-body">
+  <div class="access-panel-body text-break">
     <%= body %>
   </div>
   <%= after %>


### PR DESCRIPTION
This is particularly important for URLs on Chrome and Safari

Fixes #6817

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Before:
<img width="274" height="313" alt="Screenshot 2026-09-03 at 11 41 04 AM" src="https://github.com/user-attachments/assets/31c234c1-9d9c-4db0-819f-190a644083ba" />

After:
<img width="264" height="284" alt="Screenshot 2026-09-03 at 11 33 02 AM" src="https://github.com/user-attachments/assets/893a3818-af02-4cf5-85db-b6b2f0fbbaae" />
