### PR TITLE
Prevent calls to /browse/nearby without call_number

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -7,6 +7,7 @@ class BrowseController < ApplicationController
 
   copy_blacklight_config_from(CatalogController)
 
+  before_action :require_call_number, only: :nearby
   before_action :fetch_orginal_document
   before_action :fetch_browse_items
   before_action :fetch_bookmarks
@@ -41,6 +42,10 @@ class BrowseController < ApplicationController
 
   def browse_params
     params.permit(:start, :barcode, :before, :after, :view, :call_number)
+  end
+
+  def require_call_number
+    @call_number = params.expect(:call_number)
   end
 
   def fetch_orginal_document

--- a/app/views/browse/nearby.html.erb
+++ b/app/views/browse/nearby.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="filmstrip_<%= params[:call_number].gsub(' ', '-') %>">
+<turbo-frame id="filmstrip_<%= @call_number.to_s.gsub(' ', '-') %>">
   <% if @spines.present? %>
     <% view_config = blacklight_config&.view_config(:gallery) %>
     <div class="d-flex">

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -49,4 +49,14 @@ RSpec.describe BrowseController do
       end
     end
   end
+
+  describe 'GET #nearby' do
+    it 'requires a call number' do
+      expect(NearbyOnShelf).not_to receive(:around_spine)
+
+      expect do
+        get :nearby, params: { start: 'xyz', view: 'gallery' }
+      end.to raise_error(ActionController::ParameterMissing, /call_number/)
+    end
+  end
 end

--- a/spec/views/browse/nearby.html.erb_spec.rb
+++ b/spec/views/browse/nearby.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "browse/nearby" do
   before do
     assign(:spines, [])
-    allow(view).to receive(:params).and_return(call_number: '5174 1230')
+    assign(:call_number, '5174 1230')
   end
 
   it "renders the requested turbo frame when there are no nearby items" do


### PR DESCRIPTION
Some bots were calling it this way: https://app.honeybadger.io/projects/50022/faults/133911646\#notice-context

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
