### PR TITLE
Fix flaky specs related to auth

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -97,6 +97,7 @@ RSpec.configure do |config|
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include Warden::Test::Helpers
+  config.after { Warden.test_reset! }
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Factories::Methods


### PR DESCRIPTION
Warden's documentation says that you should call test_reset! after running a test to clean up. https://github.com/wardencommunity/warden/blob/ffee6ac52099fd32404ca66cfc897fffde5919de/lib/warden.rb#L33

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
