### PR TITLE
Install our event handlers before starting turbo

### DIFF
--- a/app/javascript/searchworks4.js
+++ b/app/javascript/searchworks4.js
@@ -1,21 +1,11 @@
 // Entry point for the build script in your packageon
 
-import "@hotwired/turbo-rails"
+import "./turbo"
 import "blacklight-frontend"
 
 import "./popover"
 import "./feedback_form"
 import "./range-limit"
 
-// Prevent the back-button from trying to add a second instance of recaptcha
-// See https://github.com/ambethia/recaptcha/issues/217#issuecomment-615221808
-document.addEventListener("turbo:before-cache", function() {
-  // On the articles page there is a feedback and a connection form.
-  // Both have a recaptcha that needs clearing.
-  document.querySelectorAll(".g-recaptcha").forEach((elem) => elem.innerHTML = "")
-})
-
 import "./controllers"
 import "./controllers/external"
-
-import "./turbo"

--- a/app/javascript/turbo/index.js
+++ b/app/javascript/turbo/index.js
@@ -1,9 +1,9 @@
+// Install request handlers before Turbo upgrades eager frames already in the document.
+import "./installEventHandlers"
+import "@hotwired/turbo-rails"
 import { StreamActions } from "@hotwired/turbo"
 
-import handleFrameFetchRequest from "./handleFrameFetchRequest"
-import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing"
 import updateOpener from "./updateOpener"
 
-document.addEventListener("turbo:before-fetch-request", handleFrameFetchRequest)
-document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)
+// Let a standalone feedback popup show its result as a toast in the window that opened it, then close itself.
 StreamActions.updateOpener = updateOpener

--- a/app/javascript/turbo/installEventHandlers.js
+++ b/app/javascript/turbo/installEventHandlers.js
@@ -1,0 +1,16 @@
+import handleFrameFetchRequest from "./handleFrameFetchRequest.js"
+import handleFilmstripFrameMissing from "./handleFilmstripFrameMissing.js"
+
+// This module must be loaded before Turbo. When the application bundle is deferred,
+// Turbo upgrades eager frames as soon as it starts and their fetch events would
+// otherwise fire before these handlers are registered.
+document.addEventListener("turbo:before-fetch-request", handleFrameFetchRequest)
+document.addEventListener("turbo:frame-missing", handleFilmstripFrameMissing)
+
+// Prevent the back-button from trying to add a second instance of recaptcha.
+// See https://github.com/ambethia/recaptcha/issues/217#issuecomment-615221808
+document.addEventListener("turbo:before-cache", function() {
+  // On the articles page there is a feedback and a connection form.
+  // Both have a recaptcha that needs clearing.
+  document.querySelectorAll(".g-recaptcha").forEach((elem) => elem.innerHTML = "")
+})

--- a/spec/javascript/installTurboEventHandlers.test.js
+++ b/spec/javascript/installTurboEventHandlers.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+test("installs the frame fetch handler when its module loads", async() => {
+  const originalDocument = globalThis.document
+  const listeners = new Map()
+  globalThis.document = {
+    addEventListener(name, handler) {
+      listeners.set(name, handler)
+    }
+  }
+
+  try {
+    await import(`../../app/javascript/turbo/installEventHandlers.js?test=${Date.now()}`)
+
+    assert.equal(typeof listeners.get("turbo:before-fetch-request"), "function")
+    assert.equal(typeof listeners.get("turbo:frame-missing"), "function")
+    assert.equal(typeof listeners.get("turbo:before-cache"), "function")
+  } finally {
+    globalThis.document = originalDocument
+  }
+})


### PR DESCRIPTION
The turbo fetch event is kicked off before our handlers have loaded, causing them not to handle the cases they were build to handle

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
