### PR TITLE
Set the target in the preview frame to _top

### DIFF
--- a/app/javascript/controllers/preview_controller.js
+++ b/app/javascript/controllers/preview_controller.js
@@ -38,6 +38,7 @@ export default class extends Controller {
 
     const frame = document.createElement("turbo-frame")
     frame.setAttribute("data-preview-target", "frame")
+    frame.setAttribute("target", "_top")
     this.element.appendChild(frame)
   }
 

--- a/app/views/catalog/preview.html.erb
+++ b/app/views/catalog/preview.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="preview_<%= @document.id %>">
+<turbo-frame id="preview_<%= @document.id %>" target="_top">
   <%= render Searchworks4::DocumentComponent.new(document: document_presenter(@document), id: "preview_doc_#{@document.id}") do |component| %>
     <% component.with_actions { '' } %>
   <% end %>

--- a/spec/features/preview_spec.rb
+++ b/spec/features/preview_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.feature "Preview routes functionality" do
   scenario "at show route" do
     visit preview_solr_document_path(1)
+    expect(page).to have_css('turbo-frame#preview_1[target="_top"]', visible: :all)
     expect(page).to have_css("h3 a", text: "An object")
   end
 end

--- a/spec/javascript/preview_controller.test.js
+++ b/spec/javascript/preview_controller.test.js
@@ -4,7 +4,31 @@ import test from "node:test"
 import PreviewController from "../../app/javascript/controllers/preview_controller.js"
 
 const load = PreviewController.prototype.load
+const appendFrame = PreviewController.prototype.appendFrame
 const reset = PreviewController.prototype.reset
+
+test("preview frame links navigate the top-level page", () => {
+  const originalDocument = globalThis.document
+  const frame = {
+    attributes: {},
+    setAttribute(name, value) {
+      this.attributes[name] = value
+    }
+  }
+  globalThis.document = { createElement: () => frame }
+  const controller = {
+    hasFrameTarget: false,
+    element: { appendChild() {} }
+  }
+
+  try {
+    appendFrame.call(controller)
+
+    assert.equal(frame.attributes.target, "_top")
+  } finally {
+    globalThis.document = originalDocument
+  }
+})
 
 test("load restores a preview frame removed by Turbo before resetting it", () => {
   const frame = {


### PR DESCRIPTION
Otherwise it tries to fetch the content within the frame, but the response does not contain a turbo-frame

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
Fixes #6833 