### PR TITLE
Filter out UnhandledPromiseRejection errors with no information

### DIFF
--- a/app/javascript/honeybadger.js
+++ b/app/javascript/honeybadger.js
@@ -1,0 +1,17 @@
+const EMPTY_PROMISE_REJECTION_MESSAGES = new Set([
+  "UnhandledPromiseRejectionWarning: {}",
+  "UnhandledPromiseRejectionWarning: Unspecified reason"
+])
+
+export function ignoreHoneybadgerNotice(notice) {
+  return notice.name === "TurnstileError" ||
+    (notice.name === "window.onunhandledrejection" && EMPTY_PROMISE_REJECTION_MESSAGES.has(notice.message))
+}
+
+export function configureHoneybadgerFilters(honeybadger = globalThis.Honeybadger) {
+  if (!honeybadger) return
+
+  honeybadger.beforeNotify((notice) => {
+    if (ignoreHoneybadgerNotice(notice)) return false
+  })
+}

--- a/app/javascript/searchworks4.js
+++ b/app/javascript/searchworks4.js
@@ -6,6 +6,9 @@ import "blacklight-frontend"
 import "./popover"
 import "./feedback_form"
 import "./range-limit"
+import { configureHoneybadgerFilters } from "./honeybadger"
 
 import "./controllers"
 import "./controllers/external"
+
+configureHoneybadgerFilters()

--- a/app/views/layouts/searchworks4.html.erb
+++ b/app/views/layouts/searchworks4.html.erb
@@ -37,11 +37,6 @@
         environment: '<%= Honeybadger.config.get(:env) %>',
         revision: '<%= Settings.REVISION %>'
       })
-      Honeybadger.beforeNotify((notice) => {
-        if ("TurnstileError" === notice.name) {
-          return false
-        }
-      })
     </script>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>

--- a/spec/javascript/honeybadger.test.js
+++ b/spec/javascript/honeybadger.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { configureHoneybadgerFilters, ignoreHoneybadgerNotice } from "../../app/javascript/honeybadger.js"
+
+test("ignores an unhandled promise rejection with an empty object reason", () => {
+  assert.equal(ignoreHoneybadgerNotice({
+    name: "window.onunhandledrejection",
+    message: "UnhandledPromiseRejectionWarning: {}"
+  }), true)
+})
+
+test("ignores an unhandled promise rejection with no specified reason", () => {
+  assert.equal(ignoreHoneybadgerNotice({
+    name: "window.onunhandledrejection",
+    message: "UnhandledPromiseRejectionWarning: Unspecified reason"
+  }), true)
+})
+
+test("reports an unhandled promise rejection with actionable information", () => {
+  assert.equal(ignoreHoneybadgerNotice({
+    name: "window.onunhandledrejection",
+    message: "UnhandledPromiseRejectionWarning: Failed to load availability"
+  }), false)
+})
+
+test("continues to ignore Turnstile errors", () => {
+  assert.equal(ignoreHoneybadgerNotice({ name: "TurnstileError", message: "Widget failed" }), true)
+})
+
+test("registers the notice filter with Honeybadger", () => {
+  let filter
+  const honeybadger = { beforeNotify(callback) { filter = callback } }
+
+  configureHoneybadgerFilters(honeybadger)
+
+  assert.equal(filter({
+    name: "window.onunhandledrejection",
+    message: "UnhandledPromiseRejectionWarning: {}"
+  }), false)
+  assert.equal(filter({ name: "TypeError", message: "Something broke" }), undefined)
+})


### PR DESCRIPTION
The rejection originated outside SearchWorks; Safari masked its source as webkit-masked-url://hidden. Honeybadger’s onunhandledrejection integration converted the empty rejection reason into {}.  Since these have no useful info and originated outside of Searchworks, we don't want to log them in Honeybadger

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
