### PR TITLE
Ignore exceptions that originate in a browser extension

### DIFF
--- a/app/javascript/honeybadger.js
+++ b/app/javascript/honeybadger.js
@@ -6,12 +6,14 @@ const EMPTY_PROMISE_REJECTION_MESSAGES = new Set([
 // This signature comes from its JavaScript-to-.NET object binding and does not indicate a failure in SearchWorks.
 const CEFSHARP_PROMISE_REJECTION_MESSAGE =
   /^UnhandledPromiseRejectionWarning: Object Not Found Matching Id:\d+, MethodName:[^,]+, ParamCount:\d+$/
+const BROWSER_EXTENSION_STACK = /(?:chrome|moz|safari-web|ms-browser)-extension:\/\//
 
 export function ignoreHoneybadgerNotice(notice) {
   return notice.name === "TurnstileError" ||
     (notice.name === "window.onunhandledrejection" &&
       (EMPTY_PROMISE_REJECTION_MESSAGES.has(notice.message) ||
-        CEFSHARP_PROMISE_REJECTION_MESSAGE.test(notice.message)))
+        CEFSHARP_PROMISE_REJECTION_MESSAGE.test(notice.message) ||
+        BROWSER_EXTENSION_STACK.test(notice.stack)))
 }
 
 export function configureHoneybadgerFilters(honeybadger = globalThis.Honeybadger) {

--- a/spec/javascript/honeybadger.test.js
+++ b/spec/javascript/honeybadger.test.js
@@ -42,6 +42,30 @@ test("reports an unhandled promise rejection with actionable information", () =>
   }), false)
 })
 
+test("ignores unhandled promise rejections raised by browser extensions", () => {
+  assert.equal(ignoreHoneybadgerNotice({
+    name: "window.onunhandledrejection",
+    message: "UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of undefined (reading 'M_ID')",
+    stack: "TypeError: Cannot read properties of undefined (reading 'M_ID')\n    at Y (chrome-extension://extension-id/executors/200.js:1:761)"
+  }), true)
+})
+
+test("reports application unhandled promise rejections even when the message mentions an extension", () => {
+  assert.equal(ignoreHoneybadgerNotice({
+    name: "window.onunhandledrejection",
+    message: "UnhandledPromiseRejectionWarning: Extension API request failed",
+    stack: "Error: Extension API request failed\n    at load (https://searchworks.stanford.edu/assets/application.js:1:100)"
+  }), false)
+})
+
+test("does not ignore non-promise errors from browser extensions", () => {
+  assert.equal(ignoreHoneybadgerNotice({
+    name: "TypeError",
+    message: "Cannot read properties of undefined",
+    stack: "TypeError\n    at load (chrome-extension://extension-id/content.js:1:100)"
+  }), false)
+})
+
 test("continues to ignore Turnstile errors", () => {
   assert.equal(ignoreHoneybadgerNotice({ name: "TurnstileError", message: "Widget failed" }), true)
 })


### PR DESCRIPTION
We can't do anything about these, so we don't need to hear about it.

<!-- Closes #ISSUE_NUMBER -->
<!-- 📝 CHANGELOG update? -->
